### PR TITLE
Update Kotlin in Maven archetypes to the latest stable version

### DIFF
--- a/jmh-archetypes/jmh-kotlin-benchmark-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/jmh-archetypes/jmh-kotlin-benchmark-archetype/src/main/resources/archetype-resources/pom.xml
@@ -75,7 +75,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
            Available versions are listed here:
                 http://kotlinlang.org/docs/reference/using-maven.html#plugin-and-versions
          -->
-        <kotlin.version>1.0.2</kotlin.version>
+        <kotlin.version>1.5.30</kotlin.version>
 
         <!--
             Select a JMH benchmark generator to use. Available options:


### PR DESCRIPTION
Testing:

* `mvn install` in the JMH
* `mvn archetype:generate -DarchetypeCatalog=local -DinteractiveMode=false -DarchetypeGroupId=org.openjdk.jmh -DarchetypeArtifactId=jmh-kotlin-benchmark-archetype -DgroupId=org.qwwdfsad -DartifactId=qtest` in CMD
* `cd qtest`
* Ensure that `mvn install && java -jar target/benchmarks.jar` passes
* Ensure that `grep "1.5.30\|1.33-SNAPSHOT" pom.xml` prints two lines