### PR TITLE
CODETOOLS-7902805: State cycle validation should be more resilient

### DIFF
--- a/jmh-core-ct/src/test/java/org/openjdk/jmh/ct/states/dag/cycles/NoDoubleUseCycleBenchmarkTest.java
+++ b/jmh-core-ct/src/test/java/org/openjdk/jmh/ct/states/dag/cycles/NoDoubleUseCycleBenchmarkTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2020, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jmh.ct.states.dag.cycles;
+
+import org.junit.Test;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.ct.CompileTest;
+
+public class NoDoubleUseCycleBenchmarkTest {
+
+    @State(Scope.Benchmark)
+    public static class B {
+    }
+
+    @State(Scope.Benchmark)
+    public static class A {
+        @Setup
+        public void setup(B b1, B b2) {
+
+        }
+        @TearDown
+        public void teardown(B b1, B b2) {
+
+        }
+    }
+
+    @Benchmark
+    public void test(A a1, A a2) {
+
+    }
+
+    @Test
+    public void compileTest() {
+        CompileTest.assertOK(this.getClass());
+    }
+
+}

--- a/jmh-core-ct/src/test/java/org/openjdk/jmh/ct/states/dag/cycles/NoDoubleUseCycleThreadTest.java
+++ b/jmh-core-ct/src/test/java/org/openjdk/jmh/ct/states/dag/cycles/NoDoubleUseCycleThreadTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2020, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jmh.ct.states.dag.cycles;
+
+import org.junit.Test;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.ct.CompileTest;
+
+public class NoDoubleUseCycleThreadTest {
+
+    @State(Scope.Thread)
+    public static class B {
+    }
+
+    @State(Scope.Thread)
+    public static class A {
+        @Setup
+        public void setup(B b1, B b2) {
+
+        }
+        @TearDown
+        public void teardown(B b1, B b2) {
+
+        }
+    }
+
+    @Benchmark
+    public void test(A a1, A a2) {
+
+    }
+
+    @Test
+    public void compileTest() {
+        CompileTest.assertOK(this.getClass());
+    }
+
+}


### PR DESCRIPTION
There is a Windows GH Actions test failure on JDK 7.

```
compileTest(org.openjdk.jmh.ct.states.dag.cycles.ExplicitCycleBenchmarkTest) Time elapsed: 0.383 sec <<< FAILURE!
junit.framework.AssertionFailedError: Failure message should contain "@State dependency cycle is detected", but was "[ERROR at line -1: Annotation generator had thrown the exception. java.lang.InternalError: java.lang.StackOverflowError
   at java.lang.reflect.Proxy.newInstance(Proxy.java:772)
   at java.lang.reflect.Proxy.newProxyInstance(Proxy.java:755)
   at sun.reflect.annotation.AnnotationParser.annotationForMap(AnnotationParser.java:301)
   at com.sun.tools.javac.model.AnnotationProxyMaker.generateAnnotation(AnnotationProxyMaker.java:86)
   at com.sun.tools.javac.model.AnnotationProxyMaker.generateAnnotation(AnnotationProxyMaker.java:78)
   at com.sun.tools.javac.model.JavacElements.getAnnotation(JavacElements.java:108)
   at com.sun.tools.javac.code.Symbol.getAnnotation(Symbol.java:456)
   at org.openjdk.jmh.generators.annotations.APMethodInfo.getAnnotation(APMethodInfo.java:82)
   at org.openjdk.jmh.generators.core.StateObjectHandler.validateNoCyclesStep(StateObjectHandler.java:248)
   at org.openjdk.jmh.generators.core.StateObjectHandler.validateNoCyclesStep(StateObjectHandler.java:249)
   at
...
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902805](https://bugs.openjdk.java.net/browse/CODETOOLS-7902805): State cycle validation should be more resilient


### Download
`$ git fetch https://git.openjdk.java.net/jmh pull/15/head:pull/15`
`$ git checkout pull/15`
