### PR TITLE
CODETOOLS-7903100: JMH: SingleShot mode should handle OperationsPerInvocations > 1

### DIFF
--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/batchsize/OpsPerInvSanityTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/batchsize/OpsPerInvSanityTest.java
@@ -118,10 +118,8 @@ public class OpsPerInvSanityTest {
                 break;
             case AverageTime:
             case SampleTime:
-                expectedScore = 1.0 * realTime / (realOps * opsPerInv);
-                break;
             case SingleShotTime:
-                expectedScore = 1.0 * realTime / realOps;
+                expectedScore = 1.0 * realTime / (realOps * opsPerInv);
                 break;
             default:
                 expectedScore = Double.NaN;

--- a/jmh-core/src/main/java/org/openjdk/jmh/generators/core/BenchmarkGenerator.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/generators/core/BenchmarkGenerator.java
@@ -1024,10 +1024,10 @@ public class BenchmarkGenerator {
 
             writer.println(ident(3) + "BenchmarkTaskResult results = new BenchmarkTaskResult(totalOps, totalOps);");
             if (isSingleMethod) {
-                writer.println(ident(3) + "results.add(new SingleShotResult(ResultRole.PRIMARY, \"" + method.getName() + "\", res.getTime(), benchmarkParams.getTimeUnit()));");
+                writer.println(ident(3) + "results.add(new SingleShotResult(ResultRole.PRIMARY, \"" + method.getName() + "\", res.getTime(), totalOps, benchmarkParams.getTimeUnit()));");
             } else {
-                writer.println(ident(3) + "results.add(new SingleShotResult(ResultRole.PRIMARY, \"" + methodGroup.getName() + "\", res.getTime(), benchmarkParams.getTimeUnit()));");
-                writer.println(ident(3) + "results.add(new SingleShotResult(ResultRole.SECONDARY, \"" + method.getName() + "\", res.getTime(), benchmarkParams.getTimeUnit()));");
+                writer.println(ident(3) + "results.add(new SingleShotResult(ResultRole.PRIMARY, \"" + methodGroup.getName() + "\", res.getTime(), totalOps, benchmarkParams.getTimeUnit()));");
+                writer.println(ident(3) + "results.add(new SingleShotResult(ResultRole.SECONDARY, \"" + method.getName() + "\", res.getTime(), totalOps, benchmarkParams.getTimeUnit()));");
             }
             addAuxCounters(writer, "SingleShotResult", states, method);
 

--- a/jmh-core/src/main/java/org/openjdk/jmh/results/SingleShotResult.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/results/SingleShotResult.java
@@ -38,8 +38,13 @@ public class SingleShotResult extends Result<SingleShotResult> {
     private static final long serialVersionUID = -1251578870918524737L;
 
     public SingleShotResult(ResultRole role, String label, long duration, TimeUnit outputTimeUnit) {
+        // TODO: Transition interface, should be removed when we decide it is OK to break the publicly leaked API.
+        this(role, label, duration, 1, outputTimeUnit);
+    }
+
+    public SingleShotResult(ResultRole role, String label, long duration, long ops, TimeUnit outputTimeUnit) {
         this(role, label,
-                of(1.0D * duration / TimeUnit.NANOSECONDS.convert(1, outputTimeUnit)),
+                of(1.0D * duration / ops / TimeUnit.NANOSECONDS.convert(1, outputTimeUnit)),
                 TimeValue.tuToString(outputTimeUnit) + "/op");
     }
 

--- a/jmh-core/src/test/java/org/openjdk/jmh/results/ResultAggregationTest.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/results/ResultAggregationTest.java
@@ -149,10 +149,10 @@ public class ResultAggregationTest {
     @Test
     public void testSingleShot() {
         IterationResult ir = new IterationResult(null, null, null);
-        ir.addResult(new SingleShotResult(ResultRole.PRIMARY, "", 10_000, TimeUnit.NANOSECONDS));
-        ir.addResult(new SingleShotResult(ResultRole.PRIMARY, "", 10_000, TimeUnit.NANOSECONDS));
-        ir.addResult(new SingleShotResult(ResultRole.SECONDARY, "sec", 5_000, TimeUnit.NANOSECONDS));
-        ir.addResult(new SingleShotResult(ResultRole.SECONDARY, "sec", 5_000, TimeUnit.NANOSECONDS));
+        ir.addResult(new SingleShotResult(ResultRole.PRIMARY, "", 10_000, 1, TimeUnit.NANOSECONDS));
+        ir.addResult(new SingleShotResult(ResultRole.PRIMARY, "", 10_000, 1, TimeUnit.NANOSECONDS));
+        ir.addResult(new SingleShotResult(ResultRole.SECONDARY, "sec", 5_000, 1, TimeUnit.NANOSECONDS));
+        ir.addResult(new SingleShotResult(ResultRole.SECONDARY, "sec", 5_000, 1, TimeUnit.NANOSECONDS));
         Assert.assertEquals(10_000.0, ir.getPrimaryResult().getScore(), ASSERT_ACCURACY);
         Assert.assertEquals(5_000.0, ir.getSecondaryResults().get("sec").getScore(), ASSERT_ACCURACY);
         Assert.assertEquals(2, ir.getPrimaryResult().getSampleCount());
@@ -161,7 +161,7 @@ public class ResultAggregationTest {
         Assert.assertEquals(2, ir.getRawSecondaryResults().get("sec").size());
 
         BenchmarkResult br = new BenchmarkResult(null, Arrays.asList(ir, ir));
-        br.addBenchmarkResult(new SingleShotResult(ResultRole.SECONDARY, "bench", 3_000, TimeUnit.NANOSECONDS));
+        br.addBenchmarkResult(new SingleShotResult(ResultRole.SECONDARY, "bench", 3_000, 1, TimeUnit.NANOSECONDS));
         Assert.assertEquals(10_000.0, br.getPrimaryResult().getScore(), ASSERT_ACCURACY);
         Assert.assertEquals(5_000.0, br.getSecondaryResults().get("sec").getScore(), ASSERT_ACCURACY);
         Assert.assertEquals(3_000.0, br.getSecondaryResults().get("bench").getScore(), ASSERT_ACCURACY);

--- a/jmh-core/src/test/java/org/openjdk/jmh/results/TestSingleShotResult.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/results/TestSingleShotResult.java
@@ -37,8 +37,8 @@ public class TestSingleShotResult {
 
     @Test
     public void testIterationAggregator1() {
-        SingleShotResult r1 = new SingleShotResult(ResultRole.PRIMARY, "Test1", 1000L, TimeUnit.MICROSECONDS);
-        SingleShotResult r2 = new SingleShotResult(ResultRole.PRIMARY, "Test1", 2000L, TimeUnit.MICROSECONDS);
+        SingleShotResult r1 = new SingleShotResult(ResultRole.PRIMARY, "Test1", 1000L, 1, TimeUnit.MICROSECONDS);
+        SingleShotResult r2 = new SingleShotResult(ResultRole.PRIMARY, "Test1", 2000L, 1, TimeUnit.MICROSECONDS);
         Result result = r1.getIterationAggregator().aggregate(Arrays.asList(r1, r2));
 
         assertEquals(1.5, result.getScore(), ASSERT_ACCURACY);
@@ -47,12 +47,21 @@ public class TestSingleShotResult {
 
     @Test
     public void testThreadAggregator1() {
-        SingleShotResult r1 = new SingleShotResult(ResultRole.PRIMARY, "Test1", 1000L, TimeUnit.MICROSECONDS);
-        SingleShotResult r2 = new SingleShotResult(ResultRole.PRIMARY, "Test1", 2000L, TimeUnit.MICROSECONDS);
+        SingleShotResult r1 = new SingleShotResult(ResultRole.PRIMARY, "Test1", 1000L, 1, TimeUnit.MICROSECONDS);
+        SingleShotResult r2 = new SingleShotResult(ResultRole.PRIMARY, "Test1", 2000L, 1, TimeUnit.MICROSECONDS);
         Result result = r1.getThreadAggregator().aggregate(Arrays.asList(r1, r2));
 
         assertEquals(1.5, result.getScore(), ASSERT_ACCURACY);
         assertEquals("us/op", result.getScoreUnit());
+    }
+
+    @Test
+    public void testMultiops() {
+        SingleShotResult r1 = new SingleShotResult(ResultRole.PRIMARY, "Test1", 1000L, 1, TimeUnit.MICROSECONDS);
+        SingleShotResult r2 = new SingleShotResult(ResultRole.PRIMARY, "Test1", 1000L, 2, TimeUnit.MICROSECONDS);
+
+        assertEquals(1, r1.getScore(), ASSERT_ACCURACY);
+        assertEquals(0.5, r2.getScore(), ASSERT_ACCURACY);
     }
 
 }


### PR DESCRIPTION
There seems to be a corner case in SingleShot mode handling: while the internal code handles OperationsPerInvocations > 1 for e.g. profilers normalization with BenchmarkTaskResult, OPI > 1 does not affect the score.

Unfortunately, the fix involves modifying a constructor in SingleShotResult, which raises a minor compatibility question. We can side-step it for a while by adding the constructor overload.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903100](https://bugs.openjdk.java.net/browse/CODETOOLS-7903100): JMH: SingleShot mode should handle OperationsPerInvocations > 1


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmh pull/61/head:pull/61` \
`$ git checkout pull/61`

Update a local copy of the PR: \
`$ git checkout pull/61` \
`$ git pull https://git.openjdk.java.net/jmh pull/61/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 61`

View PR using the GUI difftool: \
`$ git pr show -t 61`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmh/pull/61.diff">https://git.openjdk.java.net/jmh/pull/61.diff</a>

</details>
