### PR TITLE
CODETOOLS-7903001: JMH: The interrupt to time-outing benchmark can be delivered to warmdown latches

### DIFF
--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/interrupts/InterruptibleInterruptTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/interrupts/InterruptibleInterruptTest.java
@@ -42,8 +42,12 @@ import java.util.concurrent.TimeUnit;
 public class InterruptibleInterruptTest {
 
     @Benchmark
-    public void test() throws InterruptedException {
-        Thread.sleep(5_000);
+    public void test() {
+        try {
+            Thread.sleep(5_000);
+        } catch (InterruptedException e) {
+            // Harness delivered, just exit.
+        }
     }
 
     @Test

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/interrupts/InterruptibleInterruptTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/interrupts/InterruptibleInterruptTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jmh.it.interrupts;
+
+import org.junit.Test;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.it.Fixtures;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+import java.util.concurrent.TimeUnit;
+
+@Warmup(iterations = 1, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 1, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(1)
+public class InterruptibleInterruptTest {
+
+    @Benchmark
+    public void test() throws InterruptedException {
+        Thread.sleep(5_000);
+    }
+
+    @Test
+    public void invokeAPI() throws RunnerException {
+        for (Mode m : Mode.values()) {
+            if (m != Mode.All) continue;
+            Options opt = new OptionsBuilder()
+                    .include(Fixtures.getTestMask(this.getClass()))
+                    .shouldFailOnError(true)
+                    .mode(m)
+                    .timeout(TimeValue.seconds(1))
+                    .build();
+
+            new Runner(opt).run();
+        }
+    }
+
+}

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/interrupts/NonInterruptibleInterruptTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/interrupts/NonInterruptibleInterruptTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jmh.it.interrupts;
+
+import org.junit.Test;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.it.Fixtures;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+import java.util.concurrent.TimeUnit;
+
+@Warmup(iterations = 1, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 1, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(1)
+public class NonInterruptibleInterruptTest {
+
+    @Benchmark
+    public void test() {
+        // This method deliberately does not check interrupt status.
+        long start = System.currentTimeMillis();
+        long end = start + 5_000;
+        while (System.currentTimeMillis() < end) {
+            Blackhole.consumeCPU(10_000);
+        }
+    }
+
+    @Test
+    public void invokeAPI() throws RunnerException {
+        for (Mode m : Mode.values()) {
+            if (m != Mode.All) continue;
+            Options opt = new OptionsBuilder()
+                    .include(Fixtures.getTestMask(this.getClass()))
+                    .shouldFailOnError(true)
+                    .mode(m)
+                    .timeout(TimeValue.seconds(1))
+                    .build();
+
+            new Runner(opt).run();
+        }
+    }
+
+}

--- a/jmh-core/src/main/java/org/openjdk/jmh/generators/core/BenchmarkGenerator.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/generators/core/BenchmarkGenerator.java
@@ -595,10 +595,10 @@ public class BenchmarkGenerator {
 
             writer.println(ident(5) + "res.allOps++;");
             writer.println(ident(4) + "}");
-            writer.println(ident(4) + "control.preTearDown();");
-            writer.println(ident(3) + "} catch (InterruptedException ie) {");
-            writer.println(ident(4) + "control.preTearDownForce();");
+            writer.println(ident(3) + "} catch (Throwable e) {");
+            writer.println(ident(4) + "if (!(e instanceof InterruptedException)) throw e;");
             writer.println(ident(3) + "}");
+            writer.println(ident(3) + "control.preTearDown();");
 
             // iteration prolog
             iterationEpilog(writer, 3, method, states);
@@ -728,10 +728,10 @@ public class BenchmarkGenerator {
 
             writer.println(ident(5) + "res.allOps++;");
             writer.println(ident(4) + "}");
-            writer.println(ident(4) + "control.preTearDown();");
-            writer.println(ident(3) + "} catch (InterruptedException ie) {");
-            writer.println(ident(4) + "control.preTearDownForce();");
+            writer.println(ident(3) + "} catch (Throwable e) {");
+            writer.println(ident(4) + "if (!(e instanceof InterruptedException)) throw e;");
             writer.println(ident(3) + "}");
+            writer.println(ident(3) + "control.preTearDown();");
 
             iterationEpilog(writer, 3, method, states);
 
@@ -891,10 +891,10 @@ public class BenchmarkGenerator {
 
             writer.println(ident(5) + "res.allOps++;");
             writer.println(ident(4) + "}");
-            writer.println(ident(4) + "control.preTearDown();");
-            writer.println(ident(3) + "} catch (InterruptedException ie) {");
-            writer.println(ident(4) + "control.preTearDownForce();");
+            writer.println(ident(3) + "} catch (Throwable e) {");
+            writer.println(ident(4) + "if (!(e instanceof InterruptedException)) throw e;");
             writer.println(ident(3) + "}");
+            writer.println(ident(3) + "control.preTearDown();");
 
             iterationEpilog(writer, 3, method, states);
 

--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/InfraControl.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/InfraControl.java
@@ -77,17 +77,29 @@ public class InfraControl extends InfraControlL4 {
     }
 
     public void preSetup() {
-        try {
-            preSetup.countDown();
-            preSetup.await();
-        } catch (InterruptedException e) {
-            throw new IllegalStateException(e);
+        preSetup.countDown();
+
+        while (true) {
+            try {
+                preSetup.await();
+                return;
+            } catch (InterruptedException e) {
+                // Do not accept interrupts here.
+            }
         }
     }
 
-    public void preTearDown() throws InterruptedException {
+    public void preTearDown() {
         preTearDown.countDown();
-        preTearDown.await();
+
+        while (true) {
+            try {
+                preTearDown.await();
+                return;
+            } catch (InterruptedException e) {
+                // Do not accept interrupts here.
+            }
+        }
     }
 
     public void preSetupForce() {


### PR DESCRIPTION
See the bug report for details.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903001](https://bugs.openjdk.java.net/browse/CODETOOLS-7903001): JMH: The interrupt to time-outing benchmark can be delivered to warmdown latches


### Reviewers
 * [Eric Caspole](https://openjdk.java.net/census#ecaspole) (@ericcaspole - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmh pull/45/head:pull/45` \
`$ git checkout pull/45`

Update a local copy of the PR: \
`$ git checkout pull/45` \
`$ git pull https://git.openjdk.java.net/jmh pull/45/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 45`

View PR using the GUI difftool: \
`$ git pr show -t 45`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmh/pull/45.diff">https://git.openjdk.java.net/jmh/pull/45.diff</a>

</details>
