### PR TITLE
CODETOOLS-7903008: JMH: Support incremental annotation processing for Gradle Java plugin

### DIFF
--- a/jmh-core-ct/src/test/java/org/openjdk/jmh/ct/InMemoryGeneratorDestination.java
+++ b/jmh-core-ct/src/test/java/org/openjdk/jmh/ct/InMemoryGeneratorDestination.java
@@ -59,7 +59,7 @@ public class InMemoryGeneratorDestination implements GeneratorDestination {
     }
 
     @Override
-    public Writer newClass(String className) throws IOException {
+    public Writer newClass(String className, String originatingClassName) throws IOException {
         StringWriter sw = new StringWriter();
         classBodies.put(className, sw);
         return new PrintWriter(sw, true);

--- a/jmh-core/src/main/java/org/openjdk/jmh/generators/core/BenchmarkGenerator.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/generators/core/BenchmarkGenerator.java
@@ -445,7 +445,7 @@ public class BenchmarkGenerator {
         states.bindMethods(classInfo, info.methodGroup);
 
         // Create file and open an outputstream
-        PrintWriter writer = new PrintWriter(destination.newClass(info.generatedClassQName), false);
+        PrintWriter writer = new PrintWriter(destination.newClass(info.generatedClassQName, classInfo.getQualifiedName()), false);
 
         // Write package and imports
         writer.println("package " + info.generatedPackageName + ';');

--- a/jmh-core/src/main/java/org/openjdk/jmh/generators/core/FileSystemDestination.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/generators/core/FileSystemDestination.java
@@ -64,7 +64,7 @@ public class FileSystemDestination implements GeneratorDestination {
     }
 
     @Override
-    public Writer newClass(String className) throws IOException {
+    public Writer newClass(String className, String originatingClassName) throws IOException {
         String pathName = sourceDir.getAbsolutePath() + "/" + className.replaceAll("\\.", "/");
         File p = new File(pathName.substring(0, pathName.lastIndexOf("/")));
         if (!p.mkdirs() && !p.isDirectory()) {

--- a/jmh-core/src/main/java/org/openjdk/jmh/generators/core/GeneratorDestination.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/generators/core/GeneratorDestination.java
@@ -58,10 +58,11 @@ public interface GeneratorDestination {
      * Callers are responsible for closing Writers.
      *
      * @param className class name
+     * @param originatingClassName class name causing the creation of this class
      * @return writer usable to write the resource
      * @throws IOException if something wacked happens
      */
-    Writer newClass(String className) throws IOException;
+    Writer newClass(String className, String originatingClassName) throws IOException;
 
     /**
      * Print the error.

--- a/jmh-core/src/main/java/org/openjdk/jmh/generators/core/StateObjectHandler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/generators/core/StateObjectHandler.java
@@ -959,7 +959,7 @@ class StateObjectHandler {
             if (!sess.generatedStateOverrides.add(so.userType)) continue;
 
             {
-                PrintWriter pw = new PrintWriter(dst.newClass(so.packageName + "." + so.type + "_B1"));
+                PrintWriter pw = new PrintWriter(dst.newClass(so.packageName + "." + so.type + "_B1", so.userType));
 
                 pw.println("package " + so.packageName + ";");
 
@@ -973,7 +973,7 @@ class StateObjectHandler {
             }
 
             {
-                PrintWriter pw = new PrintWriter(dst.newClass(so.packageName + "." + so.type + "_B2"));
+                PrintWriter pw = new PrintWriter(dst.newClass(so.packageName + "." + so.type + "_B2", so.userType));
 
                 pw.println("package " + so.packageName + ";");
 
@@ -1011,7 +1011,7 @@ class StateObjectHandler {
             }
 
             {
-                PrintWriter pw = new PrintWriter(dst.newClass(so.packageName + "." + so.type + "_B3"));
+                PrintWriter pw = new PrintWriter(dst.newClass(so.packageName + "." + so.type + "_B3", so.userType));
 
                 pw.println("package " + so.packageName + ";");
                 pw.println("public class " + so.type + "_B3 extends " + so.type + "_B2 {");
@@ -1023,7 +1023,7 @@ class StateObjectHandler {
             }
 
             {
-                PrintWriter pw = new PrintWriter(dst.newClass(so.packageName + "." + so.type));
+                PrintWriter pw = new PrintWriter(dst.newClass(so.packageName + "." + so.type, so.userType));
 
                 pw.println("package " + so.packageName + ";");
                 pw.println("public class " + so.type + " extends " + so.type + "_B3 {");

--- a/jmh-generator-annprocess/src/main/java/org/openjdk/jmh/generators/annotations/APGeneratorDestinaton.java
+++ b/jmh-generator-annprocess/src/main/java/org/openjdk/jmh/generators/annotations/APGeneratorDestinaton.java
@@ -28,8 +28,10 @@ import org.openjdk.jmh.generators.core.GeneratorDestination;
 import org.openjdk.jmh.generators.core.MetadataInfo;
 import org.openjdk.jmh.util.Utils;
 
+import javax.annotation.processing.Filer;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.element.TypeElement;
 import javax.tools.Diagnostic;
 import javax.tools.StandardLocation;
 import java.io.*;
@@ -53,8 +55,14 @@ public class APGeneratorDestinaton implements GeneratorDestination {
     }
 
     @Override
-    public Writer newClass(String className) throws IOException {
-        return processingEnv.getFiler().createSourceFile(className).openWriter();
+    public Writer newClass(String className, String originatingClassName) throws IOException {
+        Filer filer = processingEnv.getFiler();
+        if (originatingClassName != null) {
+            TypeElement originatingType = processingEnv.getElementUtils().getTypeElement(originatingClassName);
+            return filer.createSourceFile(className, originatingType).openWriter();
+        } else {
+            return filer.createSourceFile(className).openWriter();
+        }
     }
 
     @Override

--- a/jmh-generator-annprocess/src/main/resources/META-INF/gradle/incremental.annotation.processors
+++ b/jmh-generator-annprocess/src/main/resources/META-INF/gradle/incremental.annotation.processors
@@ -1,0 +1,1 @@
+org.openjdk.jmh.generators.BenchmarkProcessor,ISOLATING


### PR DESCRIPTION
This change adds support for Gradle's [incremental annotation processing](https://docs.gradle.org/current/userguide/java_plugin.html#sec:incremental_annotation_processing). Without this support, developers using the JMH annotation processor in their Gradle projects will see their compilation time increased due to Gradle invalidating its incremental compilation cache.  

/covered

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903008](https://bugs.openjdk.java.net/browse/CODETOOLS-7903008): JMH: Support incremental annotation processing for Gradle Java plugin


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmh pull/43/head:pull/43` \
`$ git checkout pull/43`

Update a local copy of the PR: \
`$ git checkout pull/43` \
`$ git pull https://git.openjdk.java.net/jmh pull/43/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 43`

View PR using the GUI difftool: \
`$ git pr show -t 43`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmh/pull/43.diff">https://git.openjdk.java.net/jmh/pull/43.diff</a>

</details>
