### PR TITLE
CODETOOLS-7903092: JMH: Improve perfasm method metadata

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/util/CountingMap.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/util/CountingMap.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jmh.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class CountingMap<K> {
+
+    final Map<K, MutableInt> map = new HashMap<>();
+
+    public int incrementAndGet(K k) {
+        MutableInt mi = map.get(k);
+        if (mi == null) {
+            mi = new MutableInt();
+            map.put(k, mi);
+        }
+        return mi.incrementAndGet();
+    }
+
+    private static class MutableInt {
+        int value;
+        int incrementAndGet() {
+            return ++value;
+        }
+    }
+
+}


### PR DESCRIPTION
Currently we only print compilation IDs, which are globally numbered across the entire JIT. For performance investigations, it is more useful to know that is the *per method* version number.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903092](https://bugs.openjdk.java.net/browse/CODETOOLS-7903092): JMH: Improve perfasm method metadata


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmh pull/59/head:pull/59` \
`$ git checkout pull/59`

Update a local copy of the PR: \
`$ git checkout pull/59` \
`$ git pull https://git.openjdk.java.net/jmh pull/59/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 59`

View PR using the GUI difftool: \
`$ git pr show -t 59`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmh/pull/59.diff">https://git.openjdk.java.net/jmh/pull/59.diff</a>

</details>
