### PR TITLE
CODETOOLS-7903109: JMH: perfasm "freq" should accept "max" as the option

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfAsmProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfAsmProfiler.java
@@ -39,9 +39,9 @@ import java.util.*;
 
 public class LinuxPerfAsmProfiler extends AbstractPerfAsmProfiler {
 
-    private final long sampleFrequency;
+    private final String sampleFrequency;
 
-    private OptionSpec<Long> optFrequency;
+    private OptionSpec<String> optFrequency;
 
     public LinuxPerfAsmProfiler(String initLine) throws ProfilerException {
         super(initLine, "cycles");
@@ -61,8 +61,9 @@ public class LinuxPerfAsmProfiler extends AbstractPerfAsmProfiler {
     @Override
     protected void addMyOptions(OptionParser parser) {
         optFrequency = parser.accepts("frequency",
-                "Sampling frequency. This is synonymous to perf record --freq #")
-                .withRequiredArg().ofType(Long.class).describedAs("freq").defaultsTo(1000L);
+                "Sampling frequency, synonymous to perf record --freq #; " +
+                        "use \"max\" for highest sampling rate possible on the system.")
+                .withRequiredArg().ofType(String.class).describedAs("freq").defaultsTo("1000");
     }
 
     @Override


### PR DESCRIPTION
Linux perf record accepts "max" as the max sampling frequency possible on the system. JMH perfasm should accept it too. Defaulting to "max" is probably counter-productive at this point, because it probably comes with additional profiling overhead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903109](https://bugs.openjdk.java.net/browse/CODETOOLS-7903109): JMH: perfasm "freq" should accept "max" as the option


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmh pull/64/head:pull/64` \
`$ git checkout pull/64`

Update a local copy of the PR: \
`$ git checkout pull/64` \
`$ git pull https://git.openjdk.java.net/jmh pull/64/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 64`

View PR using the GUI difftool: \
`$ git pr show -t 64`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmh/pull/64.diff">https://git.openjdk.java.net/jmh/pull/64.diff</a>

</details>
