### PR TITLE
7903067: JMH: Improve English grammar in error messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.iml
 target/
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 *.iml
 target/
-.idea/

--- a/jmh-core/src/main/java/org/openjdk/jmh/generators/core/BenchmarkGenerator.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/generators/core/BenchmarkGenerator.java
@@ -259,7 +259,7 @@ public class BenchmarkGenerator {
                 throw new GenerationException(
                         "Field \"" + fi.getName() + "\" is declared within " +
                                 "a class not having @" + State.class.getSimpleName() + " annotation. " +
-                                "This can result in unspecified behavior and is prohibited.", fi);
+                                "This is prohibited because it can result in unspecified behavior.", fi);
             }
         }
 

--- a/jmh-core/src/main/java/org/openjdk/jmh/generators/core/BenchmarkGenerator.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/generators/core/BenchmarkGenerator.java
@@ -318,7 +318,7 @@ public class BenchmarkGenerator {
             if (m.getAnnotation(Group.class) != null && m.getAnnotation(Threads.class) != null) {
                 throw new GenerationException("@" + Threads.class.getSimpleName() + " annotation is placed within " +
                         "the benchmark method with @" + Group.class.getSimpleName() + " annotation. " +
-                        "This has ambiguous behavioral effect and is prohibited. " +
+                        "This is prohibited because it is ambiguous. " +
                         "Did you mean @" + GroupThreads.class.getSimpleName() + " instead?",
                         m);
             }

--- a/jmh-core/src/main/java/org/openjdk/jmh/generators/core/BenchmarkGenerator.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/generators/core/BenchmarkGenerator.java
@@ -258,8 +258,8 @@ public class BenchmarkGenerator {
                 if (fi.isStatic()) continue;
                 throw new GenerationException(
                         "Field \"" + fi.getName() + "\" is declared within " +
-                                "the class not having @" + State.class.getSimpleName() + " annotation. " +
-                                "This can result in unspecified behavior, and prohibited.", fi);
+                                "a class not having @" + State.class.getSimpleName() + " annotation. " +
+                                "This can result in unspecified behavior and is prohibited.", fi);
             }
         }
 
@@ -318,7 +318,7 @@ public class BenchmarkGenerator {
             if (m.getAnnotation(Group.class) != null && m.getAnnotation(Threads.class) != null) {
                 throw new GenerationException("@" + Threads.class.getSimpleName() + " annotation is placed within " +
                         "the benchmark method with @" + Group.class.getSimpleName() + " annotation. " +
-                        "This has ambiguous behavioral effect, and prohibited. " +
+                        "This has ambiguous behavioral effect and is prohibited. " +
                         "Did you mean @" + GroupThreads.class.getSimpleName() + " instead?",
                         m);
             }

--- a/jmh-core/src/main/java/org/openjdk/jmh/generators/core/StateObjectHandler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/generators/core/StateObjectHandler.java
@@ -533,7 +533,7 @@ class StateObjectHandler {
                 throw new GenerationException(
                         "@" + annClass.getSimpleName() + " annotation is placed within " +
                                 "a class not having @" + State.class.getSimpleName() + " annotation. " +
-                                "This has no behavioral effect and is prohibited.",
+                                "This is prohibited because it would have no effect.",
                         mi);
             }
         }

--- a/jmh-core/src/main/java/org/openjdk/jmh/generators/core/StateObjectHandler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/generators/core/StateObjectHandler.java
@@ -532,8 +532,8 @@ class StateObjectHandler {
             if (!mi.getDeclaringClass().isAbstract()) {
                 throw new GenerationException(
                         "@" + annClass.getSimpleName() + " annotation is placed within " +
-                                "the class not having @" + State.class.getSimpleName() + " annotation. " +
-                                "This has no behavioral effect, and prohibited.",
+                                "a class not having @" + State.class.getSimpleName() + " annotation. " +
+                                "This has no behavioral effect and is prohibited.",
                         mi);
             }
         }


### PR DESCRIPTION
I improved the English grammar in a few error messages
/signed
/integrate

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903067](https://bugs.openjdk.java.net/browse/CODETOOLS-7903067): JMH: Improve English grammar in error messages


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmh pull/56/head:pull/56` \
`$ git checkout pull/56`

Update a local copy of the PR: \
`$ git checkout pull/56` \
`$ git pull https://git.openjdk.java.net/jmh pull/56/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 56`

View PR using the GUI difftool: \
`$ git pr show -t 56`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmh/pull/56.diff">https://git.openjdk.java.net/jmh/pull/56.diff</a>

</details>
