### PR TITLE
CODETOOLS-7902928: Improve support for async-profiler 2.x

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/AsyncProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/AsyncProfiler.java
@@ -275,7 +275,7 @@ public final class AsyncProfiler implements ExternalProfiler, InternalProfiler {
         if (iterationParams.getType() == IterationType.WARMUP) {
             if (!warmupStarted) {
                 // Collect profiles during warmup to warmup the profiler itself.
-                start("");
+                start();
                 warmupStarted = true;
             }
         }
@@ -285,18 +285,18 @@ public final class AsyncProfiler implements ExternalProfiler, InternalProfiler {
                     // Discard samples collected during warmup...
                     execute("stop");
                 }
-                start("reset,");
+                start();
                 measurementStarted = true;
             }
         }
     }
 
-    private void start(String reset) {
+    private void start() {
         String fileConfig = "";
         if (output.contains(OutputType.jfr)) {
             File jfrFile = new File(trialOutDir, "profile.jfr");
             generated.add(jfrFile);
-            fileConfig = "," + reset + "file=" + jfrFile.getAbsolutePath();
+            fileConfig = ",file=" + jfrFile.getAbsolutePath();
         }
         execute("start," + profilerConfig + fileConfig);
     }


### PR DESCRIPTION
Allow multiple events to be captured simultaneously in this version,
provided that JFR is chosen as output format.

Delegate output file writing to the async-profiler. This is required
in 2.x for the JFR output but is supported in both versions. The file
path must be provided when starting the profiler with JFR output, so
we need to create the per-trial output directory in the first
`beforeIteration`.

Avoid the character '%' in the generated directory name as this
is interpreted by async-profiler as part %p or %t placeholder.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902928](https://bugs.openjdk.java.net/browse/CODETOOLS-7902928): Improve support for async-profiler 2.x


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmh pull/37/head:pull/37` \
`$ git checkout pull/37`

Update a local copy of the PR: \
`$ git checkout pull/37` \
`$ git pull https://git.openjdk.java.net/jmh pull/37/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 37`

View PR using the GUI difftool: \
`$ git pr show -t 37`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmh/pull/37.diff">https://git.openjdk.java.net/jmh/pull/37.diff</a>

</details>
