### PR TITLE
CODETOOLS-7902809: Remove prerequisites tag in favor of maven-enforcer-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@ questions.
                         <configuration>
                             <rules>
                                 <requireMavenVersion>
-                                    <version>3.0</version>
+                                    <version>3.2</version>
                                 </requireMavenVersion>
                             </rules>
                         </configuration>
@@ -285,10 +285,6 @@ questions.
             </dependency>
         </dependencies>
     </dependencyManagement>
-
-    <prerequisites>
-        <maven>3.2</maven>
-    </prerequisites>
 
     <modules>
         <module>jmh-core</module>


### PR DESCRIPTION
<prerequisites> tag is deprecated in favor of maven-enforcer-plugin:
https://maven.apache.org/enforcer/maven-enforcer-plugin/faq.html

We should use maven-enforcer-plugin consistently.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902809](https://bugs.openjdk.java.net/browse/CODETOOLS-7902809): Remove prerequisites tag in favor of maven-enforcer-plugin


### Download
`$ git fetch https://git.openjdk.java.net/jmh pull/14/head:pull/14`
`$ git checkout pull/14`
