### PR TITLE
CODETOOLS-7903068: JMH: Enable compiler blackholes by default, if available

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/CompilerHints.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/CompilerHints.java
@@ -51,7 +51,7 @@ public class CompilerHints extends AbstractResourceReader {
     static final String BLACKHOLE_DEBUG_NAME      = "jmh.blackhole.debug";
 
     static final boolean BLACKHOLE_MODE_AUTODETECT =
-            Boolean.parseBoolean(System.getProperty(BLACKHOLE_AUTODETECT_NAME, "false"));
+            Boolean.parseBoolean(System.getProperty(BLACKHOLE_AUTODETECT_NAME, "true"));
     static final boolean BLACKHOLE_MODE_DEBUG =
             Boolean.parseBoolean(System.getProperty(BLACKHOLE_DEBUG_NAME, "false"));
 
@@ -322,8 +322,8 @@ public class CompilerHints extends AbstractResourceReader {
     }
 
     private enum BlackholeSelect {
-        DEFAULT("default, use -D" + BLACKHOLE_AUTODETECT_NAME + "=true to auto-detect"),
-        AUTO("auto-detected"),
+        DEFAULT("default"),
+        AUTO("auto-detected, use -D" + BLACKHOLE_AUTODETECT_NAME + "=false to disable"),
         FALLBACK("fallback, use -D" + BLACKHOLE_MODE_NAME + " to force"),
         FORCED("forced"),
         ;

--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/CompilerHints.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/CompilerHints.java
@@ -275,17 +275,16 @@ public class CompilerHints extends AbstractResourceReader {
         if (BLACKHOLE_MODE_AUTODETECT) {
             if (compilerBlackholesAvailable()) {
                 blackholeMode = BlackholeMode.COMPILER;
-                blackholeSelect = BlackholeSelect.AUTO;
             } else {
                 blackholeMode = BlackholeMode.FULL_DONTINLINE;
-                blackholeSelect = BlackholeSelect.FALLBACK;
             }
+            blackholeSelect = BlackholeSelect.AUTO;
             return blackholeMode;
         }
 
-        // Not forced, not auto-detected, default
+        // Not forced, not auto-detected, fallback
         blackholeMode = BlackholeMode.FULL_DONTINLINE;
-        blackholeSelect = BlackholeSelect.DEFAULT;
+        blackholeSelect = BlackholeSelect.FALLBACK;
         return blackholeMode;
     }
 
@@ -322,7 +321,6 @@ public class CompilerHints extends AbstractResourceReader {
     }
 
     private enum BlackholeSelect {
-        DEFAULT("default"),
         AUTO("auto-detected, use -D" + BLACKHOLE_AUTODETECT_NAME + "=false to disable"),
         FALLBACK("fallback, use -D" + BLACKHOLE_MODE_NAME + " to force"),
         FORCED("forced"),


### PR DESCRIPTION
With the release of JDK 17, we can finally consider enabling [compiler blackholes](https://shipilev.net/jvm/anatomy-quarks/27-compiler-blackholes/) by default.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903068](https://bugs.openjdk.java.net/browse/CODETOOLS-7903068): JMH: Enable compiler blackholes by default, if available


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmh pull/57/head:pull/57` \
`$ git checkout pull/57`

Update a local copy of the PR: \
`$ git checkout pull/57` \
`$ git pull https://git.openjdk.java.net/jmh pull/57/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 57`

View PR using the GUI difftool: \
`$ git pr show -t 57`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmh/pull/57.diff">https://git.openjdk.java.net/jmh/pull/57.diff</a>

</details>
