### PR TITLE
CODETOOLS-7902863: JMH: Cache parsing patterns in profilers

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfProfiler.java
@@ -141,6 +141,8 @@ public class LinuxPerfProfiler implements ExternalProfiler {
         StringWriter sw = new StringWriter();
         PrintWriter pw = new PrintWriter(sw);
 
+        final Pattern hashLinePattern = Pattern.compile("(.*)#(.*)");
+
         try (FileReader fr = new FileReader(stdErr);
              BufferedReader reader = new BufferedReader(fr)) {
 
@@ -157,7 +159,7 @@ public class LinuxPerfProfiler implements ExternalProfiler {
                     printing = true;
                 }
 
-                Matcher m = Pattern.compile("(.*)#(.*)").matcher(line);
+                Matcher m = hashLinePattern.matcher(line);
                 if (m.matches()) {
                     String pair = m.group(1).trim();
                     if (pair.contains(" cycles")) {

--- a/jmh-core/src/main/java/org/openjdk/jmh/util/Utils.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/util/Utils.java
@@ -35,7 +35,6 @@ import java.lang.reflect.Method;
 import java.nio.charset.Charset;
 import java.util.*;
 import java.util.concurrent.*;
-import java.util.regex.Pattern;
 
 public class Utils {
 
@@ -53,17 +52,6 @@ public class Utils {
 
     private Utils() {
 
-    }
-
-    private static final ConcurrentMap<String, Pattern> PATTERNS = new ConcurrentHashMap<>();
-
-    public static Pattern lazyCompile(String pattern) {
-        Pattern patt = PATTERNS.get(pattern);
-        if (patt == null) {
-            patt = Pattern.compile(pattern);
-            PATTERNS.put(pattern, patt);
-        }
-        return patt;
     }
 
     public static <T extends Comparable<T>> T min(Collection<T> ts) {


### PR DESCRIPTION
Currently, perfasm profilers are compiling patterns on every suspect line. This can be better: compiling patterns before entering the hot loops.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902863](https://bugs.openjdk.java.net/browse/CODETOOLS-7902863): JMH: Cache parsing patterns in profilers


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jmh pull/32/head:pull/32`
`$ git checkout pull/32`

To update a local copy of the PR:
`$ git checkout pull/32`
`$ git pull https://git.openjdk.java.net/jmh pull/32/head`
