### PR TITLE
CODETOOLS-7903072: ForkedMain.nakedErr is not initialized on some paths

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/ForkedMain.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/ForkedMain.java
@@ -55,6 +55,9 @@ class ForkedMain {
         if (argv.length != 2) {
             throw new IllegalArgumentException("Expected two arguments for forked VM");
         } else {
+            // capture nakedErr early, so that hangup/shutdown threads could use it
+            nakedErr = System.err;
+
             // arm the hangup thread
             Runtime.getRuntime().addShutdownHook(new HangupThread());
 
@@ -75,7 +78,6 @@ class ForkedMain {
                 Options options = link.handshake();
 
                 // dump outputs into binary link
-                nakedErr = System.err;
                 System.setErr(link.getErrStream());
                 System.setOut(link.getOutStream());
 


### PR DESCRIPTION
From the description:

```
Sometimes jmh fails with
[jmh] Exception in thread "Thread-0" java.lang.NullPointerException: Cannot enter synchronized block because the return value of "java.lang.Throwable$PrintStreamOrWriter.lock()" is null
[jmh] at java.base/java.lang.Throwable.printStackTrace(Throwable.java:668)
[jmh] at java.base/java.lang.Throwable.printStackTrace(Throwable.java:659)
[jmh] at org.openjdk.jmh.runner.ForkedMain.hangup(ForkedMain.java:129)
[jmh] at org.openjdk.jmh.runner.ForkedMain$HangupThread.run(ForkedMain.java:157) 
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903072](https://bugs.openjdk.java.net/browse/CODETOOLS-7903072): ForkedMain.nakedErr is not initialized on some paths


### Reviewers
 * [Leonid Mesnik](https://openjdk.java.net/census#lmesnik) (@lmesnik - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmh pull/58/head:pull/58` \
`$ git checkout pull/58`

Update a local copy of the PR: \
`$ git checkout pull/58` \
`$ git pull https://git.openjdk.java.net/jmh pull/58/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 58`

View PR using the GUI difftool: \
`$ git pr show -t 58`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmh/pull/58.diff">https://git.openjdk.java.net/jmh/pull/58.diff</a>

</details>
