### PR TITLE
CODETOOLS-7902829: JMH Statistics implementations do not follow Comparable spec

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/util/AbstractStatistics.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/util/AbstractStatistics.java
@@ -93,7 +93,7 @@ public abstract class AbstractStatistics implements Statistics {
         if (isDifferent(other, confidence)) {
             double t = getMean();
             double o = other.getMean();
-            return (t > o) ? -1 : 1;
+            return (t < o) ? -1 : 1;
         } else {
             return 0;
         }

--- a/jmh-core/src/main/java/org/openjdk/jmh/util/AbstractStatistics.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/util/AbstractStatistics.java
@@ -91,9 +91,7 @@ public abstract class AbstractStatistics implements Statistics {
     @Override
     public int compareTo(Statistics other, double confidence) {
         if (isDifferent(other, confidence)) {
-            double t = getMean();
-            double o = other.getMean();
-            return (t < o) ? -1 : 1;
+            return Double.compare(getMean(), other.getMean());
         } else {
             return 0;
         }

--- a/jmh-core/src/test/java/org/openjdk/jmh/util/TestListStatistics.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/util/TestListStatistics.java
@@ -187,7 +187,7 @@ public class TestListStatistics {
 
         for (double conf : new double[] {0.5, 0.9, 0.99, 0.999, 0.9999, 0.99999}) {
             Assert.assertTrue("Diff significant at " + conf, s1.isDifferent(s2, conf));
-            Assert.assertEquals(1, s1.compareTo(s2, conf));
+            Assert.assertEquals(-1, s1.compareTo(s2, conf));
         }
     }
 
@@ -227,8 +227,8 @@ public class TestListStatistics {
         Assert.assertFalse("Diff not significant at 0.999", s1.isDifferent(s2, 0.999));
         Assert.assertFalse("Diff not significant at 0.9999", s1.isDifferent(s2, 0.9999));
 
-        Assert.assertEquals("compareTo at 0.5", 1, s1.compareTo(s2, 0.5));
-        Assert.assertEquals("compareTo at 0.9", 1, s1.compareTo(s2, 0.9));
+        Assert.assertEquals("compareTo at 0.5", -1, s1.compareTo(s2, 0.5));
+        Assert.assertEquals("compareTo at 0.9", -1, s1.compareTo(s2, 0.9));
         Assert.assertEquals("compareTo at 0.99", 0, s1.compareTo(s2, 0.99));
         Assert.assertEquals("compareTo at 0.999", 0, s1.compareTo(s2, 0.999));
         Assert.assertEquals("compareTo at 0.9999", 0, s1.compareTo(s2, 0.9999));

--- a/jmh-core/src/test/java/org/openjdk/jmh/util/TestListStatistics.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/util/TestListStatistics.java
@@ -187,7 +187,7 @@ public class TestListStatistics {
 
         for (double conf : new double[] {0.5, 0.9, 0.99, 0.999, 0.9999, 0.99999}) {
             Assert.assertTrue("Diff significant at " + conf, s1.isDifferent(s2, conf));
-            Assert.assertEquals(-1, s1.compareTo(s2, conf));
+            Assert.assertTrue(s1.compareTo(s2, conf) < 0);
         }
     }
 
@@ -227,8 +227,8 @@ public class TestListStatistics {
         Assert.assertFalse("Diff not significant at 0.999", s1.isDifferent(s2, 0.999));
         Assert.assertFalse("Diff not significant at 0.9999", s1.isDifferent(s2, 0.9999));
 
-        Assert.assertEquals("compareTo at 0.5", -1, s1.compareTo(s2, 0.5));
-        Assert.assertEquals("compareTo at 0.9", -1, s1.compareTo(s2, 0.9));
+        Assert.assertTrue("compareTo at 0.5", s1.compareTo(s2, 0.5) < 0);
+        Assert.assertTrue("compareTo at 0.9", s1.compareTo(s2, 0.9) < 0);
         Assert.assertEquals("compareTo at 0.99", 0, s1.compareTo(s2, 0.99));
         Assert.assertEquals("compareTo at 0.999", 0, s1.compareTo(s2, 0.999));
         Assert.assertEquals("compareTo at 0.9999", 0, s1.compareTo(s2, 0.9999));

--- a/jmh-core/src/test/java/org/openjdk/jmh/util/TestMultisetStatistics.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/util/TestMultisetStatistics.java
@@ -183,7 +183,7 @@ public class TestMultisetStatistics {
 
         for (double conf : new double[] {0.5, 0.9, 0.99, 0.999, 0.9999, 0.99999}) {
             Assert.assertTrue("Diff significant at " + conf, s1.isDifferent(s2, conf));
-            Assert.assertEquals(-1, s1.compareTo(s2, conf));
+            Assert.assertTrue(s1.compareTo(s2, conf) < 0);
         }
     }
 
@@ -219,8 +219,8 @@ public class TestMultisetStatistics {
         Assert.assertFalse("Diff not significant at 0.999", s1.isDifferent(s2, 0.999));
         Assert.assertFalse("Diff not significant at 0.9999", s1.isDifferent(s2, 0.9999));
 
-        Assert.assertEquals("compareTo at 0.5", -1, s1.compareTo(s2, 0.5));
-        Assert.assertEquals("compareTo at 0.9", -1, s1.compareTo(s2, 0.9));
+        Assert.assertTrue("compareTo at 0.5", s1.compareTo(s2, 0.5) < 0);
+        Assert.assertTrue("compareTo at 0.9", s1.compareTo(s2, 0.9) < 0);
         Assert.assertEquals("compareTo at 0.99", 0, s1.compareTo(s2, 0.99));
         Assert.assertEquals("compareTo at 0.999", 0, s1.compareTo(s2, 0.999));
         Assert.assertEquals("compareTo at 0.9999", 0, s1.compareTo(s2, 0.9999));

--- a/jmh-core/src/test/java/org/openjdk/jmh/util/TestMultisetStatistics.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/util/TestMultisetStatistics.java
@@ -183,7 +183,7 @@ public class TestMultisetStatistics {
 
         for (double conf : new double[] {0.5, 0.9, 0.99, 0.999, 0.9999, 0.99999}) {
             Assert.assertTrue("Diff significant at " + conf, s1.isDifferent(s2, conf));
-            Assert.assertEquals(1, s1.compareTo(s2, conf));
+            Assert.assertEquals(-1, s1.compareTo(s2, conf));
         }
     }
 
@@ -219,8 +219,8 @@ public class TestMultisetStatistics {
         Assert.assertFalse("Diff not significant at 0.999", s1.isDifferent(s2, 0.999));
         Assert.assertFalse("Diff not significant at 0.9999", s1.isDifferent(s2, 0.9999));
 
-        Assert.assertEquals("compareTo at 0.5", 1, s1.compareTo(s2, 0.5));
-        Assert.assertEquals("compareTo at 0.9", 1, s1.compareTo(s2, 0.9));
+        Assert.assertEquals("compareTo at 0.5", -1, s1.compareTo(s2, 0.5));
+        Assert.assertEquals("compareTo at 0.9", -1, s1.compareTo(s2, 0.9));
         Assert.assertEquals("compareTo at 0.99", 0, s1.compareTo(s2, 0.99));
         Assert.assertEquals("compareTo at 0.999", 0, s1.compareTo(s2, 0.999));
         Assert.assertEquals("compareTo at 0.9999", 0, s1.compareTo(s2, 0.9999));


### PR DESCRIPTION
`Comparable.compareTo` spec says: "Returns a negative integer, zero, or a positive integer as this object is less than, equal to, or greater than the specified object."

Unfortunately, that is not followed by JMH Statistics, because they get the order wrong. The tests that are supposed to catch this are also wrong.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902829](https://bugs.openjdk.java.net/browse/CODETOOLS-7902829): JMH Statistics implementations do not follow Comparable spec


### Download
`$ git fetch https://git.openjdk.java.net/jmh pull/21/head:pull/21`
`$ git checkout pull/21`
