### PR TITLE
CODETOOLS-7902926: JMH: More reliable Console charset probing

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/util/Utils.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/util/Utils.java
@@ -241,35 +241,37 @@ public class Utils {
         // Since JDK 17, there is Console.charset(), which we can use reflectively.
 
         // Try 1. Try to poke the System.console().
-        try {
-            Console console = System.console();
-            if (console != null) {
-                {
-                    Method m = Console.class.getDeclaredMethod("charset");
-                    Object res = m.invoke(console);
-                    if (res instanceof Charset) {
-                        return (Charset) res;
-                    }
+        Console console = System.console();
+        if (console != null) {
+            try {
+                Method m = Console.class.getDeclaredMethod("charset");
+                Object res = m.invoke(console);
+                if (res instanceof Charset) {
+                    return (Charset) res;
                 }
-                {
-                    Field f = Console.class.getDeclaredField("cs");
-                    setAccessible(console, f);
-                    Object res = f.get(console);
-                    if (res instanceof Charset) {
-                        return (Charset) res;
-                    }
-                }
-                {
-                    Method m = Console.class.getDeclaredMethod("encoding");
-                    setAccessible(console, m);
-                    Object res = m.invoke(null);
-                    if (res instanceof String) {
-                        return Charset.forName((String) res);
-                    }
-                }
+            } catch (Exception e) {
+                // fall-through
             }
-        } catch (Exception e) {
-            // fall-through
+            try {
+                Field f = Console.class.getDeclaredField("cs");
+                setAccessible(console, f);
+                Object res = f.get(console);
+                if (res instanceof Charset) {
+                    return (Charset) res;
+                }
+            } catch (Exception e) {
+                // fall-through
+            }
+            try {
+                Method m = Console.class.getDeclaredMethod("encoding");
+                setAccessible(console, m);
+                Object res = m.invoke(null);
+                if (res instanceof String) {
+                    return Charset.forName((String) res);
+                }
+            } catch (Exception e) {
+                // fall-through
+            }
         }
 
         // Try 2. Try to poke stdout.


### PR DESCRIPTION
Current Console charset probing is not very reliable: it exits on first failure. This is especially important after CODETOOLS-7902915, which polls "charset()" method that is only available in JDK 17+. This makes the whole Console charset probing block to exit early.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902926](https://bugs.openjdk.java.net/browse/CODETOOLS-7902926): JMH: More reliable Console charset probing


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmh pull/35/head:pull/35` \
`$ git checkout pull/35`

Update a local copy of the PR: \
`$ git checkout pull/35` \
`$ git pull https://git.openjdk.java.net/jmh pull/35/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 35`

View PR using the GUI difftool: \
`$ git pr show -t 35`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmh/pull/35.diff">https://git.openjdk.java.net/jmh/pull/35.diff</a>

</details>
