### PR TITLE
CODETOOLS-7902944: JMH: Avoid direct weak references in Blackhole.consume(Object)

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/infra/Blackhole.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/infra/Blackhole.java
@@ -225,8 +225,8 @@ public final class Blackhole extends BlackholeL4 {
      * regularly, but we also additionally protect with retaining the object on
      * weak reference (contrary to phantom-ref, publishing object still has to
      * happen, because reference users might need to discover the object). Some
-     * objects, for example inline types, resist to be put on weak references
-     * directly so we need to wrap them again.
+     * objects, for example inline types, resist to be referenced by weak references
+     * directly, so we need to wrap them with another reachable box.
      *
      * Observation (4) provides us with an opportunity to create a safety net in case
      * either (1), (2) or (3) fails. This is why Blackhole methods are prohibited from

--- a/jmh-core/src/main/java/org/openjdk/jmh/infra/Blackhole.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/infra/Blackhole.java
@@ -222,9 +222,7 @@ public final class Blackhole extends BlackholeL4 {
      * the condition to "false". We are warming up the slow-path in the beginning
      * to evade that effect. Some caution needs to be exercised not to retain the
      * captured objects forever: this is normally achieved by calling evaporate()
-     * regularly, but we also additionally protect with retaining the object on
-     * weak reference (contrary to phantom-ref, publishing object still has to
-     * happen, because reference users might need to discover the object).
+     * regularly.
      *
      * Observation (4) provides us with an opportunity to create a safety net in case
      * either (1), (2) or (3) fails. This is why Blackhole methods are prohibited from
@@ -514,7 +512,7 @@ public final class Blackhole extends BlackholeL4 {
         int tlr = (this.tlr = (this.tlr * 1664525 + 1013904223));
         if ((tlr & tlrMask) == 0) {
             // SHOULD ALMOST NEVER HAPPEN IN MEASUREMENT
-            this.obj1 = new WeakReference<>(obj);
+            this.obj1 = obj;
             this.tlrMask = (tlrMask << 1) + 1;
         }
     }

--- a/jmh-core/src/main/java/org/openjdk/jmh/infra/Blackhole.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/infra/Blackhole.java
@@ -516,14 +516,14 @@ public final class Blackhole extends BlackholeL4 {
         int tlr = (this.tlr = (this.tlr * 1664525 + 1013904223));
         if ((tlr & tlrMask) == 0) {
             // SHOULD ALMOST NEVER HAPPEN IN MEASUREMENT
-            this.obj1 = new WeakReference<>(new Holder(obj));
+            this.obj1 = new WeakReference<>(new Box(obj));
             this.tlrMask = (tlrMask << 1) + 1;
         }
     }
 
-    private static class Holder {
+    private static class Box {
         public Object o;
-        public Holder(Object o) { this.o = o; }
+        public Box(Object o) { this.o = o; }
     }
 
     private static volatile long consumedCPU = System.nanoTime();


### PR DESCRIPTION
CODETOOLS-7901867 wrapped the stored object reference with a `WeakReference`. This unfortunately fails with inline type boxes that throw the exceptions like:

```
java.lang.IllegalArgumentException: cannot reference a primitive type: org.openjdk.PrimitiveClasses$Value
at java.base/java.lang.ref.Reference.<init>(Reference.java:495)
at java.base/java.lang.ref.Reference.<init>(Reference.java:489)
at java.base/java.lang.ref.WeakReference.<init>(WeakReference.java:62)
at org.openjdk.jmh.infra.Blackhole.consumeFull(Blackhole.java:515)
at org.openjdk.jmh.infra.Blackhole.consume(Blackhole.java:315)
at org.openjdk.jmh_generated.PrimitiveClasses_test_jmhTest.test_avgt_jmhStub(PrimitiveClasses_test_jmhTest.java:190)
at org.openjdk.jmh_generated.PrimitiveClasses_test_jmhTest.test_AverageTime(PrimitiveClasses_test_jmhTest.java:152)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:78)
at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.base/java.lang.reflect.Method.invoke(Method.java:568)
at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:470)
at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:453)
at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1135)
at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
at java.base/java.lang.Thread.run(Thread.java:831)
```

Wrapping in `WeakReference` is not very reliable, but it is an important defense-in-depth strategy: if it hoards a large object, then a GC in the middle of benchmark would drop it. To handle inline types, it might make some sense to wrap the instance with another holder.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7902944](https://bugs.openjdk.org/browse/CODETOOLS-7902944): JMH: Avoid direct weak references in Blackhole.consume(Object) (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/42/head:pull/42` \
`$ git checkout pull/42`

Update a local copy of the PR: \
`$ git checkout pull/42` \
`$ git pull https://git.openjdk.org/jmh.git pull/42/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 42`

View PR using the GUI difftool: \
`$ git pr show -t 42`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/42.diff">https://git.openjdk.org/jmh/pull/42.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/42#issuecomment-848673445)