### PR TITLE
CODETOOLS-7903004: JMH: Compiler Blackholes auto-detection

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/CompilerHints.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/CompilerHints.java
@@ -291,14 +291,8 @@ public class CompilerHints extends AbstractResourceReader {
         return blackholeSelect;
     }
 
-    public static void printBlackholeMode(PrintStream out) {
-        BlackholeMode mode = blackholeMode();
-        out.print("# Blackhole mode: " + mode.desc() + " (" + blackholeSelect().desc() + ")");
-        out.println();
-    }
-
     private enum BlackholeMode {
-        COMPILER(true, false, "compiler-assisted"),
+        COMPILER(true, false, "compiler"),
         FULL_DONTINLINE(false, true, "full + dont-inline hint"),
         FULL(false, false, "full"),
         ;
@@ -392,6 +386,12 @@ public class CompilerHints extends AbstractResourceReader {
         if (BLACKHOLE_MODE_DEBUG) {
             System.out.println(msg);
         }
+    }
+
+    public static void printBlackhole(PrintStream out) {
+        BlackholeMode mode = blackholeMode();
+        out.print("# Blackhole: " + mode.desc() + " (" + blackholeSelect().desc() + ")");
+        out.println();
     }
 
     public static void printWarnings(PrintStream out) {

--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/CompilerHints.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/CompilerHints.java
@@ -46,8 +46,14 @@ public class CompilerHints extends AbstractResourceReader {
 
     static final String XX_COMPILE_COMMAND_FILE = "-XX:CompileCommandFile=";
 
-    static final String BLACKHOLE_MODE_PROP_NAME = "jmh.blackhole.mode";
-    static final String BLACKHOLE_MODE_AUTODETECT_NAME = "jmh.blackhole.autoDetect";
+    static final String BLACKHOLE_MODE_NAME       = "jmh.blackhole.mode";
+    static final String BLACKHOLE_AUTODETECT_NAME = "jmh.blackhole.autoDetect";
+    static final String BLACKHOLE_DEBUG_NAME      = "jmh.blackhole.debug";
+
+    static final boolean BLACKHOLE_MODE_AUTODETECT =
+            Boolean.parseBoolean(System.getProperty(BLACKHOLE_AUTODETECT_NAME, "true"));
+    static final boolean BLACKHOLE_MODE_DEBUG =
+            Boolean.parseBoolean(System.getProperty(BLACKHOLE_DEBUG_NAME, "false"));
 
     public static CompilerHints defaultList() {
         if (defaultList == null) {
@@ -239,7 +245,7 @@ public class CompilerHints extends AbstractResourceReader {
     }
 
     private static BlackholeMode blackholeMode;
-    private static BlackholeDetectMode blackholeDetectMode;
+    private static BlackholeSelect blackholeSelect;
 
     private static BlackholeMode blackholeMode() {
         if (blackholeMode != null) {
@@ -247,11 +253,11 @@ public class CompilerHints extends AbstractResourceReader {
         }
 
         // Forced mode takes precedence.
-        String propMode = System.getProperty(BLACKHOLE_MODE_PROP_NAME);
+        String propMode = System.getProperty(BLACKHOLE_MODE_NAME);
         if (propMode != null) {
             try {
                 blackholeMode = BlackholeMode.valueOf(propMode);
-                blackholeDetectMode = BlackholeDetectMode.FORCED;
+                blackholeSelect = BlackholeSelect.FORCED;
 
                 // Extra safety: If user requested compiler blackholes, check
                 // if they are available and fail otherwise.
@@ -266,29 +272,28 @@ public class CompilerHints extends AbstractResourceReader {
         }
 
         // Try to autodetect blackhole mode
-        String autoDetectProp = System.getProperty(BLACKHOLE_MODE_AUTODETECT_NAME, "true");
-        if (Boolean.parseBoolean(autoDetectProp)) {
+        if (BLACKHOLE_MODE_AUTODETECT) {
             if (compilerBlackholesAvailable()) {
                 blackholeMode = BlackholeMode.COMPILER;
-                blackholeDetectMode = BlackholeDetectMode.AUTO;
+                blackholeSelect = BlackholeSelect.AUTO;
                 return blackholeMode;
             }
         }
 
         // No dice, fallback to older mode
         blackholeMode = BlackholeMode.FULL_DONTINLINE;
-        blackholeDetectMode = BlackholeDetectMode.FALLBACK;
+        blackholeSelect = BlackholeSelect.FALLBACK;
         return blackholeMode;
     }
 
-    private static BlackholeDetectMode blackholeDetectMode() {
+    private static BlackholeSelect blackholeSelect() {
         blackholeMode();
-        return blackholeDetectMode;
+        return blackholeSelect;
     }
 
     public static void printBlackholeMode(PrintStream out) {
         BlackholeMode mode = blackholeMode();
-        out.print("# Blackhole mode: " + mode.desc() + " (" + blackholeDetectMode().desc() + ")");
+        out.print("# Blackhole mode: " + mode.desc() + " (" + blackholeSelect().desc() + ")");
         out.println();
     }
 
@@ -319,15 +324,15 @@ public class CompilerHints extends AbstractResourceReader {
         public String desc() { return desc; }
     }
 
-    private enum BlackholeDetectMode {
-        FALLBACK("fallback, use -D" + BLACKHOLE_MODE_PROP_NAME + " to force another mode"),
-        AUTO("auto-detected, use -D" + BLACKHOLE_MODE_AUTODETECT_NAME + "=false to disable"),
+    private enum BlackholeSelect {
+        FALLBACK("fallback, use -D" + BLACKHOLE_MODE_NAME + " to force another mode"),
+        AUTO("auto-detected, use -D" + BLACKHOLE_AUTODETECT_NAME + "=false to disable"),
         FORCED("forced"),
         ;
 
         final String desc;
 
-        BlackholeDetectMode(String desc) {
+        BlackholeSelect(String desc) {
             this.desc = desc;
         }
 
@@ -346,10 +351,15 @@ public class CompilerHints extends AbstractResourceReader {
             cmd.add("-XX:CompileCommand=blackhole,some/fake/Class.method");
             cmd.add("-version");
 
+            debug("Blackhole command errors test:");
+
             Collection<String> log = Utils.runWith(cmd);
             for (String l : log) {
-                if (l.contains("CompilerOracle")) return false;
-                if (l.contains("CompileCommand")) return false;
+                debug(l);
+                if (l.contains("CompilerOracle") || l.contains("CompileCommand")) {
+                    debug("Found the suspected error line, no compiler blackholes.");
+                    return false;
+                }
             }
         }
 
@@ -361,15 +371,27 @@ public class CompilerHints extends AbstractResourceReader {
             cmd.add("-XX:CompileCommand=blackhole,some/fake/Class.method");
             cmd.add("-version");
 
+            debug("Blackhole command acceptance test:");
+
             Collection<String> log = Utils.runWith(cmd);
             for (String l : log) {
-                if (l.contains("CompilerOracle")) return true;
-                if (l.contains("CompileCommand")) return true;
+                debug(l);
+                if (l.contains("CompilerOracle") || l.contains("CompileCommand")) {
+                    debug("Found the acceptance line, compiler blackholes are available.");
+                    return true;
+                }
             }
         }
 
         // Err on the side of the caution: compiler blackholes are not available.
+        debug("Compiler blackholes are not available.");
         return false;
+    }
+
+    private static void debug(String msg) {
+        if (BLACKHOLE_MODE_DEBUG) {
+            System.out.println(msg);
+        }
     }
 
     public static void printWarnings(PrintStream out) {

--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/CompilerHints.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/CompilerHints.java
@@ -51,7 +51,7 @@ public class CompilerHints extends AbstractResourceReader {
     static final String BLACKHOLE_DEBUG_NAME      = "jmh.blackhole.debug";
 
     static final boolean BLACKHOLE_MODE_AUTODETECT =
-            Boolean.parseBoolean(System.getProperty(BLACKHOLE_AUTODETECT_NAME, "true"));
+            Boolean.parseBoolean(System.getProperty(BLACKHOLE_AUTODETECT_NAME, "false"));
     static final boolean BLACKHOLE_MODE_DEBUG =
             Boolean.parseBoolean(System.getProperty(BLACKHOLE_DEBUG_NAME, "false"));
 
@@ -271,18 +271,21 @@ public class CompilerHints extends AbstractResourceReader {
             }
         }
 
-        // Try to autodetect blackhole mode
+        // Try to autodetect blackhole mode, fail if not available
         if (BLACKHOLE_MODE_AUTODETECT) {
             if (compilerBlackholesAvailable()) {
                 blackholeMode = BlackholeMode.COMPILER;
                 blackholeSelect = BlackholeSelect.AUTO;
-                return blackholeMode;
+            } else {
+                blackholeMode = BlackholeMode.FULL_DONTINLINE;
+                blackholeSelect = BlackholeSelect.FALLBACK;
             }
+            return blackholeMode;
         }
 
-        // No dice, fallback to older mode
+        // Not forced, not auto-detected, default
         blackholeMode = BlackholeMode.FULL_DONTINLINE;
-        blackholeSelect = BlackholeSelect.FALLBACK;
+        blackholeSelect = BlackholeSelect.DEFAULT;
         return blackholeMode;
     }
 
@@ -319,8 +322,9 @@ public class CompilerHints extends AbstractResourceReader {
     }
 
     private enum BlackholeSelect {
-        FALLBACK("fallback, use -D" + BLACKHOLE_MODE_NAME + " to force another mode"),
-        AUTO("auto-detected, use -D" + BLACKHOLE_AUTODETECT_NAME + "=false to disable"),
+        DEFAULT("default, use -D" + BLACKHOLE_AUTODETECT_NAME + "=true to auto-detect"),
+        AUTO("auto-detected"),
+        FALLBACK("fallback, use -D" + BLACKHOLE_MODE_NAME + " to force"),
         FORCED("forced"),
         ;
 
@@ -390,7 +394,7 @@ public class CompilerHints extends AbstractResourceReader {
 
     public static void printBlackhole(PrintStream out) {
         BlackholeMode mode = blackholeMode();
-        out.print("# Blackhole: " + mode.desc() + " (" + blackholeSelect().desc() + ")");
+        out.print("# Blackhole mode: " + mode.desc() + " (" + blackholeSelect().desc() + ")");
         out.println();
     }
 

--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/CompilerHints.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/CompilerHints.java
@@ -371,4 +371,15 @@ public class CompilerHints extends AbstractResourceReader {
         return false;
     }
 
+    public static void printWarnings(PrintStream out) {
+        if (blackholeMode() == BlackholeMode.COMPILER) {
+            out.println("NOTE: Current JVM experimentally supports Compiler Blackholes, and they are in use. Please exercise");
+            out.println("extra caution when trusting the results, look into the generated code to check the benchmark still");
+            out.println("works, and factor in a small probability of new VM bugs. Additionally, while comparisons between");
+            out.println("different JVMs are already problematic, the performance difference caused by different Blackhole");
+            out.println("modes can be very significant. Please make sure you use the consistent Blackhole mode for comparisons.");
+            out.println();
+        }
+    }
+
 }

--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/CompilerHints.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/CompilerHints.java
@@ -266,7 +266,8 @@ public class CompilerHints extends AbstractResourceReader {
         }
 
         // Try to autodetect blackhole mode
-        if (Boolean.getBoolean(BLACKHOLE_MODE_AUTODETECT_NAME)) {
+        String autoDetectProp = System.getProperty(BLACKHOLE_MODE_AUTODETECT_NAME, "true");
+        if (Boolean.parseBoolean(autoDetectProp)) {
             if (compilerBlackholesAvailable()) {
                 blackholeMode = BlackholeMode.COMPILER;
                 blackholeDetectMode = BlackholeDetectMode.AUTO;

--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/format/TextReportFormat.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/format/TextReportFormat.java
@@ -81,7 +81,7 @@ class TextReportFormat extends AbstractOutputFormat {
         println("# VM invoker: " + params.getJvm());
         println("# VM options: " + opts);
 
-        CompilerHints.printBlackholeMode(out);
+        CompilerHints.printBlackhole(out);
 
         IterationParams warmup = params.getWarmup();
         if (warmup.getCount() > 0) {

--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/format/TextReportFormat.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/format/TextReportFormat.java
@@ -241,6 +241,8 @@ class TextReportFormat extends AbstractOutputFormat {
         out.println("Do not assume the numbers tell you what you want them to tell.");
         out.println();
 
+        CompilerHints.printWarnings(out);
+
         ResultFormatFactory.getInstance(ResultFormatType.TEXT, out).writeOut(runResults);
     }
 


### PR DESCRIPTION
This is another step towards better [compiler blackholes](https://shipilev.net/jvm/anatomy-quarks/27-compiler-blackholes/) support. This time, we can teach JMH to auto-detect the support. This improves the UX by asking users to supply `-Djmh.blackhole.autoDetect` for this experimental machinery to work. This would then use compiler blackholes for JDK 17+ and full blackholes for everything else. It would also check that compiler blackholes are available when users force it.

All in all, this prevents from accidentally enabling compiler blackholes for JVMs that do not support it, and allows for a consistent JMH invocation line across all JVM versions.

We would explore enabling auto-detection by default at the later time.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903004](https://bugs.openjdk.java.net/browse/CODETOOLS-7903004): JMH: Compiler Blackholes auto-detection


### Reviewers
 * [Claes Redestad](https://openjdk.java.net/census#redestad) (@cl4es - no project role) ⚠️ Review applies to 405420218b72eb6d27a539080f907343b8e99063


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmh pull/48/head:pull/48` \
`$ git checkout pull/48`

Update a local copy of the PR: \
`$ git checkout pull/48` \
`$ git pull https://git.openjdk.java.net/jmh pull/48/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 48`

View PR using the GUI difftool: \
`$ git pr show -t 48`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmh/pull/48.diff">https://git.openjdk.java.net/jmh/pull/48.diff</a>

</details>
