### PR TITLE
CODETOOLS-7903056: perfasm can report wrong stub name

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/util/IntervalMap.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/util/IntervalMap.java
@@ -39,7 +39,33 @@ public class IntervalMap<T>  {
 
         @Override
         public int compareTo(Interval other) {
-            return (int)(this.from - other.from);
+            return Long.compare(from, other.from);
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + (int) (from ^ (from >>> 32));
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            Interval other = (Interval) obj;
+            if (from != other.from) {
+                return false;
+            }
+            return true;
         }
     }
 

--- a/jmh-core/src/main/java/org/openjdk/jmh/util/IntervalMap.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/util/IntervalMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,21 @@ import java.util.TreeMap;
 
 public class IntervalMap<T>  {
 
-    final SortedMap<Long, T> from;
+    static final class Interval implements Comparable<Interval> {
+        final long from, to;
+
+        public Interval(long from, long to) {
+            this.from = from;
+            this.to = to;
+        }
+
+        @Override
+        public int compareTo(Interval other) {
+            return (int)(this.from - other.from);
+        }
+    }
+
+    final SortedMap<Interval, T> from;
 
     public IntervalMap() {
         from = new TreeMap<>();
@@ -37,19 +51,25 @@ public class IntervalMap<T>  {
 
     public void add(T val, long from, long to) {
         // TODO: Check for intersections
-        this.from.put(from, val);
+        this.from.put(new Interval(from, to), val);
     }
 
     public T get(long k) {
-        T key = from.get(k);
+        Interval i = new Interval(k, k);
+        T key = from.get(i);
         if (key != null) {
             return key;
         }
-        SortedMap<Long, T> head = from.headMap(k);
+        SortedMap<Interval, T> head = from.headMap(i);
         if (head.isEmpty()) {
             return null;
         } else {
-            return from.get(head.lastKey());
+            Interval last = head.lastKey();
+            if (k >= last.from && k < last.to) {
+                return from.get(last);  // Interval from..to contains k
+            } else {
+                return null;
+            }
         }
     }
 


### PR DESCRIPTION
This patch changes `IntervalMap::get` to check that the value falls within an interval's high/low bounds. Otherwise it returns the closest entry < value which can be misleading.

Example of the new output, where previously the `<unknown>` line reported the wrong stub routine:

```
 18.19%           libjvm.so  ProgrammableUpcallHandler::on_entry
 13.94%                      <unknown>
  9.39%           libjvm.so  ProgrammableUpcallHandler::on_exit
  8.36%         c2, level 4  java.lang.invoke.LambdaForm$MH.0x00000008001b8400::invoke, version 1595
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903056](https://bugs.openjdk.java.net/browse/CODETOOLS-7903056): perfasm can report wrong stub name


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmh pull/54/head:pull/54` \
`$ git checkout pull/54`

Update a local copy of the PR: \
`$ git checkout pull/54` \
`$ git pull https://git.openjdk.java.net/jmh pull/54/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 54`

View PR using the GUI difftool: \
`$ git pr show -t 54`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmh/pull/54.diff">https://git.openjdk.java.net/jmh/pull/54.diff</a>

</details>
