### PR TITLE
[DRAFT] Support Java literals in @Param annotation

### DIFF
--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/params/JavaIntegerLiteralTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/params/JavaIntegerLiteralTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2014, 2015, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jmh.it.params;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.it.Fixtures;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.concurrent.TimeUnit;
+
+@Measurement(iterations = 1, time = 100, timeUnit = TimeUnit.MICROSECONDS)
+@Warmup(iterations = 1, time = 100, timeUnit = TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+@Fork(1)
+public class JavaIntegerLiteralTest {
+
+    @Param({"0b01_10__0", "0B01_10__0"})
+    public int binary;
+
+    @Param({"0B01_10__0"})
+    public int binary2;
+
+    @Param({"01_23"})
+    public byte oct;
+
+    @Param({"1__0____9"})
+    public short dec;
+
+    @Param({"0__1234___5"})
+    public int oct2;
+
+    @Param({"0x12_34"})
+    public long hex;
+
+    @Param({"0XF__F_FF"})
+    public int hex2;
+
+    @Benchmark
+    public void test() {
+        Assert.assertEquals(0b01_10__0, binary);
+        Assert.assertEquals(0B01_10__0, binary2);
+        Assert.assertEquals(01_23, oct);
+        Assert.assertEquals(0__1234___5, oct2);
+        Assert.assertEquals(1__0____9, dec);
+        Assert.assertEquals(0x12_34, hex);
+        Assert.assertEquals(0XF__F_FF, hex2);
+    }
+
+    @Test
+    public void testValidArguments() throws RunnerException {
+        Options opts = new OptionsBuilder()
+                .include(Fixtures.getTestMask(this.getClass()))
+                .shouldFailOnError(true)
+                .build();
+
+        new Runner(opts).run();
+    }
+
+    @Test
+    public void testInvalidArguments() {
+        testFailsOnInvalidLiteral("dec", "0_");
+        testFailsOnInvalidLiteral("dec", "_");
+        testFailsOnInvalidLiteral("dec", "_0");
+        testFailsOnInvalidLiteral("hex", "0x_F");
+        testFailsOnInvalidLiteral("hex", "0_xF");
+    }
+
+    private void testFailsOnInvalidLiteral(String name, String value) {
+        Options opts = new OptionsBuilder()
+                .include(Fixtures.getTestMask(this.getClass()))
+                .param(name, value)
+                .shouldFailOnError(true)
+                .build();
+
+        try {
+            new Runner(opts).run();
+            Assert.fail();
+        } catch (RunnerException e) {
+            // Expected
+        }
+    }
+}

--- a/jmh-core/src/main/java/org/openjdk/jmh/generators/core/BenchmarkGenerator.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/generators/core/BenchmarkGenerator.java
@@ -510,7 +510,8 @@ public class BenchmarkGenerator {
                 Field.class, BenchmarkParams.class, IterationParams.class,
                 Blackhole.class, Control.class,
                 ScalarResult.class, AggregationPolicy.class,
-                FailureAssistException.class
+                FailureAssistException.class,
+                NumericLiteralsParser.class
         };
 
         for (Class<?> c : imports) {

--- a/jmh-core/src/main/java/org/openjdk/jmh/generators/core/NumericLiteralsParser.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/generators/core/NumericLiteralsParser.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jmh.generators.core;
+
+import java.util.regex.Pattern;
+
+/**
+ * Java literals support for benchmark generator.
+ * <p>
+ * This class is designed for JMH-specific usages and is not
+ * supposed to be stable, backwards-compatible or usable outside JMH machinery.
+ */
+public final class NumericLiteralsParser {
+    /*
+     * Regexes are written looking at JLS 3.10.x grammar.
+     * Trailing 'L' in long literals is not supported.
+     *
+     * Grammar:
+     *
+     * ### Integers
+     * IntegerLiteral = (DecimalNumeral | HexNumeral | OctalNumeral | BinaryNumeral) [lL]?
+     * Digits = [0-9] ([0-9_]* [0-9])? // Same pattern for others
+     * DecimalNumeral = 0 | [1-9] [0-9]* | [1-9] [_]+ Digits
+     *
+     * HexNumeral = 0 [xX] HexDigits
+     * BinaryNumeral = 0 [bB] BinaryDigits
+     * OctalNumeral = 0 [_]* OctalDigits
+     *
+     * ### Floating points
+     * FloatingPointLiteral = (DecimalFloatingPointLiteral | HexadecimalFloatingPointLiteral) [fFdD]?
+     *
+     * DecimalFloatingPointLiteral =
+     *     Digits . Digits? Exponent?
+     *     . Digits Exponent?
+     *     Digits Exponent?
+     *
+     * Exponent = [eE] [+-]? Digits
+     *
+     * HexadecimalFloatingPointLiteral = HexSignificand BinaryExponent
+     * BinaryExponent = [pP] [+-]? Digits
+     * HexSignificand = HexNumeral (. HexDigits)?
+     */
+
+    /*
+     * Regex that checks whether the given string is a valid Java integer (not FP!) literal.
+     */
+    private static final Pattern INTEGRAL_PATTERN = Pattern.compile("(" +
+            "0[bB][01]([01_]*[01])?|" + // Binary literals
+            "0_*[0-7]([0-7_]*[0-7])?|" + // Oct literals
+            "(0|[1-9]([0-9_]*[0-9])?)|" + // Dec literals
+            "0[xX][0-9a-fA-F]([0-9a-fA-F_]*[0-9a-fA-F])?" + // Hex literals
+            ")"
+    );
+
+    private NumericLiteralsParser() {
+    }
+
+    /*
+     * parseX methods are invoked directly from the generated benchmarks.
+     * throwIfInvalidLiteral is invoked first to filter out things like trailing underscores etc.
+     * that parse function just unconditionally trim.
+     * We cannot ensure that the given `value` was checked via `StateObjectHandler.isParamValueConforming`
+     * because of user-supplied or cmd-overridden arguments.
+     */
+
+    public static byte parseByte(String value) {
+        throwIfInvalidLiteral(value);
+        return (byte) parseIntegral(value, Type.BYTE);
+    }
+
+    public static short parseShort(String value) {
+        throwIfInvalidLiteral(value);
+        return (short) parseIntegral(value, Type.SHORT);
+    }
+
+    public static int parseInt(String value) {
+        throwIfInvalidLiteral(value);
+        return (int) parseIntegral(value, Type.INT);
+    }
+
+    public static long parseLong(String value) {
+        throwIfInvalidLiteral(value);
+        return parseIntegral(value, Type.LONG);
+    }
+
+    public static float parseFloat(String value) {
+        // TODO maybe just trim underscores?
+        return Float.parseFloat(value);
+    }
+
+    public static double parseDouble(String value) {
+        // TODO maybe just trim underscores?
+        return Double.parseDouble(value);
+    }
+
+    private static void throwIfInvalidLiteral(String value) {
+         if (!INTEGRAL_PATTERN.matcher(value).matches()) {
+             // Mimic parse* exception. The exact type will be shown in the second frame
+             throw new NumberFormatException("For input string: \"" + value + "\"");
+         }
+    }
+
+    private static long parseIntegral(String value, Type type) {
+        // Invariant: value matches INTEGRAL_PATTERN
+        value = value.replace("_", "");
+        if (value.startsWith("0b") || value.startsWith("0B")) { // Binary
+            String trimmed = value
+                    .replaceFirst("0b", "")
+                    .replaceFirst("0B", "");
+            return type.parse(trimmed, 2);
+        } else if (value.startsWith("0x") || value.startsWith("0X")) { // Hex
+            String trimmed = value
+                    .replaceFirst("0x", "")
+                    .replaceFirst("0X", "");
+            return type.parse(trimmed, 16);
+        } else if (value.startsWith("0") && value.length() > 1) { // Oct
+            String trimmed = value
+                    .replaceFirst("0", "");
+            return type.parse(trimmed, 8);
+        } else { // Dec
+            return type.parse(value, 10);
+        }
+    }
+
+    /**
+     * Checks whether the given value (received from arguments of `@Param()` annotation)
+     * complies the given primitive type.
+     */
+    static boolean isValidLiteral(String value, Type type) {
+        if (!INTEGRAL_PATTERN.matcher(value).matches()) {
+            return false;
+        }
+
+        try {
+            // Can pass the regex, but still be e.g. too wide for the type
+            parseIntegral(value, type);
+            return true;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    // Package-private, available only for StateObjectHandler for static check
+    enum Type {
+
+        BYTE {
+            @Override
+            public long parse(String value, int radix) {
+                return Byte.parseByte(value, radix);
+            }
+        },
+
+        SHORT {
+            @Override
+            public long parse(String value, int radix) {
+                return Short.parseShort(value, radix);
+            }
+        },
+
+        INT {
+            @Override
+            public long parse(String value, int radix) {
+                return Integer.parseInt(value, radix);
+            }
+        },
+
+        LONG {
+            @Override
+            public long parse(String value, int radix) {
+                return Long.parseLong(value, radix);
+            }
+        };
+
+        public abstract long parse(String value, int radix);
+    }
+}

--- a/jmh-core/src/main/java/org/openjdk/jmh/generators/core/StateObject.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/generators/core/StateObject.java
@@ -113,7 +113,6 @@ class StateObject {
     public String getParamAccessor(FieldInfo paramField) {
         String name = paramField.getName();
         String type = paramField.getType().getQualifiedName();
-
         if (type.equalsIgnoreCase("java.lang.String")) {
             return "control.getParam(\"" + name + "\")";
         }
@@ -121,25 +120,25 @@ class StateObject {
             return "Boolean.valueOf(control.getParam(\"" + name + "\"))";
         }
         if (type.equalsIgnoreCase("byte") || type.equalsIgnoreCase("java.lang.Byte")) {
-            return "Byte.valueOf(control.getParam(\"" + name + "\"))";
+            return "NumericLiteralsParser.parseByte(control.getParam(\"" + name + "\"))";
         }
         if (type.equalsIgnoreCase("char") || type.equalsIgnoreCase("java.lang.Character")) {
             return "(control.getParam(\"" + name + "\")).charAt(0)";
         }
         if (type.equalsIgnoreCase("short") || type.equalsIgnoreCase("java.lang.Short")) {
-            return "Short.valueOf(control.getParam(\"" + name + "\"))";
+            return "NumericLiteralsParser.parseShort(control.getParam(\"" + name + "\"))";
         }
         if (type.equalsIgnoreCase("int") || type.equalsIgnoreCase("java.lang.Integer")) {
-            return "Integer.valueOf(control.getParam(\"" + name + "\"))";
+            return "NumericLiteralsParser.parseInt(control.getParam(\"" + name + "\"))";
         }
         if (type.equalsIgnoreCase("float") || type.equalsIgnoreCase("java.lang.Float")) {
-            return "Float.valueOf(control.getParam(\"" + name + "\"))";
+            return "NumericLiteralsParser.parseFloat(control.getParam(\"" + name + "\"))";
         }
         if (type.equalsIgnoreCase("long") || type.equalsIgnoreCase("java.lang.Long")) {
-            return "Long.valueOf(control.getParam(\"" + name + "\"))";
+            return "NumericLiteralsParser.parseLong(control.getParam(\"" + name + "\"))";
         }
         if (type.equalsIgnoreCase("double") || type.equalsIgnoreCase("java.lang.Double")) {
-            return "Double.valueOf(control.getParam(\"" + name + "\"))";
+            return "NumericLiteralsParser.parseDouble(control.getParam(\"" + name + "\"))";
         }
 
         // assume enum

--- a/jmh-core/src/main/java/org/openjdk/jmh/generators/core/StateObjectHandler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/generators/core/StateObjectHandler.java
@@ -473,31 +473,16 @@ class StateObjectHandler {
             return (val.equals("true") || val.equals("false"));
         }
         if (typeName.equals("byte") || typeName.equals("java.lang.Byte")) {
-            try {
-                Byte.parseByte(val);
-                return true;
-            } catch (NumberFormatException nfe) {
-                return false;
-            }
+            return NumericLiteralsParser.isValidLiteral(val, NumericLiteralsParser.Type.BYTE);
         }
         if (typeName.equals("char") || typeName.equals("java.lang.Character")) {
             return (val.length() == 1);
         }
         if (typeName.equals("short") || typeName.equals("java.lang.Short")) {
-            try {
-                Short.parseShort(val);
-                return true;
-            } catch (NumberFormatException nfe) {
-                return false;
-            }
+            return NumericLiteralsParser.isValidLiteral(val, NumericLiteralsParser.Type.SHORT);
         }
         if (typeName.equals("int") || typeName.equals("java.lang.Integer")) {
-            try {
-                Integer.parseInt(val);
-                return true;
-            } catch (NumberFormatException nfe) {
-                return false;
-            }
+            return NumericLiteralsParser.isValidLiteral(val, NumericLiteralsParser.Type.INT);
         }
         if (typeName.equals("float") || typeName.equals("java.lang.Float")) {
             try {
@@ -508,12 +493,7 @@ class StateObjectHandler {
             }
         }
         if (typeName.equals("long") || typeName.equals("java.lang.Long")) {
-            try {
-                Long.parseLong(val);
-                return true;
-            } catch (NumberFormatException nfe) {
-                return false;
-            }
+            return NumericLiteralsParser.isValidLiteral(val, NumericLiteralsParser.Type.LONG);
         }
         if (typeName.equals("double") || typeName.equals("java.lang.Double")) {
             try {
@@ -527,7 +507,7 @@ class StateObjectHandler {
     }
 
     private void checkHelpers(MethodInfo mi, Class<? extends Annotation> annClass) {
-        // OK to have these annotation for @State objects
+        // OK to have these annotations for @State objects
         if (BenchmarkGeneratorUtils.getAnnSuper(mi.getDeclaringClass(), State.class) == null) {
             if (!mi.getDeclaringClass().isAbstract()) {
                 throw new GenerationException(

--- a/jmh-core/src/test/java/org/openjdk/jmh/generators/core/NumericLiteralsParserTest.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/generators/core/NumericLiteralsParserTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2014, 2015, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jmh.generators.core;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class NumericLiteralsParserTest {
+    @Test
+    public void testIntegerLiteral() {
+        testValidIntegerLiteral(10, "10");
+        testValidIntegerLiteral(1_0, "10");
+        testValidIntegerLiteral(1__0__0, "1__0__0");
+        testValidIntegerLiteral(0xFFF, "0xFFF");
+        testValidIntegerLiteral(0xF__F_F, "0xF__F_F");
+        testValidIntegerLiteral(0000, "0000");
+        testValidIntegerLiteral(0_1234, "0_1234");
+        testValidIntegerLiteral(0_12___3_4, "0_12___3_4");
+        testValidIntegerLiteral(0b0_000, "0b0_000");
+        testValidIntegerLiteral(0b0_1___00, "0b0_1___00");
+
+        testInvalidIntegerLiteral("_00");
+        testInvalidIntegerLiteral("00_");
+        testInvalidIntegerLiteral("123_");
+        testInvalidIntegerLiteral("0x_F");
+        testInvalidIntegerLiteral("0_xF");
+        testInvalidIntegerLiteral("0b1212");
+        testInvalidIntegerLiteral("09");
+        testInvalidIntegerLiteral("0_9");
+    }
+
+    private void testValidIntegerLiteral(int actualValue, String literal) {
+        Assert.assertTrue(NumericLiteralsParser.isValidLiteral(literal, NumericLiteralsParser.Type.INT));
+        assertEquals(actualValue, NumericLiteralsParser.parseInt(literal));
+    }
+
+    private void testInvalidIntegerLiteral(String literal) {
+        Assert.assertFalse(NumericLiteralsParser.isValidLiteral(literal, NumericLiteralsParser.Type.INT));
+        try {
+            NumericLiteralsParser.parseInt(literal);
+            fail();
+        } catch (NumberFormatException e) {
+            // Nothing
+        }
+    }
+}


### PR DESCRIPTION
This is a follow-up to https://mail.openjdk.java.net/pipermail/jmh-dev/2020-October/003039.html

I've prototyped it and found few corners which I'd like to highlight and discuss.

The initial purpose of the change is to be able to use underscores for the sake of better readability in both code and text reports:

`@Param("1_000", "10_000", "100_000")` 

and

```
Benchmark        (listSize)   Mode  Cnt      Score   Error  Units
ShowOff.consume       1_000  thrpt       42294.795          ops/s
ShowOff.consume      10_000  thrpt        4057.322          ops/s
ShowOff.consume     100_000  thrpt        2866.069          ops/s
```


While doing so, I've decided that it would be nice to support the strict subset of actual Java literals (at least to have a reference to point at) which has a lot of pitfalls:

* Now we have (?) to support octal, binary and hexadecimal literals
* The actual grammar is quite wild, so literals like `0_12___3_4` are also supported
* `l` and `L` at the end of `long` literals are not supported (it seems a bit weird to do so)
* `NumericLiteralsParser` leaks to public API, so the generated benchmarks can invoke it (not sure what's the API policy here, but it's worth pointing it out)
* Underscores in floating points literals are not supported, mostly because then I have to match hexadecimal literals with underscores as well. No particular reason apart from "it's extra work without clear benefits". I can implement it if it's required for the PR though.

Most importantly, support of such literals will break existing benchmarks that prefixed their numeric parameters with zero -- now they are interpreted as octal literals (and either rejected, e.g. `09` or converted to decimal, breaking the original authors intent). Previously, `X.parseX` functions (e.g. `Integer.parseInt`) were used and they are okay with leading zeroes.

Breaking change seems to be the blocker here, and I'd like to hear your opinion of the acceptable approach aligned with JMH API

Potential alternatives:

* Do nothing, don't support underscores
* Support only decimal literals
* Support any subset of literals (e.g. decimal and hexadecimal only)
* Just trim all the underscores and parse it as before via `Integer.parseInt` and so on

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/50/head:pull/50` \
`$ git checkout pull/50`

Update a local copy of the PR: \
`$ git checkout pull/50` \
`$ git pull https://git.openjdk.org/jmh.git pull/50/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 50`

View PR using the GUI difftool: \
`$ git pr show -t 50`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/50.diff">https://git.openjdk.org/jmh/pull/50.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/50#issuecomment-917427877)