### PR TITLE
CODETOOLS-7902929: JMH generators fail for benchmark in unnamed package

### DIFF
--- a/jmh-core-ct/src/test/java/UnnamedPackageTest.java
+++ b/jmh-core-ct/src/test/java/UnnamedPackageTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.ct.CompileTest;
+import org.openjdk.jmh.ct.InMemoryGeneratorDestination;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class UnnamedPackageTest {
+
+    @State(Scope.Benchmark)
+    public static class S {
+        @Setup(Level.Trial)
+        public void setup(AtomicInteger v) {}
+    }
+
+    @Benchmark
+    public void test(S s) {
+
+    }
+
+    @Test
+    public void compileTest() {
+        InMemoryGeneratorDestination destination = new InMemoryGeneratorDestination();
+        boolean success = CompileTest.doTest(getClass(), destination);
+        if (success) {
+            Assert.fail("Should have failed.");
+        }
+        String error = destination.getErrors().get(0);
+        Assert.assertTrue(error, error.contains("Benchmark class should have package other than default."));
+    }
+}

--- a/jmh-core-ct/src/test/java/UnnamedPackageTest.java
+++ b/jmh-core-ct/src/test/java/UnnamedPackageTest.java
@@ -23,35 +23,17 @@
  * questions.
  */
 
-import org.junit.Assert;
 import org.junit.Test;
-import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.ct.CompileTest;
-import org.openjdk.jmh.ct.InMemoryGeneratorDestination;
-
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class UnnamedPackageTest {
-
-    @State(Scope.Benchmark)
-    public static class S {
-        @Setup(Level.Trial)
-        public void setup(AtomicInteger v) {}
-    }
-
     @Benchmark
-    public void test(S s) {
-
+    public void test() {
     }
 
     @Test
     public void compileTest() {
-        InMemoryGeneratorDestination destination = new InMemoryGeneratorDestination();
-        boolean success = CompileTest.doTest(getClass(), destination);
-        if (success) {
-            Assert.fail("Should have failed.");
-        }
-        String error = destination.getErrors().get(0);
-        Assert.assertTrue(error, error.contains("Benchmark class should have package other than default."));
+        CompileTest.assertFail(getClass(), "Benchmark class should have package other than default.");
     }
 }

--- a/jmh-core-ct/src/test/java/org/openjdk/jmh/ct/CompileTest.java
+++ b/jmh-core-ct/src/test/java/org/openjdk/jmh/ct/CompileTest.java
@@ -88,7 +88,7 @@ public class CompileTest {
         }
     }
 
-    private static boolean doTest(Class<?> klass, InMemoryGeneratorDestination destination) {
+    public static boolean doTest(Class<?> klass, InMemoryGeneratorDestination destination) {
         if (GENERATOR_TYPE.equalsIgnoreCase("reflection")) {
             RFGeneratorSource source = new RFGeneratorSource();
             source.processClasses(klass);

--- a/jmh-core-ct/src/test/java/org/openjdk/jmh/ct/CompileTest.java
+++ b/jmh-core-ct/src/test/java/org/openjdk/jmh/ct/CompileTest.java
@@ -88,7 +88,7 @@ public class CompileTest {
         }
     }
 
-    public static boolean doTest(Class<?> klass, InMemoryGeneratorDestination destination) {
+    private static boolean doTest(Class<?> klass, InMemoryGeneratorDestination destination) {
         if (GENERATOR_TYPE.equalsIgnoreCase("reflection")) {
             RFGeneratorSource source = new RFGeneratorSource();
             source.processClasses(klass);

--- a/jmh-generator-asm/src/main/java/org/openjdk/jmh/generators/asm/ASMClassInfo.java
+++ b/jmh-generator-asm/src/main/java/org/openjdk/jmh/generators/asm/ASMClassInfo.java
@@ -87,6 +87,16 @@ class ASMClassInfo extends ClassVisitor implements ClassInfo {
         } else {
             packageName = "";
         }
+
+        this.origQualifiedName = qualifiedName;
+        this.qualifiedName = qualifiedName.replace('$', '.');
+
+        dotIndex = qualifiedName.lastIndexOf(".");
+        if (dotIndex != -1) {
+            this.name = qualifiedName.substring(dotIndex + 1);
+        } else {
+            this.name = qualifiedName;
+        }
     }
 
     @Override

--- a/jmh-generator-asm/src/main/java/org/openjdk/jmh/generators/asm/ASMClassInfo.java
+++ b/jmh-generator-asm/src/main/java/org/openjdk/jmh/generators/asm/ASMClassInfo.java
@@ -79,11 +79,14 @@ class ASMClassInfo extends ClassVisitor implements ClassInfo {
         this.superName = superName;
         this.idName = name;
         this.access = access;
-        qualifiedName = name.replace("/", ".");
-        packageName = qualifiedName.substring(0, qualifiedName.lastIndexOf("."));
-        origQualifiedName = qualifiedName;
-        qualifiedName = qualifiedName.replace('$', '.');
-        this.name = qualifiedName.substring(qualifiedName.lastIndexOf(".") + 1);
+        this.qualifiedName = name.replace("/", ".");
+
+        int dotIndex = qualifiedName.lastIndexOf(".");
+        if (dotIndex != -1) {
+            packageName = qualifiedName.substring(0, dotIndex);
+        } else {
+            packageName = "";
+        }
     }
 
     @Override

--- a/jmh-generator-reflection/src/main/java/org/openjdk/jmh/generators/reflection/RFClassInfo.java
+++ b/jmh-generator-reflection/src/main/java/org/openjdk/jmh/generators/reflection/RFClassInfo.java
@@ -46,9 +46,9 @@ class RFClassInfo implements ClassInfo {
     @Override
     public String getPackageName() {
         if (klass.getDeclaringClass() != null) {
-            return klass.getDeclaringClass().getPackage().getName();
+            return nameOf(klass.getDeclaringClass().getPackage());
         } else {
-            return klass.getPackage().getName();
+            return nameOf(klass.getPackage());
         }
     }
 
@@ -170,5 +170,9 @@ class RFClassInfo implements ClassInfo {
     @Override
     public String toString() {
         return getQualifiedName();
+    }
+
+    private String nameOf(Package pack) {
+        return pack == null ? "" : pack.getName();
     }
 }


### PR DESCRIPTION
Prior to the patch, the enclosed test failed with:

```
$ mvn -Preflection test
...
Running UnnamedPackageTest
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.004 sec <<< FAILURE! - in UnnamedPackageTest
compileTest(UnnamedPackageTest)  Time elapsed: 0.004 sec  <<< FAILURE!
java.lang.AssertionError: Annotation generator had thrown the exception.:
java.lang.NullPointerException
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.assertTrue(Assert.java:42)
	at UnnamedPackageTest.compileTest(UnnamedPackageTest.java:55)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902929](https://bugs.openjdk.java.net/browse/CODETOOLS-7902929): JMH generators fail for benchmark in unnamed package


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmh pull/38/head:pull/38` \
`$ git checkout pull/38`

Update a local copy of the PR: \
`$ git checkout pull/38` \
`$ git pull https://git.openjdk.java.net/jmh pull/38/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 38`

View PR using the GUI difftool: \
`$ git pr show -t 38`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmh/pull/38.diff">https://git.openjdk.java.net/jmh/pull/38.diff</a>

</details>
