### PR TITLE
CODETOOLS-7903094: JMH: Replace Math.log with predictable code in samples

### DIFF
--- a/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_08_DeadCode.java
+++ b/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_08_DeadCode.java
@@ -57,6 +57,13 @@ public class JMHSample_08_DeadCode {
 
     private double x = Math.PI;
 
+    private double compute(double d) {
+        for (int c = 0; c < 10; c++) {
+            d = d * d / Math.PI;
+        }
+        return d;
+    }
+
     @Benchmark
     public void baseline() {
         // do nothing, this is a baseline
@@ -65,13 +72,13 @@ public class JMHSample_08_DeadCode {
     @Benchmark
     public void measureWrong() {
         // This is wrong: result is not used and the entire computation is optimized away.
-        Math.log(x);
+        compute(x);
     }
 
     @Benchmark
     public double measureRight() {
         // This is correct: the result is being used.
-        return Math.log(x);
+        return compute(x);
     }
 
     /*

--- a/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_09_Blackholes.java
+++ b/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_09_Blackholes.java
@@ -56,24 +56,31 @@ public class JMHSample_09_Blackholes {
     double x1 = Math.PI;
     double x2 = Math.PI * 2;
 
+    private double compute(double d) {
+        for (int c = 0; c < 10; c++) {
+            d = d * d / Math.PI;
+        }
+        return d;
+    }
+
     /*
-     * Baseline measurement: how much single Math.log costs.
+     * Baseline measurement: how much a single compute() costs.
      */
 
     @Benchmark
     public double baseline() {
-        return Math.log(x1);
+        return compute(x1);
     }
 
     /*
-     * While the Math.log(x2) computation is intact, Math.log(x1)
+     * While the compute(x2) computation is intact, compute(x1)
      * is redundant and optimized out.
      */
 
     @Benchmark
     public double measureWrong() {
-        Math.log(x1);
-        return Math.log(x2);
+        compute(x1);
+        return compute(x2);
     }
 
     /*
@@ -86,7 +93,7 @@ public class JMHSample_09_Blackholes {
 
     @Benchmark
     public double measureRight_1() {
-        return Math.log(x1) + Math.log(x2);
+        return compute(x1) + compute(x2);
     }
 
     /*
@@ -98,8 +105,8 @@ public class JMHSample_09_Blackholes {
 
     @Benchmark
     public void measureRight_2(Blackhole bh) {
-        bh.consume(Math.log(x1));
-        bh.consume(Math.log(x2));
+        bh.consume(compute(x1));
+        bh.consume(compute(x2));
     }
 
     /*

--- a/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_10_ConstantFold.java
+++ b/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_10_ConstantFold.java
@@ -63,6 +63,13 @@ public class JMHSample_10_ConstantFold {
     // (While this is normally fine advice, it does not work in the context of measuring correctly.)
     private final double wrongX = Math.PI;
 
+    private double compute(double d) {
+        for (int c = 0; c < 10; c++) {
+            d = d * d / Math.PI;
+        }
+        return d;
+    }
+
     @Benchmark
     public double baseline() {
         // simply return the value, this is a baseline
@@ -72,19 +79,19 @@ public class JMHSample_10_ConstantFold {
     @Benchmark
     public double measureWrong_1() {
         // This is wrong: the source is predictable, and computation is foldable.
-        return Math.log(Math.PI);
+        return compute(Math.PI);
     }
 
     @Benchmark
     public double measureWrong_2() {
         // This is wrong: the source is predictable, and computation is foldable.
-        return Math.log(wrongX);
+        return compute(wrongX);
     }
 
     @Benchmark
     public double measureRight() {
         // This is correct: the source is not predictable.
-        return Math.log(x);
+        return compute(x);
     }
 
     /*

--- a/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_28_BlackholeHelpers.java
+++ b/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_28_BlackholeHelpers.java
@@ -76,6 +76,13 @@ public class JMHSample_28_BlackholeHelpers {
     private Worker workerRight;
     private Worker workerWrong;
 
+    private double compute(double d) {
+        for (int c = 0; c < 10; c++) {
+            d = d * d / Math.PI;
+        }
+        return d;
+    }
+
     @Setup
     public void setup(final Blackhole bh) {
         workerBaseline = new Worker() {
@@ -92,7 +99,7 @@ public class JMHSample_28_BlackholeHelpers {
 
             @Override
             public void work() {
-                Math.log(x);
+                compute(x);
             }
         };
 
@@ -101,7 +108,7 @@ public class JMHSample_28_BlackholeHelpers {
 
             @Override
             public void work() {
-                bh.consume(Math.log(x));
+                bh.consume(compute(x));
             }
         };
 


### PR DESCRIPTION
Looks like `Math.log` is no longer intrinsified into C2 IR, so dead code / constant fold examples no longer work. It seems to have started since JDK 9 and [JDK-8152907](https://bugs.openjdk.java.net/browse/JDK-8152907) that now defers the computation of `Math.log` to quick LIBM stub. It does, however, limits the compiler optimizations around the Math.log, and samples do not work properly. The samples should not rely on JDK internals, and should just use the custom written payload.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903094](https://bugs.openjdk.java.net/browse/CODETOOLS-7903094): JMH: Replace Math.log with predictable code in samples


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmh pull/60/head:pull/60` \
`$ git checkout pull/60`

Update a local copy of the PR: \
`$ git checkout pull/60` \
`$ git pull https://git.openjdk.java.net/jmh pull/60/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 60`

View PR using the GUI difftool: \
`$ git pr show -t 60`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmh/pull/60.diff">https://git.openjdk.java.net/jmh/pull/60.diff</a>

</details>
