### PR TITLE
CODETOOLS-7902828: JMH: Start testing with JDK 17 EA

### DIFF
--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java: [7, 8, 11, 15, 16-ea]
+        java: [7, 8, 11, 15, 16-ea, 17-ea]
         os: [ubuntu-18.04, windows-2019, macos-10.15]
         profile: [default, reflection, asm]
       fail-fast: false


### PR DESCRIPTION
JDK mainline had switched development to JDK 17 EA, we should be adding that version to pipelines.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902828](https://bugs.openjdk.java.net/browse/CODETOOLS-7902828): JMH: Start testing with JDK 17 EA


### Download
`$ git fetch https://git.openjdk.java.net/jmh pull/20/head:pull/20`
`$ git checkout pull/20`
