### PR TITLE
CODETOOLS-7902825: Generated BenchmarkList file should be sorted for reproducibility

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/BenchmarkList.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/BenchmarkList.java
@@ -56,9 +56,9 @@ public class BenchmarkList extends AbstractResourceReader {
         return new BenchmarkList(null, null, strings);
     }
 
-    public static Collection<BenchmarkListEntry> readBenchmarkList(InputStream stream) throws IOException {
+    public static List<BenchmarkListEntry> readBenchmarkList(InputStream stream) throws IOException {
         try (Reader reader = new InputStreamReader(stream, StandardCharsets.UTF_8)) {
-            Collection<BenchmarkListEntry> entries = new ArrayList<>();
+            List<BenchmarkListEntry> entries = new ArrayList<>();
             for (String line : FileUtils.readAllLines(reader)) {
                 BenchmarkListEntry ble = new BenchmarkListEntry(line);
                 entries.add(ble);
@@ -69,7 +69,9 @@ public class BenchmarkList extends AbstractResourceReader {
 
     public static void writeBenchmarkList(OutputStream stream, Collection<BenchmarkListEntry> entries) {
         try (PrintWriter writer = new PrintWriter(new OutputStreamWriter(stream, StandardCharsets.UTF_8))) {
-            for (BenchmarkListEntry entry : entries) {
+            List<BenchmarkListEntry> sorted = new ArrayList<>(entries);
+            Collections.sort(sorted);
+            for (BenchmarkListEntry entry : sorted) {
                 writer.println(entry.toLine());
             }
         }

--- a/jmh-core/src/test/java/org/openjdk/jmh/runner/TestBenchmarkListSorting.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/runner/TestBenchmarkListSorting.java
@@ -86,7 +86,7 @@ public class TestBenchmarkListSorting {
                 "something.generated.TestMethod",
                 Mode.AverageTime);
 
-        // Present to writer in reverse order
+        // Present to writer in mixed order
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         BenchmarkList.writeBenchmarkList(bos, Arrays.asList(br4, br2, br3, br1));
 


### PR DESCRIPTION
As stated in the RFE, JMH should sort BenchmarkListEntries before writing them out. It is cleaner to do in `BenchmarkList` itself, as it allows unit testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902825](https://bugs.openjdk.java.net/browse/CODETOOLS-7902825): Generated BenchmarkList file should be sorted for reproducibility


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - no project role)


### Download
`$ git fetch https://git.openjdk.java.net/jmh pull/19/head:pull/19`
`$ git checkout pull/19`
