### PR TITLE
CODETOOLS-7902813: Amend experimental compiler-assisted blackhole support

### DIFF
--- a/jmh-core-benchmarks/src/main/java/org/openjdk/jmh/validation/Main.java
+++ b/jmh-core-benchmarks/src/main/java/org/openjdk/jmh/validation/Main.java
@@ -25,7 +25,6 @@
 package org.openjdk.jmh.validation;
 
 import joptsimple.*;
-import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.runner.CompilerHints;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.*;

--- a/jmh-core-benchmarks/src/main/java/org/openjdk/jmh/validation/Main.java
+++ b/jmh-core-benchmarks/src/main/java/org/openjdk/jmh/validation/Main.java
@@ -25,6 +25,7 @@
 package org.openjdk.jmh.validation;
 
 import joptsimple.*;
+import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.runner.CompilerHints;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.*;
@@ -154,8 +155,6 @@ public class Main {
                 throw new IllegalStateException();
         }
 
-        boolean testCompilerBlackhole = JDKVersion.parseMajor(System.getProperty("java.version")) >= 16;
-
         for (Test t : tests) {
             switch (t) {
                 case timing:
@@ -195,17 +194,23 @@ public class Main {
                     new BlackholeConsumeCPUTest().runWith(pw, opts);
                     break;
                 case blackhole_single:
-                    new BlackholeSingleTest().runWith(pw, opts);
+                    setBlackholeOpts(BlackholeTestMode.normal);
+                    new BlackholeSingleTest(BlackholeTestMode.normal).runWith(pw, opts);
+                    setBlackholeOpts(BlackholeTestMode.compiler);
+                    new BlackholeSingleTest(BlackholeTestMode.compiler).runWith(pw, opts);
+                    setBlackholeOpts(BlackholeTestMode.full_dontinline);
+                    new BlackholeSingleTest(BlackholeTestMode.full_dontinline).runWith(pw, opts);
+                    setBlackholeOpts(BlackholeTestMode.full);
+                    new BlackholeSingleTest(BlackholeTestMode.full).runWith(pw, opts);
+                    setBlackholeOpts(BlackholeTestMode.normal);
                     break;
                 case blackhole_pipelined:
                     setBlackholeOpts(BlackholeTestMode.normal);
                     new BlackholePipelinedTest(false, BlackholeTestMode.normal).runWith(pw, opts);
                     new BlackholePipelinedTest(true, BlackholeTestMode.normal).runWith(pw, opts);
-                    if (testCompilerBlackhole) {
-                        setBlackholeOpts(BlackholeTestMode.compiler);
-                        new BlackholePipelinedTest(false, BlackholeTestMode.compiler).runWith(pw, opts);
-                        new BlackholePipelinedTest(true, BlackholeTestMode.compiler).runWith(pw, opts);
-                    }
+                    setBlackholeOpts(BlackholeTestMode.compiler);
+                    new BlackholePipelinedTest(false, BlackholeTestMode.compiler).runWith(pw, opts);
+                    new BlackholePipelinedTest(true, BlackholeTestMode.compiler).runWith(pw, opts);
                     setBlackholeOpts(BlackholeTestMode.full_dontinline);
                     new BlackholePipelinedTest(false, BlackholeTestMode.full_dontinline).runWith(pw, opts);
                     new BlackholePipelinedTest(true, BlackholeTestMode.full_dontinline).runWith(pw, opts);
@@ -217,10 +222,8 @@ public class Main {
                 case blackhole_consec:
                     setBlackholeOpts(BlackholeTestMode.normal);
                     new BlackholeConsecutiveTest(BlackholeTestMode.normal).runWith(pw, opts);
-                    if (testCompilerBlackhole) {
-                        setBlackholeOpts(BlackholeTestMode.compiler);
-                        new BlackholeConsecutiveTest(BlackholeTestMode.compiler).runWith(pw, opts);
-                    }
+                    setBlackholeOpts(BlackholeTestMode.compiler);
+                    new BlackholeConsecutiveTest(BlackholeTestMode.compiler).runWith(pw, opts);
                     setBlackholeOpts(BlackholeTestMode.full_dontinline);
                     new BlackholeConsecutiveTest(BlackholeTestMode.full_dontinline).runWith(pw, opts);
                     setBlackholeOpts(BlackholeTestMode.full);

--- a/jmh-core-benchmarks/src/main/java/org/openjdk/jmh/validation/tests/BlackholeSingleTest.java
+++ b/jmh-core-benchmarks/src/main/java/org/openjdk/jmh/validation/tests/BlackholeSingleTest.java
@@ -37,9 +37,15 @@ import org.openjdk.jmh.validation.ValidationTest;
 import java.io.PrintWriter;
 
 public class BlackholeSingleTest extends ValidationTest {
+    private final BlackholeTestMode mode;
+
+    public BlackholeSingleTest(BlackholeTestMode mode) {
+        this.mode = mode;
+    }
+
     @Override
     public void runWith(PrintWriter pw, Options parent) throws RunnerException {
-        pw.println("--------- BLACKHOLE SINGLE INVOCATION TEST");
+        pw.println("--------- BLACKHOLE SINGLE INVOCATION TEST (" + blackholeModeString(mode) + ")");
         pw.println();
 
         org.openjdk.jmh.util.Utils.reflow(pw,
@@ -48,6 +54,8 @@ public class BlackholeSingleTest extends ValidationTest {
                         "should be the same for implicit and explicit cases, and comparable across all data types. ",
                 80, 2);
         pw.println();
+
+        blackholeModeMessage(pw, mode);
 
         String[] types = new String[]  {
                 "boolean", "byte",   "short",


### PR DESCRIPTION
JDK-8258619 changes the requirements for compiler-assisted blackholes to be empty static methods. This requires adjustments to JMH Blackhole itself.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902813](https://bugs.openjdk.java.net/browse/CODETOOLS-7902813): Amend experimental compiler-assisted blackhole support


### Download
`$ git fetch https://git.openjdk.java.net/jmh pull/16/head:pull/16`
`$ git checkout pull/16`
