### PR TITLE
CODETOOLS-7902695: JMH should not try to access inaccessible fields

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/util/Utils.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/util/Utils.java
@@ -228,18 +228,20 @@ public class Utils {
         // to the console if we try setAccessible(true) on inaccessible object.
         // JDK 16 would deny access by default, so we have no recourse at all.
         // Try to check with JDK 9+ AccessibleObject.canAccess before doing this
-        // to avoid the confusing console warnings.
-        try {
-            Method canAccess = AccessibleObject.class.getDeclaredMethod("canAccess", Object.class);
-            if (!(boolean) canAccess.invoke(o, holder)) {
-                throw new IllegalAccessException(o + " is not accessible");
+        // to avoid the confusing console warnings. Force the break in if user asks
+        // explicitly.
+
+        if (!Boolean.getBoolean("jmh.forceSetAccessible")) {
+            try {
+                Method canAccess = AccessibleObject.class.getDeclaredMethod("canAccess", Object.class);
+                if (!(boolean) canAccess.invoke(o, holder)) {
+                    throw new IllegalAccessException(o + " is not accessible");
+                }
+            } catch (NoSuchMethodException | InvocationTargetException e) {
+                // fall-through
             }
-        } catch (NoSuchMethodException | InvocationTargetException e) {
-            // fall-through
         }
 
-        // JDK 8-: reflection checks are lax, this should succeed
-        // JDK 9+: canAccess passed, this should succeed
         o.setAccessible(true);
     }
 

--- a/jmh-core/src/main/java/org/openjdk/jmh/util/Utils.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/util/Utils.java
@@ -227,7 +227,8 @@ public class Utils {
         // JDK 9+ has the module protections in place, which would print the warning
         // to the console if we try setAccessible(true) on inaccessible object.
         // JDK 16 would deny access by default, so we have no recourse at all.
-        // Try to check with JDK 9 canAccesss before doing this to avoid warnings.
+        // Try to check with JDK 9+ AccessibleObject.canAccess before doing this
+        // to avoid the confusing console warnings.
         try {
             Method canAccess = AccessibleObject.class.getDeclaredMethod("canAccess", Object.class);
             if (!(boolean) canAccess.invoke(o, holder)) {
@@ -237,7 +238,8 @@ public class Utils {
             // fall-through
         }
 
-        // Try to force our way through.
+        // JDK 8-: reflection checks are lax, this should succeed
+        // JDK 9+: canAccess passed, this should succeed
         o.setAccessible(true);
     }
 

--- a/jmh-core/src/main/java/org/openjdk/jmh/util/Utils.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/util/Utils.java
@@ -28,7 +28,9 @@ import sun.misc.Unsafe;
 
 import java.io.*;
 import java.lang.management.ManagementFactory;
+import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.charset.Charset;
 import java.util.*;
@@ -221,6 +223,24 @@ public class Utils {
         return max;
     }
 
+    private static void setAccessible(Object holder, AccessibleObject o) throws IllegalAccessException {
+        // JDK 9+ has the module protections in place, which would print the warning
+        // to the console if we try setAccessible(true) on inaccessible object.
+        // JDK 16 would deny access by default, so we have no recourse at all.
+        // Try to check with JDK 9 canAccesss before doing this to avoid warnings.
+        try {
+            Method canAccess = AccessibleObject.class.getDeclaredMethod("canAccess", Object.class);
+            if (!(boolean) canAccess.invoke(o, holder)) {
+                throw new IllegalAccessException(o + " is not accessible");
+            }
+        } catch (NoSuchMethodException | InvocationTargetException e) {
+            // fall-through
+        }
+
+        // Try to force our way through.
+        o.setAccessible(true);
+    }
+
     public static Charset guessConsoleEncoding() {
         // The reason for this method to exist is simple: we need the proper platform encoding for output.
         // We cannot use Console class directly, because we also need the access to the raw byte stream,
@@ -232,13 +252,13 @@ public class Utils {
             Console console = System.console();
             if (console != null) {
                 Field f = Console.class.getDeclaredField("cs");
-                f.setAccessible(true);
+                setAccessible(console, f);
                 Object res = f.get(console);
                 if (res instanceof Charset) {
                     return (Charset) res;
                 }
                 Method m = Console.class.getDeclaredMethod("encoding");
-                m.setAccessible(true);
+                setAccessible(console, m);
                 res = m.invoke(null);
                 if (res instanceof String) {
                     return Charset.forName((String) res);
@@ -256,7 +276,7 @@ public class Utils {
             PrintStream out = System.out;
             if (out != null) {
                 Field f = PrintStream.class.getDeclaredField("charOut");
-                f.setAccessible(true);
+                setAccessible(out, f);
                 Object res = f.get(out);
                 if (res instanceof OutputStreamWriter) {
                     String encoding = ((OutputStreamWriter) res).getEncoding();


### PR DESCRIPTION
JDK 9+ reluctantly allows accessing `Console.cs` field to get the console encoding for e.g. Windows. JDK 16+ disallows it point-blank. JDK 9+ still prints the warning. Given that we would not be able to do this in future, it makes sense to check for field accessibility before trying to `setAccessible` the field for JDK 9+.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902695](https://bugs.openjdk.java.net/browse/CODETOOLS-7902695): JMH should not try to access inaccessible fields


### Download
`$ git fetch https://git.openjdk.java.net/jmh pull/18/head:pull/18`
`$ git checkout pull/18`
