### PR TITLE
CODETOOLS-7902840: JMH: Fix *Statistics iterators to throw NoSuchElementException properly

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/util/ListStatistics.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/util/ListStatistics.java
@@ -30,6 +30,7 @@ import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.NoSuchElementException;
 
 /**
  * Calculate statistics over a list of doubles.
@@ -181,6 +182,9 @@ public class ListStatistics extends AbstractStatistics {
 
         @Override
         public Map.Entry<Double, Long> next() {
+            if (!hasNext()) {
+                throw new NoSuchElementException("No more elements.");
+            }
             return new AbstractMap.SimpleImmutableEntry<>(values[currentIndex++], 1L);
         }
 

--- a/jmh-core/src/main/java/org/openjdk/jmh/util/SingletonStatistics.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/util/SingletonStatistics.java
@@ -27,6 +27,7 @@ package org.openjdk.jmh.util;
 import java.util.AbstractMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.NoSuchElementException;
 
 /**
  * Calculate statistics with just a single value.
@@ -98,6 +99,9 @@ public class SingletonStatistics extends AbstractStatistics {
 
         @Override
         public Map.Entry<Double, Long> next() {
+            if (entryReturned) {
+                throw new NoSuchElementException("No more elements.");
+            }
             entryReturned = true;
             return new AbstractMap.SimpleImmutableEntry<>(value, 1L);
         }

--- a/jmh-core/src/test/java/org/openjdk/jmh/util/TestListStatistics.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/util/TestListStatistics.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 
 import java.util.Iterator;
 import java.util.Map;
+import java.util.NoSuchElementException;
 
 import static org.junit.Assert.assertEquals;
 
@@ -407,7 +408,14 @@ public class TestListStatistics {
             Assert.assertEquals(entry.getKey(), item);
             Assert.assertEquals(entry.getValue().longValue(), 1L);
         }
+
         Assert.assertFalse(listIter.hasNext());
+        try {
+            listIter.next();
+            Assert.fail("Expected NoSuchElementException");
+        } catch (NoSuchElementException e) {
+            // expected
+        }
     }
 
 }

--- a/jmh-core/src/test/java/org/openjdk/jmh/util/TestMultisetStatistics.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/util/TestMultisetStatistics.java
@@ -28,7 +28,9 @@ import junit.framework.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.Iterator;
 import java.util.Map;
+import java.util.NoSuchElementException;
 
 import static org.junit.Assert.assertEquals;
 
@@ -394,7 +396,8 @@ public class TestMultisetStatistics {
     @Test
     public strictfp void testRawDataIterator_no_duplicates() {
         int itemCount = 0;
-        for (Map.Entry<Double, Long> entry : Utils.adaptForLoop(instance.getRawData())) {
+        Iterator<Map.Entry<Double, Long>> it = instance.getRawData();
+        for (Map.Entry<Double, Long> entry : Utils.adaptForLoop(it)) {
             Assert.assertEquals(entry.getValue().longValue(), 1L);
 
             // Check if key (the actual data) is in the VALUES collection,
@@ -413,6 +416,14 @@ public class TestMultisetStatistics {
             itemCount++;
         }
         Assert.assertEquals(itemCount, VALUES.length);
+
+        Assert.assertFalse(it.hasNext());
+        try {
+            it.next();
+            Assert.fail("Expected NoSuchElementException");
+        } catch (NoSuchElementException e) {
+            // expected
+        }
     }
 
     /**
@@ -426,12 +437,21 @@ public class TestMultisetStatistics {
             s.addValue(c * 10, c);
         }
 
+        Iterator<Map.Entry<Double, Long>> it = s.getRawData();
         int itemCount = 0;
-        for (Map.Entry<Double, Long> entry : Utils.adaptForLoop(s.getRawData())) {
+        for (Map.Entry<Double, Long> entry : Utils.adaptForLoop(it)) {
             Assert.assertEquals(entry.getKey(), (double)(entry.getValue() * 10));
             itemCount++;
         }
         Assert.assertEquals(itemCount, 10);
+
+        Assert.assertFalse(it.hasNext());
+        try {
+            it.next();
+            Assert.fail("Expected NoSuchElementException");
+        } catch (NoSuchElementException e) {
+            // expected
+        }
     }
 
 }

--- a/jmh-core/src/test/java/org/openjdk/jmh/util/TestSingletonStatistics.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/util/TestSingletonStatistics.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 
 import java.util.Iterator;
 import java.util.Map;
+import java.util.NoSuchElementException;
 
 import static org.junit.Assert.assertEquals;
 
@@ -258,7 +259,14 @@ public class TestSingletonStatistics {
         Map.Entry<Double, Long> entry = singIter.next();
         Assert.assertEquals(entry.getKey(), VALUE);
         Assert.assertEquals(entry.getValue().longValue(), 1L);
+
         Assert.assertFalse(singIter.hasNext());
+        try {
+            singIter.next();
+            Assert.fail("Expected NoSuchElementException");
+        } catch (NoSuchElementException e) {
+            // expected
+        }
     }
 
 }


### PR DESCRIPTION
SonarCloud instance reports:
 Add a "NoSuchElementException" for iteration beyond the end of the collection.

...in places like:

```
        @Override
        public Map.Entry<Double, Long> next() {
            return new AbstractMap.SimpleImmutableEntry<>(values[currentIndex++], 1L);
        }

        @Override
        public Map.Entry<Double, Long> next() {
            entryReturned = true;
            return new AbstractMap.SimpleImmutableEntry<>(value, 1L);
        }
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902840](https://bugs.openjdk.java.net/browse/CODETOOLS-7902840): JMH: Fix *Statistics iterators to throw NoSuchElementException properly


### Download
`$ git fetch https://git.openjdk.java.net/jmh pull/27/head:pull/27`
`$ git checkout pull/27`
