### PR TITLE
CODETOOLS-7902830: dtraceasm: do not Process.destroy the dtrace process

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/util/Utils.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/util/Utils.java
@@ -478,23 +478,6 @@ public class Utils {
         }
     }
 
-    public static Collection<String> destroy(Process process) {
-        Collection<String> messages = new ArrayList<>();
-        try {
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            process.destroy();
-            int exitCode = process.waitFor();
-            if (exitCode == 0) {
-                return Collections.emptyList();
-            }
-
-            messages.add(baos.toString());
-            return messages;
-        } catch (InterruptedException e) {
-            throw new IllegalStateException(e);
-        }
-    }
-
     public static Collection<String> runWith(List<String> cmd) {
         Collection<String> messages = new ArrayList<>();
         try {

--- a/jmh-core/src/main/java/org/openjdk/jmh/util/Utils.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/util/Utils.java
@@ -457,7 +457,7 @@ public class Utils {
             // Fallthrough
         }
 
-        // Step 2. Try to hack into the JDK 8 UNIXProcess.
+        // Step 2. Try to hack into the JDK 8- UNIXProcess.
         try {
             Class<?> c = Class.forName("java.lang.UNIXProcess");
             Field f = c.getDeclaredField("pid");
@@ -467,7 +467,7 @@ public class Utils {
                 return (int) o;
             }
         } catch (NoSuchFieldException | ClassNotFoundException | IllegalAccessException e) {
-            // Fallthrough.
+            // Fallthrough
         }
 
         // Step 3. Try to hack into JDK 9+ ProcessImpl.
@@ -481,10 +481,10 @@ public class Utils {
                 return (int) o;
             }
         } catch (NoSuchFieldException | ClassNotFoundException | IllegalAccessException e) {
-            // Fallthrough.
+            // Fallthrough
         }
 
-        // No dice, return bad PID.
+        // No dice, return zero
         return 0;
     }
 

--- a/jmh-core/src/main/java/org/openjdk/jmh/util/Utils.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/util/Utils.java
@@ -440,6 +440,54 @@ public class Utils {
         throw new IllegalStateException("Unsupported PID format: " + name);
     }
 
+    /**
+     * Gets the PID of the target process.
+     * @param process to poll
+     * @return PID, or zero if no PID is found
+     */
+    public static long getPid(Process process) {
+        // Step 1. Try Process.pid, available since Java 9.
+        try {
+            Method m = Process.class.getMethod("pid");
+            Object pid = m.invoke(process);
+            if (pid instanceof Long) {
+                return (long) pid;
+            }
+        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+            // Fallthrough
+        }
+
+        // Step 2. Try to hack into the JDK 8 UNIXProcess.
+        try {
+            Class<?> c = Class.forName("java.lang.UNIXProcess");
+            Field f = c.getDeclaredField("pid");
+            setAccessible(process, f);
+            Object o = f.get(process);
+            if (o instanceof Integer) {
+                return (int) o;
+            }
+        } catch (NoSuchFieldException | ClassNotFoundException | IllegalAccessException e) {
+            // Fallthrough.
+        }
+
+        // Step 3. Try to hack into JDK 9+ ProcessImpl.
+        // Renamed from UNIXProcess with JDK-8071481.
+        try {
+            Class<?> c = Class.forName("java.lang.ProcessImpl");
+            Field f = c.getDeclaredField("pid");
+            setAccessible(process, f);
+            Object o = f.get(process);
+            if (o instanceof Integer) {
+                return (int) o;
+            }
+        } catch (NoSuchFieldException | ClassNotFoundException | IllegalAccessException e) {
+            // Fallthrough.
+        }
+
+        // No dice, return bad PID.
+        return 0;
+    }
+
     public static Collection<String> tryWith(String... cmd) {
         Collection<String> messages = new ArrayList<>();
         try {

--- a/jmh-core/src/test/java/org/openjdk/jmh/util/TestUtil.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/util/TestUtil.java
@@ -34,7 +34,7 @@ public class TestUtil {
 
     @Test
     public void testPID_Current() {
-        Assert.assertNotSame(0, Utils.getPid());
+        Assert.assertTrue(Utils.getPid() != 0);
     }
 
     @Test
@@ -42,7 +42,7 @@ public class TestUtil {
         if (!Utils.isWindows()) {
             ProcessBuilder pb = new ProcessBuilder().command("sleep", "1");
             Process p = pb.start();
-            Assert.assertNotSame(0, Utils.getPid(p));
+            Assert.assertTrue(Utils.getPid(p) != 0);
             p.waitFor();
         }
     }

--- a/jmh-core/src/test/java/org/openjdk/jmh/util/TestUtil.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/util/TestUtil.java
@@ -27,13 +27,24 @@ package org.openjdk.jmh.util;
 import junit.framework.Assert;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.Arrays;
 
 public class TestUtil {
 
     @Test
-    public void testPID() {
-        Assert.assertFalse(Utils.getPid() == 0);
+    public void testPID_Current() {
+        Assert.assertNotSame(0, Utils.getPid());
+    }
+
+    @Test
+    public void testPID_Other() throws IOException, InterruptedException {
+        if (!Utils.isWindows()) {
+            ProcessBuilder pb = new ProcessBuilder().command("sleep", "1");
+            Process p = pb.start();
+            Assert.assertNotSame(0, Utils.getPid(p));
+            p.waitFor();
+        }
     }
 
     @Test


### PR DESCRIPTION
Look here:
 https://mail.openjdk.java.net/pipermail/jmh-dev/2021-February/003134.html

Process.destroy closes the streams, so whatever output the profiler had accrued would be lost.

I need someone with functioning Mac OS dtrace to test this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902830](https://bugs.openjdk.java.net/browse/CODETOOLS-7902830): dtraceasm: do not Process.destroy the dtrace process


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - no project role) ⚠️ Review applies to 9b8dd13e82e6f0fb98725f462a7a13c8e1aa5613


### Download
`$ git fetch https://git.openjdk.java.net/jmh pull/22/head:pull/22`
`$ git checkout pull/22`
