### PR TITLE
7902804: -prof async help messages should mention DYLD_LIBRARY_PATH for Mac OS users

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/AsyncProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/AsyncProfiler.java
@@ -87,8 +87,8 @@ public final class AsyncProfiler implements ExternalProfiler, InternalProfiler {
 
         OptionSpec<String> optLibPath = parser.accepts("libPath",
                 "Location of asyncProfiler library. If not specified, System.loadLibrary will be used " +
-                "and the library must be made available to the forked JVM in an entry of -Djava.library.path " +
-                "or LD_LIBRARY_PATH.")
+                "and the library must be made available to the forked JVM in an entry of -Djava.library.path, " +
+                "LD_LIBRARY_PATH (Linux), or DYLD_LIBRARY_PATH (Mac OS).")
                 .withRequiredArg().ofType(String.class).describedAs("path");
 
         OptionSpec<String> optEvent = parser.accepts("event",
@@ -233,7 +233,8 @@ public final class AsyncProfiler implements ExternalProfiler, InternalProfiler {
                 }
             } catch (UnsatisfiedLinkError e) {
                 throw new ProfilerException("Unable to load async-profiler. Ensure asyncProfiler library " +
-                        "is on LD_LIBRARY_PATH, -Djava.library.path or libPath=", e);
+                        "is on LD_LIBRARY_PATH (Linux), DYLD_LIBRARY_PATH (Mac OS), or -Djava.library.path. " +
+                        "Alternatively, point to explicit library location with -prof async:libPath=<path>.", e);
             }
             this.direction = optDirection.value(set);
             this.output = optOutput.values(set);


### PR DESCRIPTION
MacOS needs DYLD_LIBRARY_PATH to be set, not LD_LIBRARY_PATH. Plus, we might want to point out that libPath is available to work-around async-profiler naming issue:
 https://github.com/jvm-profiling-tools/async-profiler/issues/378

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902804](https://bugs.openjdk.java.net/browse/CODETOOLS-7902804): -prof async help messages should mention DYLD_LIBRARY_PATH for Mac OS users


### Download
`$ git fetch https://git.openjdk.java.net/jmh pull/11/head:pull/11`
`$ git checkout pull/11`
