### PR TITLE
CODETOOLS-7902844: JMH: Clean up jmh.separateClassLoader support

### DIFF
--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/separatecl/SeparateClassLoaderTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/separatecl/SeparateClassLoaderTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jmh.it.separatecl;
+
+import org.junit.Test;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.it.Fixtures;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+public class SeparateClassLoaderTest {
+
+    @Benchmark
+    @BenchmarkMode(Mode.All)
+    @Warmup(iterations = 0)
+    @Measurement(iterations = 1, time = 1, timeUnit = TimeUnit.MILLISECONDS)
+    @Fork(1)
+    public void test() {
+        Fixtures.work();
+    }
+
+    @Test
+    public void invokeAPI() throws RunnerException {
+        Options opts = new OptionsBuilder()
+                .include(Fixtures.getTestMask(this.getClass()))
+                .shouldFailOnError(true)
+                .jvmArgsAppend("-Djmh.separateClassLoader=true")
+                .build();
+        new Runner(opts).run();
+    }
+
+}


### PR DESCRIPTION
SonarCloud instance reports the following trouble in ClassUtils.loadClass: "Use try-with-resources or close this "URLClassLoader" in a "finally" clause."

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902844](https://bugs.openjdk.java.net/browse/CODETOOLS-7902844): JMH: Clean up jmh.separateClassLoader support


### Download
`$ git fetch https://git.openjdk.java.net/jmh pull/30/head:pull/30`
`$ git checkout pull/30`
