### PR TITLE
7903125: JMH: async profiler uses wrong option for profiler output

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/AsyncProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/AsyncProfiler.java
@@ -251,7 +251,6 @@ public final class AsyncProfiler implements ExternalProfiler, InternalProfiler {
             direction = optDirection.value(set);
 
             output = optOutput.values(set);
-            builder.appendMulti(optOutput);
 
             // Secondary events are those that may be collected simultaneously with a primary event in a JFR profile.
             // To be used as such, we require they are specifed with the lock and alloc option, rather than event=lock,

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/AsyncProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/AsyncProfiler.java
@@ -369,7 +369,11 @@ public final class AsyncProfiler implements ExternalProfiler, InternalProfiler {
             switch (outputType) {
                 case text:
                     File out = outputFile("summary-%s.txt");
-                    dump(out, "summary,flat=" + flat + ",traces=" + traces);
+                    if (isVersion1x) {
+                        dump(out, "summary,flat=" + flat + ",traces=" + traces);
+                    } else {
+                        dump(out, "flat=" + flat + ",traces=" + traces);
+                    }
                     try {
                         for (String line : FileUtils.readAllLines(out)) {
                             pw.println(line);


### PR DESCRIPTION
Previously, the jmh will call async-profiler with output=flamegraph,
which the 'output' option is not a valid option for both async-profiler
v1 and v2.

For jfr format, this class will call the profiler with
'start,file=name.jfr', async-profiler can get the output format from the
extension corretly, so we don't need to have a redundant option like
'start,jfr,file=name.jfr'.

For other formats like flamegraph, this class call the dump separately
with the format option included in the option, like
`flamegraph,file=dump.html`.

**Reference**

- v1: https://github.com/jvm-profiling-tools/async-profiler/blob/v1.8.7/src/arguments.cpp
- v2: https://github.com/jvm-profiling-tools/async-profiler/blob/v2.7/src/arguments.cpp

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903125](https://bugs.openjdk.java.net/browse/CODETOOLS-7903125): JMH: async profiler uses wrong option for profiler output


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - Committer) ⚠️ Review applies to d3b9cb51635e1846ca2a7c44bdf9869df1ada5e0


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmh pull/65/head:pull/65` \
`$ git checkout pull/65`

Update a local copy of the PR: \
`$ git checkout pull/65` \
`$ git pull https://git.openjdk.java.net/jmh pull/65/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 65`

View PR using the GUI difftool: \
`$ git pr show -t 65`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmh/pull/65.diff">https://git.openjdk.java.net/jmh/pull/65.diff</a>

</details>
