### PR TITLE
7902902: JMH: non .jar class path file entries treated as directories

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/Runner.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/Runner.java
@@ -885,7 +885,7 @@ public class Runner extends BaseRunner {
 
                     String rel = relPath.toString();
                     sb.append(rel.replace('\\', '/').replace(" ", "%20"));
-                    if (!cp.endsWith(".jar")) {
+                    if (Files.isDirectory(cpPath)) {
                         sb.append('/');
                     }
                     sb.append(" ");


### PR DESCRIPTION
Signed-off-by: Patrick Reinhart <patrick@reini.net>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902902](https://bugs.openjdk.java.net/browse/CODETOOLS-7902902): JMH: non .jar class path file entries treated as directories


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmh pull/33/head:pull/33` \
`$ git checkout pull/33`

Update a local copy of the PR: \
`$ git checkout pull/33` \
`$ git pull https://git.openjdk.java.net/jmh pull/33/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 33`

View PR using the GUI difftool: \
`$ git pr show -t 33`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmh/pull/33.diff">https://git.openjdk.java.net/jmh/pull/33.diff</a>

</details>
