### PR TITLE
CODETOOLS-7903000: JMH: Fix error message for @Setup helpers on a class missing @State

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/generators/core/StateObjectHandler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/generators/core/StateObjectHandler.java
@@ -531,7 +531,7 @@ class StateObjectHandler {
         if (BenchmarkGeneratorUtils.getAnnSuper(mi.getDeclaringClass(), State.class) == null) {
             if (!mi.getDeclaringClass().isAbstract()) {
                 throw new GenerationException(
-                        "@" + TearDown.class.getSimpleName() + " annotation is placed within " +
+                        "@" + annClass.getSimpleName() + " annotation is placed within " +
                                 "the class not having @" + State.class.getSimpleName() + " annotation. " +
                                 "This has no behavioral effect, and prohibited.",
                         mi);


### PR DESCRIPTION
Such error messages previously incorrectly referred to `@TearDown`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903000](https://bugs.openjdk.java.net/browse/CODETOOLS-7903000): JMH: Fix error message for @Setup helpers on a class missing @State


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmh pull/44/head:pull/44` \
`$ git checkout pull/44`

Update a local copy of the PR: \
`$ git checkout pull/44` \
`$ git pull https://git.openjdk.java.net/jmh pull/44/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 44`

View PR using the GUI difftool: \
`$ git pr show -t 44`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmh/pull/44.diff">https://git.openjdk.java.net/jmh/pull/44.diff</a>

</details>
