### PR TITLE
CODETOOLS-7902834: JMHSample_25_API_GA selectToBreed selection bug

### DIFF
--- a/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_25_API_GA.java
+++ b/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_25_API_GA.java
@@ -182,11 +182,15 @@ public class JMHSample_25_API_GA {
 
             double thresh = Math.random() * totalScore;
             for (Chromosome c : list) {
-                if (thresh < 0) return c;
-                thresh =- c.score();
+                if (thresh >= 0) {
+                    thresh -= c.score();
+                } else {
+                    return c;
+                }
             }
 
-            throw new IllegalStateException("Can not choose");
+            // Return the last
+            return list.get(list.size() - 1);
         }
 
         public int size() {


### PR DESCRIPTION
SonarCloud instance reports: 'Was "-=" meant instead?'

```
            double thresh = Math.random() * totalScore;
            for (Chromosome c : list) {
                if (thresh < 0) return c;
                thresh =- c.score(); // <--- here
            }
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902834](https://bugs.openjdk.java.net/browse/CODETOOLS-7902834): JMHSample_25_API_GA selectToBreed selection bug


### Download
`$ git fetch https://git.openjdk.java.net/jmh pull/28/head:pull/28`
`$ git checkout pull/28`
