### PR TITLE
CODETOOLS-7902853: JMH: Fix lint and deprecation warnings

### DIFF
--- a/jmh-core-ct/src/test/java/org/openjdk/jmh/ct/multsession/MultipleSessionsTest.java
+++ b/jmh-core-ct/src/test/java/org/openjdk/jmh/ct/multsession/MultipleSessionsTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.ct.multsession;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.ct.InMemoryGeneratorDestination;
 import org.openjdk.jmh.generators.core.BenchmarkGenerator;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/asymm/ExactThreadCountTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/asymm/ExactThreadCountTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.asymm;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/asymm/Zero1ThreadCountTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/asymm/Zero1ThreadCountTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.asymm;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/asymm/Zero2ThreadCountTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/asymm/Zero2ThreadCountTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.asymm;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/batchsize/BatchSizeSanityTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/batchsize/BatchSizeSanityTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.batchsize;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.it.Fixtures;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/batchsize/OpsPerInvSanityTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/batchsize/OpsPerInvSanityTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.batchsize;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.it.Fixtures;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/bulkwarmup/NonForkedModesTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/bulkwarmup/NonForkedModesTest.java
@@ -43,7 +43,7 @@ import org.openjdk.jmh.runner.options.WarmupMode;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 @State(Scope.Thread)
 public class NonForkedModesTest {

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/bulkwarmup/WarmupMode0_Test.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/bulkwarmup/WarmupMode0_Test.java
@@ -42,7 +42,7 @@ import org.openjdk.jmh.runner.options.TimeValue;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests if harness honors warmup command line settings like:

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/bulkwarmup/WarmupMode1_Test.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/bulkwarmup/WarmupMode1_Test.java
@@ -42,7 +42,7 @@ import org.openjdk.jmh.runner.options.TimeValue;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests if harness honors warmup command line settings like:

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/bulkwarmup/WarmupMode2_Test.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/bulkwarmup/WarmupMode2_Test.java
@@ -42,7 +42,7 @@ import org.openjdk.jmh.runner.options.TimeValue;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests if harness honors warmup command line settings like:

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/bulkwarmup/WarmupMode3_Test.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/bulkwarmup/WarmupMode3_Test.java
@@ -42,7 +42,7 @@ import org.openjdk.jmh.runner.options.TimeValue;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests if harness honors warmup command line settings like:

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/bulkwarmup/WarmupMode4_Test.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/bulkwarmup/WarmupMode4_Test.java
@@ -42,7 +42,7 @@ import org.openjdk.jmh.runner.options.TimeValue;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests if harness honors warmup command line settings like:

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/bulkwarmup/WarmupMode5_Test.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/bulkwarmup/WarmupMode5_Test.java
@@ -43,7 +43,7 @@ import org.openjdk.jmh.runner.options.WarmupMode;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests if harness honors warmup command line settings like:

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/bulkwarmup/WarmupMode6_Test.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/bulkwarmup/WarmupMode6_Test.java
@@ -43,7 +43,7 @@ import org.openjdk.jmh.runner.options.WarmupMode;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests if harness honors warmup command line settings like:

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/control/ControlStartStopTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/control/ControlStartStopTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.control;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Control;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/dagorder/BenchmarkIterationDagOrderTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/dagorder/BenchmarkIterationDagOrderTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.dagorder;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/dagorder/BenchmarkTrialDagOrderTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/dagorder/BenchmarkTrialDagOrderTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.dagorder;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/dagorder/MixedBGTIterationDagOrderTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/dagorder/MixedBGTIterationDagOrderTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.dagorder;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.it.Fixtures;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/dagorder/MixedBGTTrialDagOrderTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/dagorder/MixedBGTTrialDagOrderTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.dagorder;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.it.Fixtures;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/dagorder/MixedBTGIterationDagOrderTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/dagorder/MixedBTGIterationDagOrderTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.dagorder;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.it.Fixtures;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/dagorder/MixedBTGTrialDagOrderTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/dagorder/MixedBTGTrialDagOrderTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.dagorder;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.it.Fixtures;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/dagorder/MixedGBTIterationDagOrderTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/dagorder/MixedGBTIterationDagOrderTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.dagorder;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.it.Fixtures;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/dagorder/MixedGBTTrialDagOrderTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/dagorder/MixedGBTTrialDagOrderTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.dagorder;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.it.Fixtures;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/dagorder/MixedGTBIterationDagOrderTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/dagorder/MixedGTBIterationDagOrderTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.dagorder;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.it.Fixtures;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/dagorder/MixedGTBTrialDagOrderTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/dagorder/MixedGTBTrialDagOrderTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.dagorder;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.it.Fixtures;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/dagorder/MixedTBGIterationDagOrderTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/dagorder/MixedTBGIterationDagOrderTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.dagorder;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.it.Fixtures;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/dagorder/MixedTBGTrialDagOrderTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/dagorder/MixedTBGTrialDagOrderTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.dagorder;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.it.Fixtures;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/dagorder/MixedTGBIterationDagOrderTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/dagorder/MixedTGBIterationDagOrderTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.dagorder;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.it.Fixtures;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/dagorder/MixedTGBTrialDagOrderTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/dagorder/MixedTGBTrialDagOrderTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.dagorder;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.it.Fixtures;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/dagorder/ThreadIterationDagOrderTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/dagorder/ThreadIterationDagOrderTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.dagorder;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/dagorder/ThreadTrialDagOrderTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/dagorder/ThreadTrialDagOrderTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.dagorder;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/errors/EmbeddedErrorsTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/errors/EmbeddedErrorsTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.errors;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Measurement;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/errors/EmbeddedThrowExceptionTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/errors/EmbeddedThrowExceptionTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.errors;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Measurement;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/errors/EmbeddedThrowRuntimeExceptionTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/errors/EmbeddedThrowRuntimeExceptionTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.errors;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Measurement;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/errors/ForkedErrorsTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/errors/ForkedErrorsTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.errors;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Measurement;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/errors/ForkedExit0Test.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/errors/ForkedExit0Test.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.errors;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Measurement;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/errors/ForkedExit1Test.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/errors/ForkedExit1Test.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.errors;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Measurement;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/errors/ForkedExit42Test.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/errors/ForkedExit42Test.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.errors;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Measurement;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/errors/ForkedHalt1Test.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/errors/ForkedHalt1Test.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.errors;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Measurement;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/errors/ForkedHalt42Test.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/errors/ForkedHalt42Test.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.errors;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Measurement;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/errors/ForkedStuckShutdownHookTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/errors/ForkedStuckShutdownHookTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.errors;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.it.Fixtures;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/errors/ForkedStuckThreadTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/errors/ForkedStuckThreadTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.errors;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.it.Fixtures;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/errors/ForkedThrowExceptionTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/errors/ForkedThrowExceptionTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.errors;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Measurement;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/errors/ForkedThrowRuntimeExceptionTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/errors/ForkedThrowRuntimeExceptionTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.errors;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Measurement;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingBenchmarkBenchTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingBenchmarkBenchTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.fails;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingForkedBenchStackProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingForkedBenchStackProfilerTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.fails;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingForkedBenchTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingForkedBenchTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.fails;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingGroupBenchTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingGroupBenchTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.fails;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingThreadBenchTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/fails/FailingThreadBenchTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.fails;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/interorder/BenchmarkBenchOrderTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/interorder/BenchmarkBenchOrderTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.interorder;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/interorder/BenchmarkStateOrderTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/interorder/BenchmarkStateOrderTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.interorder;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/interorder/GroupBenchOrderTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/interorder/GroupBenchOrderTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.interorder;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/interorder/GroupStateOrderTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/interorder/GroupStateOrderTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.interorder;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/interorder/ThreadBenchOrderTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/interorder/ThreadBenchOrderTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.interorder;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/interorder/ThreadStateOrderTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/interorder/ThreadStateOrderTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.interorder;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/params/CollidingParamsTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/params/CollidingParamsTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.params;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Param;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/params/EmptyLeadingStringParamTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/params/EmptyLeadingStringParamTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.params;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.it.Fixtures;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/params/EmptyMiddleStringParamTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/params/EmptyMiddleStringParamTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.params;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.it.Fixtures;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/params/EmptyTrailingStringParamTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/params/EmptyTrailingStringParamTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.params;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.it.Fixtures;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/params/EnumBenchParamImplicitSequenceTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/params/EnumBenchParamImplicitSequenceTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.params;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Fork;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/params/EnumParamSequenceTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/params/EnumParamSequenceTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.params;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Fork;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/params/EnumParamToStringOverridingTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/params/EnumParamToStringOverridingTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.params;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Fork;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/params/EnumStateParamImplicitSequenceTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/params/EnumStateParamImplicitSequenceTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.params;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Fork;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/params/EscapedParamsTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/params/EscapedParamsTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.params;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.it.Fixtures;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/params/IsolatedParamSequenceTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/params/IsolatedParamSequenceTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.params;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Fork;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/params/OverridingParamsTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/params/OverridingParamsTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.params;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Param;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/params/QuotedParamsTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/params/QuotedParamsTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.params;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.it.Fixtures;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/params/Shared.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/params/Shared.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.params;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.openjdk.jmh.infra.BenchmarkParams;
 import org.openjdk.jmh.results.RunResult;
 

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/params/UTF8ParamsTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/params/UTF8ParamsTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.params;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.it.Fixtures;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/ChangeJVMOptsTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/ChangeJVMOptsTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.profilers;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.it.Fixtures;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/CountingExternalProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/CountingExternalProfilerTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.profilers;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Fork;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/DuplicateProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/DuplicateProfilerTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.profilers;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Fork;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/ItExternalProfiler.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/ItExternalProfiler.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.profilers;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.openjdk.jmh.infra.BenchmarkParams;
 import org.openjdk.jmh.profile.ExternalProfiler;
 import org.openjdk.jmh.results.BenchmarkResult;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/order/ProfilerOrderTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/order/ProfilerOrderTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.profilers.order;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Fork;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/MaxThreadCountTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/MaxThreadCountTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.threads;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/OneThreadCountTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/OneThreadCountTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.threads;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/TwoThreadCountTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/TwoThreadCountTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.threads;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/times/GroupThreadStateHelperTimesTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/times/GroupThreadStateHelperTimesTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.times;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.it.Fixtures;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/times/fail/BenchmarkInvocationFailureTimesTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/times/fail/BenchmarkInvocationFailureTimesTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.times.fail;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.it.Fixtures;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/times/fail/BenchmarkIterationFailureTimesTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/times/fail/BenchmarkIterationFailureTimesTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.times.fail;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.it.Fixtures;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/times/fail/BenchmarkTrialFailureTimesTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/times/fail/BenchmarkTrialFailureTimesTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.times.fail;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.it.Fixtures;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/times/fail/GroupInvocationFailureTimesTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/times/fail/GroupInvocationFailureTimesTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.times.fail;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.it.Fixtures;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/times/fail/GroupIterationFailureTimesTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/times/fail/GroupIterationFailureTimesTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.times.fail;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.it.Fixtures;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/times/fail/GroupTrialFailureTimesTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/times/fail/GroupTrialFailureTimesTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.times.fail;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.it.Fixtures;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/times/fail/ThreadInvocationFailureTimesTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/times/fail/ThreadInvocationFailureTimesTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.times.fail;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.it.Fixtures;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/times/fail/ThreadIterationFailureTimesTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/times/fail/ThreadIterationFailureTimesTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.times.fail;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.it.Fixtures;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/times/fail/ThreadTrialFailureTimesTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/times/fail/ThreadTrialFailureTimesTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.it.times.fail;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.it.Fixtures;

--- a/jmh-core/src/main/java/org/openjdk/jmh/generators/core/BenchmarkGenerator.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/generators/core/BenchmarkGenerator.java
@@ -1022,7 +1022,7 @@ public class BenchmarkGenerator {
             writer.println(ident(3) + "int opsPerInv = control.benchmarkParams.getOpsPerInvocation();");
             writer.println(ident(3) + "long totalOps = opsPerInv;");
 
-            writer.println(ident(3) + "BenchmarkTaskResult results = new BenchmarkTaskResult((long)totalOps, (long)totalOps);");
+            writer.println(ident(3) + "BenchmarkTaskResult results = new BenchmarkTaskResult(totalOps, totalOps);");
             if (isSingleMethod) {
                 writer.println(ident(3) + "results.add(new SingleShotResult(ResultRole.PRIMARY, \"" + method.getName() + "\", res.getTime(), benchmarkParams.getTimeUnit()));");
             } else {

--- a/jmh-core/src/test/java/org/openjdk/jmh/BlackholeTest.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/BlackholeTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.infra.Blackhole;
 

--- a/jmh-core/src/test/java/org/openjdk/jmh/profile/PerfParseTest.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/profile/PerfParseTest.java
@@ -24,13 +24,15 @@
  */
 package org.openjdk.jmh.profile;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class PerfParseTest {
+
+    private static final double ASSERT_ACCURACY = 0.0000001;
 
     @Test
     public void parsePerf_4_4() {
@@ -41,7 +43,7 @@ public class PerfParseTest {
 
         for (String line : lines) {
             LinuxPerfAsmProfiler.PerfLine perfLine = LinuxPerfAsmProfiler.parsePerfLine(line);
-            Assert.assertEquals(328650.667569D, perfLine.time());
+            Assert.assertEquals(328650.667569D, perfLine.time(), ASSERT_ACCURACY);
             Assert.assertEquals("instructions", perfLine.eventName());
             Assert.assertEquals(0x7f82b6a8beb4L, perfLine.addr());
             Assert.assertEquals("ConstantPoolCache::allocate", perfLine.symbol());
@@ -57,7 +59,7 @@ public class PerfParseTest {
 
         for (String line : lines) {
             LinuxPerfAsmProfiler.PerfLine perfLine = LinuxPerfAsmProfiler.parsePerfLine(line);
-            Assert.assertEquals(328650.667569D, perfLine.time());
+            Assert.assertEquals(328650.667569D, perfLine.time(), ASSERT_ACCURACY);
             Assert.assertEquals("instructions", perfLine.eventName());
             Assert.assertEquals(0x7f82b6a8beb4L, perfLine.addr());
             Assert.assertEquals("ConstantPoolCache::allocate(Thread* thr)", perfLine.symbol());
@@ -78,7 +80,7 @@ public class PerfParseTest {
         for (String line : lines) {
             LinuxPerfAsmProfiler.PerfLine perfLine = LinuxPerfAsmProfiler.parsePerfLine(line);
 
-            Assert.assertEquals(328650.667569D, perfLine.time());
+            Assert.assertEquals(328650.667569D, perfLine.time(), ASSERT_ACCURACY);
             Assert.assertEquals("instructions", perfLine.eventName());
             Assert.assertEquals(0x7f82b6a8beb4L, perfLine.addr());
             Assert.assertEquals("ConstantPoolCache::allocate", perfLine.symbol());

--- a/jmh-core/src/test/java/org/openjdk/jmh/profile/SafepointsProfilerTest.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/profile/SafepointsProfilerTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.profile;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class SafepointsProfilerTest {

--- a/jmh-core/src/test/java/org/openjdk/jmh/results/ResultAggregationTest.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/results/ResultAggregationTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.results;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.util.SampleBuffer;
 
@@ -33,6 +33,8 @@ import java.util.concurrent.TimeUnit;
 
 public class ResultAggregationTest {
 
+    private static final double ASSERT_ACCURACY = 0.0000001;
+
     @Test
     public void testThroughput() {
         IterationResult ir = new IterationResult(null, null, null);
@@ -40,8 +42,8 @@ public class ResultAggregationTest {
         ir.addResult(new ThroughputResult(ResultRole.PRIMARY, "", 10_000, 1, TimeUnit.NANOSECONDS));
         ir.addResult(new ThroughputResult(ResultRole.SECONDARY, "sec", 5_000, 1, TimeUnit.NANOSECONDS));
         ir.addResult(new ThroughputResult(ResultRole.SECONDARY, "sec", 5_000, 1, TimeUnit.NANOSECONDS));
-        Assert.assertEquals(20_000.0, ir.getPrimaryResult().getScore());
-        Assert.assertEquals(10_000.0, ir.getSecondaryResults().get("sec").getScore());
+        Assert.assertEquals(20_000.0, ir.getPrimaryResult().getScore(), ASSERT_ACCURACY);
+        Assert.assertEquals(10_000.0, ir.getSecondaryResults().get("sec").getScore(), ASSERT_ACCURACY);
         Assert.assertEquals(2, ir.getPrimaryResult().getSampleCount());
         Assert.assertEquals(2, ir.getSecondaryResults().get("sec").getSampleCount());
         Assert.assertEquals(2, ir.getRawPrimaryResults().size());
@@ -49,18 +51,18 @@ public class ResultAggregationTest {
 
         BenchmarkResult br = new BenchmarkResult(null, Arrays.asList(ir, ir));
         br.addBenchmarkResult(new ThroughputResult(ResultRole.SECONDARY, "bench", 3_000, 1, TimeUnit.NANOSECONDS));
-        Assert.assertEquals(20_000.0, br.getPrimaryResult().getScore());
-        Assert.assertEquals(10_000.0, br.getSecondaryResults().get("sec").getScore());
-        Assert.assertEquals(3_000.0, br.getSecondaryResults().get("bench").getScore());
+        Assert.assertEquals(20_000.0, br.getPrimaryResult().getScore(), ASSERT_ACCURACY);
+        Assert.assertEquals(10_000.0, br.getSecondaryResults().get("sec").getScore(), ASSERT_ACCURACY);
+        Assert.assertEquals(3_000.0, br.getSecondaryResults().get("bench").getScore(), ASSERT_ACCURACY);
         Assert.assertEquals(2, br.getPrimaryResult().getSampleCount());
         Assert.assertEquals(2, br.getSecondaryResults().get("sec").getSampleCount());
         Assert.assertEquals(1, br.getSecondaryResults().get("bench").getSampleCount());
         Assert.assertEquals(2, br.getIterationResults().size());
 
         RunResult rr = new RunResult(null, Arrays.asList(br, br));
-        Assert.assertEquals(20_000.0, rr.getPrimaryResult().getScore());
-        Assert.assertEquals(10_000.0, rr.getSecondaryResults().get("sec").getScore());
-        Assert.assertEquals(3_000.0, rr.getSecondaryResults().get("bench").getScore());
+        Assert.assertEquals(20_000.0, rr.getPrimaryResult().getScore(), ASSERT_ACCURACY);
+        Assert.assertEquals(10_000.0, rr.getSecondaryResults().get("sec").getScore(), ASSERT_ACCURACY);
+        Assert.assertEquals(3_000.0, rr.getSecondaryResults().get("bench").getScore(), ASSERT_ACCURACY);
         Assert.assertEquals(4, rr.getPrimaryResult().getSampleCount());
         Assert.assertEquals(4, rr.getSecondaryResults().get("sec").getSampleCount());
         Assert.assertEquals(2, rr.getSecondaryResults().get("bench").getSampleCount());
@@ -74,8 +76,8 @@ public class ResultAggregationTest {
         ir.addResult(new AverageTimeResult(ResultRole.PRIMARY, "", 1, 10_000, TimeUnit.NANOSECONDS));
         ir.addResult(new AverageTimeResult(ResultRole.SECONDARY, "sec", 1, 5_000, TimeUnit.NANOSECONDS));
         ir.addResult(new AverageTimeResult(ResultRole.SECONDARY, "sec", 1, 5_000, TimeUnit.NANOSECONDS));
-        Assert.assertEquals(10_000.0, ir.getPrimaryResult().getScore());
-        Assert.assertEquals(5_000.0, ir.getSecondaryResults().get("sec").getScore());
+        Assert.assertEquals(10_000.0, ir.getPrimaryResult().getScore(), ASSERT_ACCURACY);
+        Assert.assertEquals(5_000.0, ir.getSecondaryResults().get("sec").getScore(), ASSERT_ACCURACY);
         Assert.assertEquals(2, ir.getPrimaryResult().getSampleCount());
         Assert.assertEquals(2, ir.getSecondaryResults().get("sec").getSampleCount());
         Assert.assertEquals(2, ir.getRawPrimaryResults().size());
@@ -83,18 +85,18 @@ public class ResultAggregationTest {
 
         BenchmarkResult br = new BenchmarkResult(null, Arrays.asList(ir, ir));
         br.addBenchmarkResult(new AverageTimeResult(ResultRole.SECONDARY, "bench", 1, 3_000, TimeUnit.NANOSECONDS));
-        Assert.assertEquals(10_000.0, br.getPrimaryResult().getScore());
-        Assert.assertEquals(5_000.0, br.getSecondaryResults().get("sec").getScore());
-        Assert.assertEquals(3_000.0, br.getSecondaryResults().get("bench").getScore());
+        Assert.assertEquals(10_000.0, br.getPrimaryResult().getScore(), ASSERT_ACCURACY);
+        Assert.assertEquals(5_000.0, br.getSecondaryResults().get("sec").getScore(), ASSERT_ACCURACY);
+        Assert.assertEquals(3_000.0, br.getSecondaryResults().get("bench").getScore(), ASSERT_ACCURACY);
         Assert.assertEquals(2, br.getPrimaryResult().getSampleCount());
         Assert.assertEquals(2, br.getSecondaryResults().get("sec").getSampleCount());
         Assert.assertEquals(1, br.getSecondaryResults().get("bench").getSampleCount());
         Assert.assertEquals(2, br.getIterationResults().size());
 
         RunResult rr = new RunResult(null, Arrays.asList(br, br));
-        Assert.assertEquals(10_000.0, rr.getPrimaryResult().getScore());
-        Assert.assertEquals(5_000.0, rr.getSecondaryResults().get("sec").getScore());
-        Assert.assertEquals(3_000.0, rr.getSecondaryResults().get("bench").getScore());
+        Assert.assertEquals(10_000.0, rr.getPrimaryResult().getScore(), ASSERT_ACCURACY);
+        Assert.assertEquals(5_000.0, rr.getSecondaryResults().get("sec").getScore(), ASSERT_ACCURACY);
+        Assert.assertEquals(3_000.0, rr.getSecondaryResults().get("bench").getScore(), ASSERT_ACCURACY);
         Assert.assertEquals(4, rr.getPrimaryResult().getSampleCount());
         Assert.assertEquals(4, rr.getSecondaryResults().get("sec").getSampleCount());
         Assert.assertEquals(2, rr.getSecondaryResults().get("bench").getSampleCount());
@@ -117,8 +119,8 @@ public class ResultAggregationTest {
         ir.addResult(new SampleTimeResult(ResultRole.PRIMARY, "", sb10000, TimeUnit.NANOSECONDS));
         ir.addResult(new SampleTimeResult(ResultRole.SECONDARY, "sec", sb5000, TimeUnit.NANOSECONDS));
         ir.addResult(new SampleTimeResult(ResultRole.SECONDARY, "sec", sb5000, TimeUnit.NANOSECONDS));
-        Assert.assertEquals(10_000.0, ir.getPrimaryResult().getScore());
-        Assert.assertEquals(5_000.0, ir.getSecondaryResults().get("sec").getScore());
+        Assert.assertEquals(10_000.0, ir.getPrimaryResult().getScore(), ASSERT_ACCURACY);
+        Assert.assertEquals(5_000.0, ir.getSecondaryResults().get("sec").getScore(), ASSERT_ACCURACY);
         Assert.assertEquals(2, ir.getRawPrimaryResults().size());
         Assert.assertEquals(2, ir.getRawSecondaryResults().get("sec").size());
         Assert.assertEquals(2, ir.getPrimaryResult().getSampleCount());
@@ -126,18 +128,18 @@ public class ResultAggregationTest {
 
         BenchmarkResult br = new BenchmarkResult(null, Arrays.asList(ir, ir));
         br.addBenchmarkResult(new SampleTimeResult(ResultRole.SECONDARY, "bench", sb3000, TimeUnit.NANOSECONDS));
-        Assert.assertEquals(10_000.0, br.getPrimaryResult().getScore());
-        Assert.assertEquals(5_000.0, br.getSecondaryResults().get("sec").getScore());
-        Assert.assertEquals(3_000.0, br.getSecondaryResults().get("bench").getScore());
+        Assert.assertEquals(10_000.0, br.getPrimaryResult().getScore(), ASSERT_ACCURACY);
+        Assert.assertEquals(5_000.0, br.getSecondaryResults().get("sec").getScore(), ASSERT_ACCURACY);
+        Assert.assertEquals(3_000.0, br.getSecondaryResults().get("bench").getScore(), ASSERT_ACCURACY);
         Assert.assertEquals(4, br.getPrimaryResult().getSampleCount());
         Assert.assertEquals(4, br.getSecondaryResults().get("sec").getSampleCount());
         Assert.assertEquals(1, br.getSecondaryResults().get("bench").getSampleCount());
         Assert.assertEquals(2, br.getIterationResults().size());
 
         RunResult rr = new RunResult(null, Arrays.asList(br, br));
-        Assert.assertEquals(10_000.0, rr.getPrimaryResult().getScore());
-        Assert.assertEquals(5_000.0, rr.getSecondaryResults().get("sec").getScore());
-        Assert.assertEquals(3_000.0, rr.getSecondaryResults().get("bench").getScore());
+        Assert.assertEquals(10_000.0, rr.getPrimaryResult().getScore(), ASSERT_ACCURACY);
+        Assert.assertEquals(5_000.0, rr.getSecondaryResults().get("sec").getScore(), ASSERT_ACCURACY);
+        Assert.assertEquals(3_000.0, rr.getSecondaryResults().get("bench").getScore(), ASSERT_ACCURACY);
         Assert.assertEquals(8, rr.getPrimaryResult().getSampleCount());
         Assert.assertEquals(8, rr.getSecondaryResults().get("sec").getSampleCount());
         Assert.assertEquals(2, rr.getSecondaryResults().get("bench").getSampleCount());
@@ -151,8 +153,8 @@ public class ResultAggregationTest {
         ir.addResult(new SingleShotResult(ResultRole.PRIMARY, "", 10_000, TimeUnit.NANOSECONDS));
         ir.addResult(new SingleShotResult(ResultRole.SECONDARY, "sec", 5_000, TimeUnit.NANOSECONDS));
         ir.addResult(new SingleShotResult(ResultRole.SECONDARY, "sec", 5_000, TimeUnit.NANOSECONDS));
-        Assert.assertEquals(10_000.0, ir.getPrimaryResult().getScore());
-        Assert.assertEquals(5_000.0, ir.getSecondaryResults().get("sec").getScore());
+        Assert.assertEquals(10_000.0, ir.getPrimaryResult().getScore(), ASSERT_ACCURACY);
+        Assert.assertEquals(5_000.0, ir.getSecondaryResults().get("sec").getScore(), ASSERT_ACCURACY);
         Assert.assertEquals(2, ir.getPrimaryResult().getSampleCount());
         Assert.assertEquals(2, ir.getSecondaryResults().get("sec").getSampleCount());
         Assert.assertEquals(2, ir.getRawPrimaryResults().size());
@@ -160,18 +162,18 @@ public class ResultAggregationTest {
 
         BenchmarkResult br = new BenchmarkResult(null, Arrays.asList(ir, ir));
         br.addBenchmarkResult(new SingleShotResult(ResultRole.SECONDARY, "bench", 3_000, TimeUnit.NANOSECONDS));
-        Assert.assertEquals(10_000.0, br.getPrimaryResult().getScore());
-        Assert.assertEquals(5_000.0, br.getSecondaryResults().get("sec").getScore());
-        Assert.assertEquals(3_000.0, br.getSecondaryResults().get("bench").getScore());
+        Assert.assertEquals(10_000.0, br.getPrimaryResult().getScore(), ASSERT_ACCURACY);
+        Assert.assertEquals(5_000.0, br.getSecondaryResults().get("sec").getScore(), ASSERT_ACCURACY);
+        Assert.assertEquals(3_000.0, br.getSecondaryResults().get("bench").getScore(), ASSERT_ACCURACY);
         Assert.assertEquals(2, br.getPrimaryResult().getSampleCount());
         Assert.assertEquals(2, br.getSecondaryResults().get("sec").getSampleCount());
         Assert.assertEquals(1, br.getSecondaryResults().get("bench").getSampleCount());
         Assert.assertEquals(2, br.getIterationResults().size());
 
         RunResult rr = new RunResult(null, Arrays.asList(br, br));
-        Assert.assertEquals(10_000.0, rr.getPrimaryResult().getScore());
-        Assert.assertEquals(5_000.0, rr.getSecondaryResults().get("sec").getScore());
-        Assert.assertEquals(3_000.0, rr.getSecondaryResults().get("bench").getScore());
+        Assert.assertEquals(10_000.0, rr.getPrimaryResult().getScore(), ASSERT_ACCURACY);
+        Assert.assertEquals(5_000.0, rr.getSecondaryResults().get("sec").getScore(), ASSERT_ACCURACY);
+        Assert.assertEquals(3_000.0, rr.getSecondaryResults().get("bench").getScore(), ASSERT_ACCURACY);
         Assert.assertEquals(4, rr.getPrimaryResult().getSampleCount());
         Assert.assertEquals(4, rr.getSecondaryResults().get("sec").getSampleCount());
         Assert.assertEquals(2, rr.getSecondaryResults().get("bench").getSampleCount());

--- a/jmh-core/src/test/java/org/openjdk/jmh/results/TestAverageTimeResult.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/results/TestAverageTimeResult.java
@@ -29,9 +29,11 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 public class TestAverageTimeResult {
+
+    private static final double ASSERT_ACCURACY = 0.0000001;
 
     @Test
     public void testIterationAggregator1() {
@@ -39,7 +41,7 @@ public class TestAverageTimeResult {
         AverageTimeResult r2 = new AverageTimeResult(ResultRole.PRIMARY, "test1", 1_000L, 2_000_000L, TimeUnit.MICROSECONDS);
         Result result = r1.getIterationAggregator().aggregate(Arrays.asList(r1, r2));
 
-        assertEquals(1.5, result.getScore());
+        assertEquals(1.5, result.getScore(), ASSERT_ACCURACY);
         assertEquals("us/op", result.getScoreUnit());
     }
 
@@ -49,7 +51,7 @@ public class TestAverageTimeResult {
         AverageTimeResult r2 = new AverageTimeResult(ResultRole.PRIMARY, "test1", 1_000L, 1_000_000L, TimeUnit.MICROSECONDS);
         Result result = r1.getIterationAggregator().aggregate(Arrays.asList(r1, r2));
 
-        assertEquals(1.0, result.getScore());
+        assertEquals(1.0, result.getScore(), ASSERT_ACCURACY);
         assertEquals("us/op", result.getScoreUnit());
     }
 
@@ -59,7 +61,7 @@ public class TestAverageTimeResult {
         AverageTimeResult r2 = new AverageTimeResult(ResultRole.PRIMARY, "test1", 1_000L, 1_000_000L, TimeUnit.MICROSECONDS);
         Result result = r1.getThreadAggregator().aggregate(Arrays.asList(r1, r2));
 
-        assertEquals(1.0, result.getScore());
+        assertEquals(1.0, result.getScore(), ASSERT_ACCURACY);
         assertEquals("us/op", result.getScoreUnit());
     }
 
@@ -69,7 +71,7 @@ public class TestAverageTimeResult {
         AverageTimeResult r2 = new AverageTimeResult(ResultRole.PRIMARY, "test1", 1_000L, 2_000_000L, TimeUnit.MICROSECONDS);
         Result result = r1.getThreadAggregator().aggregate(Arrays.asList(r1, r2));
 
-        assertEquals(1.5, result.getScore());
+        assertEquals(1.5, result.getScore(), ASSERT_ACCURACY);
         assertEquals("us/op", result.getScoreUnit());
     }
 }

--- a/jmh-core/src/test/java/org/openjdk/jmh/results/TestSampleTimeResult.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/results/TestSampleTimeResult.java
@@ -30,9 +30,11 @@ import org.openjdk.jmh.util.SampleBuffer;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 public class TestSampleTimeResult {
+
+    private static final double ASSERT_ACCURACY = 0.0000001;
 
     @Test
     public void testIterationAggregator1() {
@@ -48,7 +50,7 @@ public class TestSampleTimeResult {
         SampleTimeResult r2 = new SampleTimeResult(ResultRole.PRIMARY, "Test1", b2, TimeUnit.MICROSECONDS);
         Result result = r1.getIterationAggregator().aggregate(Arrays.asList(r1, r2));
 
-        assertEquals(2.5, result.getScore());
+        assertEquals(2.5, result.getScore(), ASSERT_ACCURACY);
         assertEquals("us/op", result.getScoreUnit());
     }
 
@@ -66,7 +68,7 @@ public class TestSampleTimeResult {
         SampleTimeResult r2 = new SampleTimeResult(ResultRole.PRIMARY, "Test1", b2, TimeUnit.MICROSECONDS);
         Result result = r1.getThreadAggregator().aggregate(Arrays.asList(r1, r2));
 
-        assertEquals(2.5, result.getScore());
+        assertEquals(2.5, result.getScore(), ASSERT_ACCURACY);
         assertEquals("us/op", result.getScoreUnit());
     }
 

--- a/jmh-core/src/test/java/org/openjdk/jmh/results/TestSingleShotResult.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/results/TestSingleShotResult.java
@@ -29,9 +29,11 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 public class TestSingleShotResult {
+
+    private static final double ASSERT_ACCURACY = 0.0000001;
 
     @Test
     public void testIterationAggregator1() {
@@ -39,7 +41,7 @@ public class TestSingleShotResult {
         SingleShotResult r2 = new SingleShotResult(ResultRole.PRIMARY, "Test1", 2000L, TimeUnit.MICROSECONDS);
         Result result = r1.getIterationAggregator().aggregate(Arrays.asList(r1, r2));
 
-        assertEquals(1.5, result.getScore());
+        assertEquals(1.5, result.getScore(), ASSERT_ACCURACY);
         assertEquals("us/op", result.getScoreUnit());
     }
 
@@ -49,7 +51,7 @@ public class TestSingleShotResult {
         SingleShotResult r2 = new SingleShotResult(ResultRole.PRIMARY, "Test1", 2000L, TimeUnit.MICROSECONDS);
         Result result = r1.getThreadAggregator().aggregate(Arrays.asList(r1, r2));
 
-        assertEquals(1.5, result.getScore());
+        assertEquals(1.5, result.getScore(), ASSERT_ACCURACY);
         assertEquals("us/op", result.getScoreUnit());
     }
 

--- a/jmh-core/src/test/java/org/openjdk/jmh/results/TestThroughputResult.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/results/TestThroughputResult.java
@@ -29,9 +29,11 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 public class TestThroughputResult {
+
+    private static final double ASSERT_ACCURACY = 0.0000001;
 
     /**
      * Test of getScore method, of class ThroughputResult.
@@ -83,7 +85,7 @@ public class TestThroughputResult {
         ThroughputResult r2 = new ThroughputResult(ResultRole.PRIMARY, "test1", 2_000L, 10_000_000L, TimeUnit.MILLISECONDS);
         Result result = r1.getIterationAggregator().aggregate(Arrays.asList(r1, r2));
 
-        assertEquals(150.0, result.getScore());
+        assertEquals(150.0, result.getScore(), ASSERT_ACCURACY);
         assertEquals("ops/ms", result.getScoreUnit());
     }
 
@@ -93,7 +95,7 @@ public class TestThroughputResult {
         ThroughputResult r2 = new ThroughputResult(ResultRole.PRIMARY, "test1", 2_000L, 20_000_000L, TimeUnit.MILLISECONDS);
         Result result = r1.getIterationAggregator().aggregate(Arrays.asList(r1, r2));
 
-        assertEquals(100.0, result.getScore());
+        assertEquals(100.0, result.getScore(), ASSERT_ACCURACY);
         assertEquals("ops/ms", result.getScoreUnit());
     }
 
@@ -103,7 +105,7 @@ public class TestThroughputResult {
         ThroughputResult r2 = new ThroughputResult(ResultRole.PRIMARY, "test1", 2_000_000_000L, 20_000_000L, TimeUnit.MILLISECONDS);
         Result result = r1.getIterationAggregator().aggregate(Arrays.asList(r1, r2));
 
-        assertEquals(100_000_000.0, result.getScore());
+        assertEquals(100_000_000.0, result.getScore(), ASSERT_ACCURACY);
         assertEquals("ops/ms", result.getScoreUnit());
     }
 
@@ -114,7 +116,7 @@ public class TestThroughputResult {
         Result result = r1.getThreadAggregator().aggregate(Arrays.asList(r1, r2));
 
         assertEquals("ops/ms", result.getScoreUnit());
-        assertEquals(300.0, result.getScore());
+        assertEquals(300.0, result.getScore(), ASSERT_ACCURACY);
     }
 
     @Test
@@ -124,7 +126,7 @@ public class TestThroughputResult {
         Result result = r1.getThreadAggregator().aggregate(Arrays.asList(r1, r2));
 
         assertEquals("ops/ms", result.getScoreUnit());
-        assertEquals(200.0, result.getScore());
+        assertEquals(200.0, result.getScore(), ASSERT_ACCURACY);
     }
 
     @Test  // regression test, check for overflow
@@ -134,6 +136,6 @@ public class TestThroughputResult {
         Result result = r1.getThreadAggregator().aggregate(Arrays.asList(r1, r2));
 
         assertEquals("ops/ms", result.getScoreUnit());
-        assertEquals(200_000_000.0, result.getScore());
+        assertEquals(200_000_000.0, result.getScore(), ASSERT_ACCURACY);
     }
 }

--- a/jmh-core/src/test/java/org/openjdk/jmh/results/format/ResultFormatTest.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/results/format/ResultFormatTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.results.format;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.infra.BenchmarkParams;

--- a/jmh-core/src/test/java/org/openjdk/jmh/runner/DistributeGroupsTest.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/runner/DistributeGroupsTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.runner;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.infra.ThreadParams;
 

--- a/jmh-core/src/test/java/org/openjdk/jmh/runner/parameters/TimeValueTest.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/runner/parameters/TimeValueTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.runner.parameters;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.runner.options.TimeValue;
 

--- a/jmh-core/src/test/java/org/openjdk/jmh/util/BoundedPriorityQueueTest.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/util/BoundedPriorityQueueTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.util;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Collections;

--- a/jmh-core/src/test/java/org/openjdk/jmh/util/MultisetsTest.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/util/MultisetsTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.util;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.List;

--- a/jmh-core/src/test/java/org/openjdk/jmh/util/TestClassUtils.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/util/TestClassUtils.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.util;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;

--- a/jmh-core/src/test/java/org/openjdk/jmh/util/TestListStatistics.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/util/TestListStatistics.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.util;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -46,6 +46,8 @@ public class TestListStatistics {
         15.78967174, 34.43339987, 65.40063304, 69.86288638, 22.55130769,
         36.99130073, 60.17648239, 33.1484382, 56.4605944, 93.67454206
     };
+
+    private static final double ASSERT_ACCURACY = 0.0000000001;
 
     private static final ListStatistics instance = new ListStatistics();
 
@@ -240,17 +242,17 @@ public class TestListStatistics {
         Statistics s = new ListStatistics();
 
         Assert.assertEquals(0, s.getN());
-        Assert.assertEquals(Double.NaN, s.getSum());
-        Assert.assertEquals(Double.NaN, s.getMin());
-        Assert.assertEquals(Double.NaN, s.getMax());
-        Assert.assertEquals(Double.NaN, s.getMean());
-        Assert.assertEquals(Double.NaN, s.getMeanErrorAt(0.5));
-        Assert.assertEquals(Double.NaN, s.getVariance());
-        Assert.assertEquals(Double.NaN, s.getStandardDeviation());
-        Assert.assertEquals(Double.NaN, s.getConfidenceIntervalAt(0.50)[0]);
-        Assert.assertEquals(Double.NaN, s.getConfidenceIntervalAt(0.50)[1]);
-        Assert.assertEquals(Double.NaN, s.getPercentile(0));
-        Assert.assertEquals(Double.NaN, s.getPercentile(100));
+        Assert.assertEquals(Double.NaN, s.getSum(), ASSERT_ACCURACY);
+        Assert.assertEquals(Double.NaN, s.getMin(), ASSERT_ACCURACY);
+        Assert.assertEquals(Double.NaN, s.getMax(), ASSERT_ACCURACY);
+        Assert.assertEquals(Double.NaN, s.getMean(), ASSERT_ACCURACY);
+        Assert.assertEquals(Double.NaN, s.getMeanErrorAt(0.5), ASSERT_ACCURACY);
+        Assert.assertEquals(Double.NaN, s.getVariance(), ASSERT_ACCURACY);
+        Assert.assertEquals(Double.NaN, s.getStandardDeviation(), ASSERT_ACCURACY);
+        Assert.assertEquals(Double.NaN, s.getConfidenceIntervalAt(0.50)[0], ASSERT_ACCURACY);
+        Assert.assertEquals(Double.NaN, s.getConfidenceIntervalAt(0.50)[1], ASSERT_ACCURACY);
+        Assert.assertEquals(Double.NaN, s.getPercentile(0), ASSERT_ACCURACY);
+        Assert.assertEquals(Double.NaN, s.getPercentile(100), ASSERT_ACCURACY);
     }
 
     @Test
@@ -259,17 +261,17 @@ public class TestListStatistics {
         s.addValue(42.0D);
 
         Assert.assertEquals(1, s.getN());
-        Assert.assertEquals(42.0D, s.getSum());
-        Assert.assertEquals(42.0D, s.getMin());
-        Assert.assertEquals(42.0D, s.getMax());
-        Assert.assertEquals(42.0D, s.getMean());
-        Assert.assertEquals(Double.NaN, s.getMeanErrorAt(0.5));
-        Assert.assertEquals(Double.NaN, s.getVariance());
-        Assert.assertEquals(Double.NaN, s.getStandardDeviation());
-        Assert.assertEquals(Double.NaN, s.getConfidenceIntervalAt(0.50)[0]);
-        Assert.assertEquals(Double.NaN, s.getConfidenceIntervalAt(0.50)[1]);
-        Assert.assertEquals(42.0D, s.getPercentile(0));
-        Assert.assertEquals(42.0D, s.getPercentile(100));
+        Assert.assertEquals(42.0D, s.getSum(), ASSERT_ACCURACY);
+        Assert.assertEquals(42.0D, s.getMin(), ASSERT_ACCURACY);
+        Assert.assertEquals(42.0D, s.getMax(), ASSERT_ACCURACY);
+        Assert.assertEquals(42.0D, s.getMean(), ASSERT_ACCURACY);
+        Assert.assertEquals(Double.NaN, s.getMeanErrorAt(0.5), ASSERT_ACCURACY);
+        Assert.assertEquals(Double.NaN, s.getVariance(), ASSERT_ACCURACY);
+        Assert.assertEquals(Double.NaN, s.getStandardDeviation(), ASSERT_ACCURACY);
+        Assert.assertEquals(Double.NaN, s.getConfidenceIntervalAt(0.50)[0], ASSERT_ACCURACY);
+        Assert.assertEquals(Double.NaN, s.getConfidenceIntervalAt(0.50)[1], ASSERT_ACCURACY);
+        Assert.assertEquals(42.0D, s.getPercentile(0), ASSERT_ACCURACY);
+        Assert.assertEquals(42.0D, s.getPercentile(100), ASSERT_ACCURACY);
     }
 
     @Test
@@ -405,8 +407,8 @@ public class TestListStatistics {
         for (double item : VALUES) {
             Assert.assertTrue(listIter.hasNext());
             Map.Entry<Double, Long> entry = listIter.next();
-            Assert.assertEquals(entry.getKey(), item);
-            Assert.assertEquals(entry.getValue().longValue(), 1L);
+            Assert.assertEquals(entry.getKey(), item, ASSERT_ACCURACY);
+            Assert.assertEquals(1L, entry.getValue().longValue());
         }
 
         Assert.assertFalse(listIter.hasNext());

--- a/jmh-core/src/test/java/org/openjdk/jmh/util/TestMultisetStatistics.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/util/TestMultisetStatistics.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.util;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -46,6 +46,8 @@ public class TestMultisetStatistics {
         15.78967174, 34.43339987, 65.40063304, 69.86288638, 22.55130769,
         36.99130073, 60.17648239, 33.1484382, 56.4605944, 93.67454206
     };
+
+    private static final double ASSERT_ACCURACY = 0.000000001;
 
     private static final MultisetStatistics instance = new MultisetStatistics();
 
@@ -234,17 +236,17 @@ public class TestMultisetStatistics {
         Statistics s = new MultisetStatistics();
 
         Assert.assertEquals(0, s.getN());
-        Assert.assertEquals(Double.NaN, s.getSum());
-        Assert.assertEquals(Double.NaN, s.getMin());
-        Assert.assertEquals(Double.NaN, s.getMax());
-        Assert.assertEquals(Double.NaN, s.getMean());
-        Assert.assertEquals(Double.NaN, s.getMeanErrorAt(0.5));
-        Assert.assertEquals(Double.NaN, s.getVariance());
-        Assert.assertEquals(Double.NaN, s.getStandardDeviation());
-        Assert.assertEquals(Double.NaN, s.getConfidenceIntervalAt(0.50)[0]);
-        Assert.assertEquals(Double.NaN, s.getConfidenceIntervalAt(0.50)[1]);
-        Assert.assertEquals(Double.NaN, s.getPercentile(0));
-        Assert.assertEquals(Double.NaN, s.getPercentile(100));
+        Assert.assertEquals(Double.NaN, s.getSum(), ASSERT_ACCURACY);
+        Assert.assertEquals(Double.NaN, s.getMin(), ASSERT_ACCURACY);
+        Assert.assertEquals(Double.NaN, s.getMax(), ASSERT_ACCURACY);
+        Assert.assertEquals(Double.NaN, s.getMean(), ASSERT_ACCURACY);
+        Assert.assertEquals(Double.NaN, s.getMeanErrorAt(0.5), ASSERT_ACCURACY);
+        Assert.assertEquals(Double.NaN, s.getVariance(), ASSERT_ACCURACY);
+        Assert.assertEquals(Double.NaN, s.getStandardDeviation(), ASSERT_ACCURACY);
+        Assert.assertEquals(Double.NaN, s.getConfidenceIntervalAt(0.50)[0], ASSERT_ACCURACY);
+        Assert.assertEquals(Double.NaN, s.getConfidenceIntervalAt(0.50)[1], ASSERT_ACCURACY);
+        Assert.assertEquals(Double.NaN, s.getPercentile(0), ASSERT_ACCURACY);
+        Assert.assertEquals(Double.NaN, s.getPercentile(100), ASSERT_ACCURACY);
     }
 
     @Test
@@ -253,17 +255,17 @@ public class TestMultisetStatistics {
         s.addValue(42.0D, 1);
 
         Assert.assertEquals(1, s.getN());
-        Assert.assertEquals(42.0D, s.getSum());
-        Assert.assertEquals(42.0D, s.getMin());
-        Assert.assertEquals(42.0D, s.getMax());
-        Assert.assertEquals(42.0D, s.getMean());
-        Assert.assertEquals(Double.NaN, s.getMeanErrorAt(0.5));
-        Assert.assertEquals(Double.NaN, s.getVariance());
-        Assert.assertEquals(Double.NaN, s.getStandardDeviation());
-        Assert.assertEquals(Double.NaN, s.getConfidenceIntervalAt(0.50)[0]);
-        Assert.assertEquals(Double.NaN, s.getConfidenceIntervalAt(0.50)[1]);
-        Assert.assertEquals(42.0D, s.getPercentile(0));
-        Assert.assertEquals(42.0D, s.getPercentile(100));
+        Assert.assertEquals(42.0D, s.getSum(), ASSERT_ACCURACY);
+        Assert.assertEquals(42.0D, s.getMin(), ASSERT_ACCURACY);
+        Assert.assertEquals(42.0D, s.getMax(), ASSERT_ACCURACY);
+        Assert.assertEquals(42.0D, s.getMean(), ASSERT_ACCURACY);
+        Assert.assertEquals(Double.NaN, s.getMeanErrorAt(0.5), ASSERT_ACCURACY);
+        Assert.assertEquals(Double.NaN, s.getVariance(), ASSERT_ACCURACY);
+        Assert.assertEquals(Double.NaN, s.getStandardDeviation(), ASSERT_ACCURACY);
+        Assert.assertEquals(Double.NaN, s.getConfidenceIntervalAt(0.50)[0], ASSERT_ACCURACY);
+        Assert.assertEquals(Double.NaN, s.getConfidenceIntervalAt(0.50)[1], ASSERT_ACCURACY);
+        Assert.assertEquals(42.0D, s.getPercentile(0), ASSERT_ACCURACY);
+        Assert.assertEquals(42.0D, s.getPercentile(100), ASSERT_ACCURACY);
     }
 
 
@@ -440,7 +442,7 @@ public class TestMultisetStatistics {
         Iterator<Map.Entry<Double, Long>> it = s.getRawData();
         int itemCount = 0;
         for (Map.Entry<Double, Long> entry : Utils.adaptForLoop(it)) {
-            Assert.assertEquals(entry.getKey(), (double)(entry.getValue() * 10));
+            Assert.assertEquals(entry.getKey(), (double)(entry.getValue() * 10), ASSERT_ACCURACY);
             itemCount++;
         }
         Assert.assertEquals(itemCount, 10);

--- a/jmh-core/src/test/java/org/openjdk/jmh/util/TestSingletonStatistics.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/util/TestSingletonStatistics.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.util;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -40,6 +40,7 @@ import static org.junit.Assert.assertEquals;
 public class TestSingletonStatistics {
 
     private static final double VALUE = 42.73638635;
+    private static final double ASSERT_ACCURACY = 0.000000001;
 
     private static final ListStatistics listStats = new ListStatistics();
     private static final SingletonStatistics singStats = new SingletonStatistics(VALUE);
@@ -146,17 +147,17 @@ public class TestSingletonStatistics {
         SingletonStatistics s = new SingletonStatistics(42.0D);
 
         Assert.assertEquals(1, s.getN());
-        Assert.assertEquals(42.0D, s.getSum());
-        Assert.assertEquals(42.0D, s.getMin());
-        Assert.assertEquals(42.0D, s.getMax());
-        Assert.assertEquals(42.0D, s.getMean());
-        Assert.assertEquals(Double.NaN, s.getMeanErrorAt(0.5));
-        Assert.assertEquals(Double.NaN, s.getVariance());
-        Assert.assertEquals(Double.NaN, s.getStandardDeviation());
-        Assert.assertEquals(Double.NaN, s.getConfidenceIntervalAt(0.50)[0]);
-        Assert.assertEquals(Double.NaN, s.getConfidenceIntervalAt(0.50)[1]);
-        Assert.assertEquals(42.0D, s.getPercentile(0));
-        Assert.assertEquals(42.0D, s.getPercentile(100));
+        Assert.assertEquals(42.0D, s.getSum(), ASSERT_ACCURACY);
+        Assert.assertEquals(42.0D, s.getMin(), ASSERT_ACCURACY);
+        Assert.assertEquals(42.0D, s.getMax(), ASSERT_ACCURACY);
+        Assert.assertEquals(42.0D, s.getMean(), ASSERT_ACCURACY);
+        Assert.assertEquals(Double.NaN, s.getMeanErrorAt(0.5), ASSERT_ACCURACY);
+        Assert.assertEquals(Double.NaN, s.getVariance(), ASSERT_ACCURACY);
+        Assert.assertEquals(Double.NaN, s.getStandardDeviation(), ASSERT_ACCURACY);
+        Assert.assertEquals(Double.NaN, s.getConfidenceIntervalAt(0.50)[0], ASSERT_ACCURACY);
+        Assert.assertEquals(Double.NaN, s.getConfidenceIntervalAt(0.50)[1], ASSERT_ACCURACY);
+        Assert.assertEquals(42.0D, s.getPercentile(0), ASSERT_ACCURACY);
+        Assert.assertEquals(42.0D, s.getPercentile(100), ASSERT_ACCURACY);
     }
 
     @Test
@@ -257,7 +258,7 @@ public class TestSingletonStatistics {
         Iterator<Map.Entry<Double, Long>> singIter = singStats.getRawData();
         Assert.assertTrue(singIter.hasNext());
         Map.Entry<Double, Long> entry = singIter.next();
-        Assert.assertEquals(entry.getKey(), VALUE);
+        Assert.assertEquals(entry.getKey(), VALUE, ASSERT_ACCURACY);
         Assert.assertEquals(entry.getValue().longValue(), 1L);
 
         Assert.assertFalse(singIter.hasNext());

--- a/jmh-core/src/test/java/org/openjdk/jmh/util/TestUtil.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/util/TestUtil.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.util;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;

--- a/jmh-core/src/test/java/org/openjdk/jmh/util/Util.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/util/Util.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.util;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import java.util.Arrays;
 

--- a/jmh-core/src/test/java/org/openjdk/jmh/util/lines/TestLineTest.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/util/lines/TestLineTest.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.util.lines;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.runner.options.TimeValue;
 import org.openjdk.jmh.util.Optional;


### PR DESCRIPTION
In my projects I always use -Werror as the compiler flag as one of the means to get a high standard for code quality.
In this project https://github.com/nielsbasjes/yauaa I have a module that does the benchmarks.
When I update the JMH from 1.26 to 1.28 my build fails with 
```
[WARNING] COMPILATION WARNING : 
[INFO] -------------------------------------------------------------
[WARNING] /home/nbasjes/workspace/Prive/yauaa_/benchmarks/target/generated-sources/annotations/nl/basjes/parse/useragent/benchmarks/jmh_generated/AnalyzerBenchmarks_android6Chrome46_jmhTest.java:[324,67] redundant cast to long
[WARNING] /home/nbasjes/workspace/Prive/yauaa_/benchmarks/target/generated-sources/annotations/nl/basjes/parse/useragent/benchmarks/jmh_generated/AnalyzerBenchmarks_android6Chrome46_jmhTest.java:[324,83] redundant cast to long
[WARNING] /home/nbasjes/workspace/Prive/yauaa_/benchmarks/target/generated-sources/annotations/nl/basjes/parse/useragent/benchmarks/jmh_generated/AnalyzerBenchmarks_androidPhone_jmhTest.java:[324,67] redundant cast to long
[WARNING] /home/nbasjes/workspace/Prive/yauaa_/benchmarks/target/generated-sources/annotations/nl/basjes/parse/useragent/benchmarks/jmh_generated/AnalyzerBenchmarks_androidPhone_jmhTest.java:[324,83] redundant cast to long
```
and at the end it fails
```
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] /home/nbasjes/workspace/Prive/yauaa_/benchmarks/target/generated-sources/annotations/nl/basjes/parse/useragent/benchmarks/jmh_generated/AnalyzerBenchmarks_android6Chrome46_jmhTest.java: warnings found and -Werror specified
[INFO] 1 error
```

Turns out this problem is caused by a change in code generated by JMH.

This pull request fixes this problem.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902853](https://bugs.openjdk.java.net/browse/CODETOOLS-7902853): JMH: Fix lint and deprecation warnings


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - Committer)


### Contributors
 * Aleksey Shipilev `<shade@openjdk.org>`

### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jmh pull/31/head:pull/31`
`$ git checkout pull/31`

To update a local copy of the PR:
`$ git checkout pull/31`
`$ git pull https://git.openjdk.java.net/jmh pull/31/head`
