### PR TITLE
CODETOOLS-7902838: JMH: Don't use fail() inside a try-catch catching an AssertionError

### DIFF
--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/AbruptFailureTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/AbruptFailureTest.java
@@ -57,7 +57,7 @@ public class AbruptFailureTest {
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         long time1 = System.nanoTime();
         try {
             Options opt = new OptionsBuilder()
@@ -67,7 +67,7 @@ public class AbruptFailureTest {
             new Runner(opt).run();
 
             Assert.fail("Should have failed");
-        } catch (Throwable t) {
+        } catch (RunnerException e) {
             // expected
             long time2 = System.nanoTime();
             long delay = TimeUnit.NANOSECONDS.toSeconds(time2 - time1);

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingBenchmarkBenchSetupTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingBenchmarkBenchSetupTest.java
@@ -65,7 +65,7 @@ public class FailingBenchmarkBenchSetupTest {
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -74,7 +74,7 @@ public class FailingBenchmarkBenchSetupTest {
             new Runner(opt).run();
 
             Assert.fail("Should have failed");
-        } catch (Throwable t) {
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingBenchmarkBenchTearDownTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingBenchmarkBenchTearDownTest.java
@@ -65,7 +65,7 @@ public class FailingBenchmarkBenchTearDownTest {
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -74,7 +74,7 @@ public class FailingBenchmarkBenchTearDownTest {
             new Runner(opt).run();
 
             Assert.fail("Should have failed");
-        } catch (Throwable t) {
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingBenchmarkBenchTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingBenchmarkBenchTest.java
@@ -59,7 +59,7 @@ public class FailingBenchmarkBenchTest {
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -67,8 +67,8 @@ public class FailingBenchmarkBenchTest {
                     .build();
             new Runner(opt).run();
 
-            org.junit.Assert.fail("Should have failed");
-        } catch (Throwable t) {
+            Assert.fail("Should have failed");
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingBenchmarkStateSetupTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingBenchmarkStateSetupTest.java
@@ -67,7 +67,7 @@ public class FailingBenchmarkStateSetupTest {
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -75,8 +75,8 @@ public class FailingBenchmarkStateSetupTest {
                     .build();
             new Runner(opt).run();
 
-            org.junit.Assert.fail("Should have failed");
-        } catch (Throwable t) {
+            Assert.fail("Should have failed");
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingBenchmarkStateTearDownTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingBenchmarkStateTearDownTest.java
@@ -67,7 +67,7 @@ public class FailingBenchmarkStateTearDownTest {
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -75,8 +75,8 @@ public class FailingBenchmarkStateTearDownTest {
                     .build();
             new Runner(opt).run();
 
-            org.junit.Assert.fail("Should have failed");
-        } catch (Throwable t) {
+            Assert.fail("Should have failed");
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingForkedBenchStackProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingForkedBenchStackProfilerTest.java
@@ -60,7 +60,7 @@ public class FailingForkedBenchStackProfilerTest {
     }
 
     @Test(timeout = 60*1000)
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -70,8 +70,8 @@ public class FailingForkedBenchStackProfilerTest {
                     .build();
             new Runner(opt).run();
 
-            org.junit.Assert.fail("Should have failed");
-        } catch (Throwable t) {
+            Assert.fail("Should have failed");
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingForkedBenchTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingForkedBenchTest.java
@@ -59,7 +59,7 @@ public class FailingForkedBenchTest {
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -68,8 +68,8 @@ public class FailingForkedBenchTest {
                     .build();
             new Runner(opt).run();
 
-            org.junit.Assert.fail("Should have failed");
-        } catch (Throwable t) {
+            Assert.fail("Should have failed");
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingForkedSetupTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingForkedSetupTest.java
@@ -65,7 +65,7 @@ public class FailingForkedSetupTest {
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -74,8 +74,8 @@ public class FailingForkedSetupTest {
                     .build();
             new Runner(opt).run();
 
-            org.junit.Assert.fail("Should have failed");
-        } catch (Throwable t) {
+            Assert.fail("Should have failed");
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingForkedTearDownTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingForkedTearDownTest.java
@@ -65,7 +65,7 @@ public class FailingForkedTearDownTest {
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -74,8 +74,8 @@ public class FailingForkedTearDownTest {
                     .build();
             new Runner(opt).run();
 
-            org.junit.Assert.fail("Should have failed");
-        } catch (Throwable t) {
+            Assert.fail("Should have failed");
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingGroupBenchSetupTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingGroupBenchSetupTest.java
@@ -67,7 +67,7 @@ public class FailingGroupBenchSetupTest {
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -75,8 +75,8 @@ public class FailingGroupBenchSetupTest {
                     .build();
             new Runner(opt).run();
 
-            org.junit.Assert.fail("Should have failed");
-        } catch (Throwable t) {
+            Assert.fail("Should have failed");
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingGroupBenchTearDownTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingGroupBenchTearDownTest.java
@@ -67,7 +67,7 @@ public class FailingGroupBenchTearDownTest {
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -75,8 +75,8 @@ public class FailingGroupBenchTearDownTest {
                     .build();
             new Runner(opt).run();
 
-            org.junit.Assert.fail("Should have failed");
-        } catch (Throwable t) {
+            Assert.fail("Should have failed");
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingGroupBenchTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingGroupBenchTest.java
@@ -61,7 +61,7 @@ public class FailingGroupBenchTest {
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -69,8 +69,8 @@ public class FailingGroupBenchTest {
                     .build();
             new Runner(opt).run();
 
-            org.junit.Assert.fail("Should have failed");
-        } catch (Throwable t) {
+            Assert.fail("Should have failed");
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingGroupStateSetupTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingGroupStateSetupTest.java
@@ -69,7 +69,7 @@ public class FailingGroupStateSetupTest {
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -77,8 +77,8 @@ public class FailingGroupStateSetupTest {
                     .build();
             new Runner(opt).run();
 
-            org.junit.Assert.fail("Should have failed");
-        } catch (Throwable t) {
+            Assert.fail("Should have failed");
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingGroupStateTearDownTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingGroupStateTearDownTest.java
@@ -69,7 +69,7 @@ public class FailingGroupStateTearDownTest {
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -77,8 +77,8 @@ public class FailingGroupStateTearDownTest {
                     .build();
             new Runner(opt).run();
 
-            org.junit.Assert.fail("Should have failed");
-        } catch (Throwable t) {
+            Assert.fail("Should have failed");
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingThreadBenchSetupTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingThreadBenchSetupTest.java
@@ -65,7 +65,7 @@ public class FailingThreadBenchSetupTest {
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -73,8 +73,8 @@ public class FailingThreadBenchSetupTest {
                     .build();
             new Runner(opt).run();
 
-            org.junit.Assert.fail("Should have failed");
-        } catch (Throwable t) {
+            Assert.fail("Should have failed");
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingThreadBenchTearDownTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingThreadBenchTearDownTest.java
@@ -65,7 +65,7 @@ public class FailingThreadBenchTearDownTest {
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -73,8 +73,8 @@ public class FailingThreadBenchTearDownTest {
                     .build();
             new Runner(opt).run();
 
-            org.junit.Assert.fail("Should have failed");
-        } catch (Throwable t) {
+            Assert.fail("Should have failed");
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingThreadBenchTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingThreadBenchTest.java
@@ -59,7 +59,7 @@ public class FailingThreadBenchTest {
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -67,8 +67,8 @@ public class FailingThreadBenchTest {
                     .build();
             new Runner(opt).run();
 
-            org.junit.Assert.fail("Should have failed");
-        } catch (Throwable t) {
+            Assert.fail("Should have failed");
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingThreadStateSetupTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingThreadStateSetupTest.java
@@ -67,7 +67,7 @@ public class FailingThreadStateSetupTest {
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -75,8 +75,8 @@ public class FailingThreadStateSetupTest {
                     .build();
             new Runner(opt).run();
 
-            org.junit.Assert.fail("Should have failed");
-        } catch (Throwable t) {
+            Assert.fail("Should have failed");
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingThreadStateTearDownTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingThreadStateTearDownTest.java
@@ -67,7 +67,7 @@ public class FailingThreadStateTearDownTest {
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -75,8 +75,8 @@ public class FailingThreadStateTearDownTest {
                     .build();
             new Runner(opt).run();
 
-            org.junit.Assert.fail("Should have failed");
-        } catch (Throwable t) {
+            Assert.fail("Should have failed");
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/AbstractBenchmarkBenchSetupTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/AbstractBenchmarkBenchSetupTest.java
@@ -61,7 +61,7 @@ public class AbstractBenchmarkBenchSetupTest extends AbstractSetupBase {
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -70,7 +70,7 @@ public class AbstractBenchmarkBenchSetupTest extends AbstractSetupBase {
             new Runner(opt).run();
 
             Assert.fail("Should have failed");
-        } catch (Throwable t) {
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/AbstractBenchmarkBenchTearDownTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/AbstractBenchmarkBenchTearDownTest.java
@@ -61,7 +61,7 @@ public class AbstractBenchmarkBenchTearDownTest extends AbstractTearDownBase {
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -70,7 +70,7 @@ public class AbstractBenchmarkBenchTearDownTest extends AbstractTearDownBase {
             new Runner(opt).run();
 
             Assert.fail("Should have failed");
-        } catch (Throwable t) {
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/AbstractBenchmarkStateSetupTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/AbstractBenchmarkStateSetupTest.java
@@ -63,7 +63,7 @@ public class AbstractBenchmarkStateSetupTest {
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -72,7 +72,7 @@ public class AbstractBenchmarkStateSetupTest {
             new Runner(opt).run();
 
             Assert.fail("Should have failed");
-        } catch (Throwable t) {
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/AbstractBenchmarkStateTearDownTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/AbstractBenchmarkStateTearDownTest.java
@@ -63,7 +63,7 @@ public class AbstractBenchmarkStateTearDownTest {
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -72,7 +72,7 @@ public class AbstractBenchmarkStateTearDownTest {
             new Runner(opt).run();
 
             Assert.fail("Should have failed");
-        } catch (Throwable t) {
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/AbstractGroupBenchSetupTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/AbstractGroupBenchSetupTest.java
@@ -63,7 +63,7 @@ public class AbstractGroupBenchSetupTest extends AbstractSetupBase {
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -72,7 +72,7 @@ public class AbstractGroupBenchSetupTest extends AbstractSetupBase {
             new Runner(opt).run();
 
             Assert.fail("Should have failed");
-        } catch (Throwable t) {
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/AbstractGroupBenchTearDownTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/AbstractGroupBenchTearDownTest.java
@@ -63,7 +63,7 @@ public class AbstractGroupBenchTearDownTest extends AbstractTearDownBase {
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -72,7 +72,7 @@ public class AbstractGroupBenchTearDownTest extends AbstractTearDownBase {
             new Runner(opt).run();
 
             Assert.fail("Should have failed");
-        } catch (Throwable t) {
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/AbstractGroupStateSetupTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/AbstractGroupStateSetupTest.java
@@ -65,7 +65,7 @@ public class AbstractGroupStateSetupTest {
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -74,7 +74,7 @@ public class AbstractGroupStateSetupTest {
             new Runner(opt).run();
 
             Assert.fail("Should have failed");
-        } catch (Throwable t) {
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/AbstractGroupStateTearDownTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/AbstractGroupStateTearDownTest.java
@@ -65,7 +65,7 @@ public class AbstractGroupStateTearDownTest {
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -74,7 +74,7 @@ public class AbstractGroupStateTearDownTest {
             new Runner(opt).run();
 
             Assert.fail("Should have failed");
-        } catch (Throwable t) {
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/AbstractThreadBenchSetupTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/AbstractThreadBenchSetupTest.java
@@ -61,7 +61,7 @@ public class AbstractThreadBenchSetupTest extends AbstractSetupBase {
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -70,7 +70,7 @@ public class AbstractThreadBenchSetupTest extends AbstractSetupBase {
             new Runner(opt).run();
 
             Assert.fail("Should have failed");
-        } catch (Throwable t) {
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/AbstractThreadBenchTearDownTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/AbstractThreadBenchTearDownTest.java
@@ -61,7 +61,7 @@ public class AbstractThreadBenchTearDownTest extends AbstractTearDownBase {
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -70,7 +70,7 @@ public class AbstractThreadBenchTearDownTest extends AbstractTearDownBase {
             new Runner(opt).run();
 
             Assert.fail("Should have failed");
-        } catch (Throwable t) {
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/AbstractThreadStateSetupTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/AbstractThreadStateSetupTest.java
@@ -63,7 +63,7 @@ public class AbstractThreadStateSetupTest {
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -72,7 +72,7 @@ public class AbstractThreadStateSetupTest {
             new Runner(opt).run();
 
             Assert.fail("Should have failed");
-        } catch (Throwable t) {
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/AbstractThreadStateTearDownTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/AbstractThreadStateTearDownTest.java
@@ -63,7 +63,7 @@ public class AbstractThreadStateTearDownTest {
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -72,7 +72,7 @@ public class AbstractThreadStateTearDownTest {
             new Runner(opt).run();
 
             Assert.fail("Should have failed");
-        } catch (Throwable t) {
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/InheritBenchmarkBenchSetupTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/InheritBenchmarkBenchSetupTest.java
@@ -58,7 +58,7 @@ public class InheritBenchmarkBenchSetupTest extends InheritableBenchmarkSetupSta
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -67,7 +67,7 @@ public class InheritBenchmarkBenchSetupTest extends InheritableBenchmarkSetupSta
             new Runner(opt).run();
 
             Assert.fail("Should have failed");
-        } catch (Throwable t) {
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/InheritBenchmarkBenchTearDownTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/InheritBenchmarkBenchTearDownTest.java
@@ -58,7 +58,7 @@ public class InheritBenchmarkBenchTearDownTest extends InheritableBenchmarkTearD
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -67,7 +67,7 @@ public class InheritBenchmarkBenchTearDownTest extends InheritableBenchmarkTearD
             new Runner(opt).run();
 
             Assert.fail("Should have failed");
-        } catch (Throwable t) {
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/InheritBenchmarkStateSetupTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/InheritBenchmarkStateSetupTest.java
@@ -60,7 +60,7 @@ public class InheritBenchmarkStateSetupTest {
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -69,7 +69,7 @@ public class InheritBenchmarkStateSetupTest {
             new Runner(opt).run();
 
             Assert.fail("Should have failed");
-        } catch (Throwable t) {
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/InheritBenchmarkStateTearDownTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/InheritBenchmarkStateTearDownTest.java
@@ -60,7 +60,7 @@ public class InheritBenchmarkStateTearDownTest {
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -69,7 +69,7 @@ public class InheritBenchmarkStateTearDownTest {
             new Runner(opt).run();
 
             Assert.fail("Should have failed");
-        } catch (Throwable t) {
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/InheritGroupBenchSetupTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/InheritGroupBenchSetupTest.java
@@ -60,7 +60,7 @@ public class InheritGroupBenchSetupTest extends InheritableGroupSetupState {
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -69,7 +69,7 @@ public class InheritGroupBenchSetupTest extends InheritableGroupSetupState {
             new Runner(opt).run();
 
             Assert.fail("Should have failed");
-        } catch (Throwable t) {
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/InheritGroupBenchTearDownTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/InheritGroupBenchTearDownTest.java
@@ -60,7 +60,7 @@ public class InheritGroupBenchTearDownTest extends InheritableGroupTearDownState
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -69,7 +69,7 @@ public class InheritGroupBenchTearDownTest extends InheritableGroupTearDownState
             new Runner(opt).run();
 
             Assert.fail("Should have failed");
-        } catch (Throwable t) {
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/InheritGroupStateSetupTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/InheritGroupStateSetupTest.java
@@ -62,7 +62,7 @@ public class InheritGroupStateSetupTest {
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -71,7 +71,7 @@ public class InheritGroupStateSetupTest {
             new Runner(opt).run();
 
             Assert.fail("Should have failed");
-        } catch (Throwable t) {
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/InheritGroupStateTearDownTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/InheritGroupStateTearDownTest.java
@@ -62,7 +62,7 @@ public class InheritGroupStateTearDownTest {
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -71,7 +71,7 @@ public class InheritGroupStateTearDownTest {
             new Runner(opt).run();
 
             Assert.fail("Should have failed");
-        } catch (Throwable t) {
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/InheritThreadBenchSetupTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/InheritThreadBenchSetupTest.java
@@ -58,7 +58,7 @@ public class InheritThreadBenchSetupTest extends InheritableThreadSetupState {
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -67,7 +67,7 @@ public class InheritThreadBenchSetupTest extends InheritableThreadSetupState {
             new Runner(opt).run();
 
             Assert.fail("Should have failed");
-        } catch (Throwable t) {
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/InheritThreadBenchTearDownTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/InheritThreadBenchTearDownTest.java
@@ -58,7 +58,7 @@ public class InheritThreadBenchTearDownTest extends InheritableThreadTearDownSta
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -67,7 +67,7 @@ public class InheritThreadBenchTearDownTest extends InheritableThreadTearDownSta
             new Runner(opt).run();
 
             Assert.fail("Should have failed");
-        } catch (Throwable t) {
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/InheritThreadStateSetupTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/InheritThreadStateSetupTest.java
@@ -60,7 +60,7 @@ public class InheritThreadStateSetupTest {
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -69,7 +69,7 @@ public class InheritThreadStateSetupTest {
             new Runner(opt).run();
 
             Assert.fail("Should have failed");
-        } catch (Throwable t) {
+        } catch (RunnerException e) {
             // expected
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/InheritThreadStateTearDownTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/inherit/InheritThreadStateTearDownTest.java
@@ -60,7 +60,7 @@ public class InheritThreadStateTearDownTest {
     }
 
     @Test
-    public void invokeAPI() throws RunnerException {
+    public void invokeAPI() {
         try {
             Options opt = new OptionsBuilder()
                     .include(Fixtures.getTestMask(this.getClass()))
@@ -69,7 +69,7 @@ public class InheritThreadStateTearDownTest {
             new Runner(opt).run();
 
             Assert.fail("Should have failed");
-        } catch (Throwable t) {
+        } catch (RunnerException e) {
             // expected
         }
     }


### PR DESCRIPTION
SonarCloud instance reports a bug in our tests:
 "Don't use fail() inside a try-catch catching an AssertionError."

```
    @Test
    public void invokeAPI() throws RunnerException {
        try {
            ...
            new Runner(opt).run();

            Assert.fail("Should have failed"); // <--- here
        } catch (RunnerException e) {
            // expected
        }
    }
```

Indeed, that does not look correct.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902838](https://bugs.openjdk.java.net/browse/CODETOOLS-7902838): JMH: Don't use fail() inside a try-catch catching an AssertionError


### Download
`$ git fetch https://git.openjdk.java.net/jmh pull/25/head:pull/25`
`$ git checkout pull/25`
