### PR TITLE
7903127: JMH: SecurityManager tests fail on modern JDK

### DIFF
--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/security/BenchmarkMinRunnerSecurityManagerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/security/BenchmarkMinRunnerSecurityManagerTest.java
@@ -62,7 +62,7 @@ public class BenchmarkMinRunnerSecurityManagerTest {
     public void invokeAPI() throws RunnerException, URISyntaxException, NoSuchAlgorithmException {
         URI policyFile = BenchmarkMinRunnerSecurityManagerTest.class.getResource("/jmh-security-minimal-runner.policy").toURI();
         Policy.setPolicy(Policy.getInstance("JavaPolicy", new URIParameter(policyFile)));
-        System.setSecurityManager(new SecurityManager());
+        SecurityManagerTestUtils.install();
 
         try {
             Options opts = new OptionsBuilder()
@@ -71,7 +71,7 @@ public class BenchmarkMinRunnerSecurityManagerTest {
                     .build();
             new Runner(opts).run();
         } finally {
-            System.setSecurityManager(null);
+            SecurityManagerTestUtils.remove();
         }
     }
 

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/security/BenchmarkMinSecurityManagerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/security/BenchmarkMinSecurityManagerTest.java
@@ -57,12 +57,12 @@ public class BenchmarkMinSecurityManagerTest {
         Fixtures.work();
         URI policyFile = BenchmarkMinSecurityManagerTest.class.getResource("/jmh-security-minimal.policy").toURI();
         Policy.setPolicy(Policy.getInstance("JavaPolicy", new URIParameter(policyFile)));
-        System.setSecurityManager(new SecurityManager());
+        SecurityManagerTestUtils.install();
     }
 
     @TearDown
     public void tearDown() {
-        System.setSecurityManager(null);
+        SecurityManagerTestUtils.remove();
     }
 
     @Benchmark

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/security/BenchmarkSecurityManagerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/security/BenchmarkSecurityManagerTest.java
@@ -57,12 +57,12 @@ public class BenchmarkSecurityManagerTest {
         Fixtures.work();
         URI policyFile = BenchmarkSecurityManagerTest.class.getResource("/jmh-security.policy").toURI();
         Policy.setPolicy(Policy.getInstance("JavaPolicy", new URIParameter(policyFile)));
-        System.setSecurityManager(new SecurityManager());
+        SecurityManagerTestUtils.install();
     }
 
     @TearDown
     public void tearDown() {
-        System.setSecurityManager(null);
+        SecurityManagerTestUtils.remove();
     }
 
     @Benchmark

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/security/GroupMinRunnerSecurityManagerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/security/GroupMinRunnerSecurityManagerTest.java
@@ -66,7 +66,7 @@ public class GroupMinRunnerSecurityManagerTest {
     public void invokeAPI() throws RunnerException, URISyntaxException, NoSuchAlgorithmException {
         URI policyFile = GroupMinRunnerSecurityManagerTest.class.getResource("/jmh-security-minimal-runner.policy").toURI();
         Policy.setPolicy(Policy.getInstance("JavaPolicy", new URIParameter(policyFile)));
-        System.setSecurityManager(new SecurityManager());
+        SecurityManagerTestUtils.install();
 
         try {
             Options opts = new OptionsBuilder()
@@ -75,7 +75,7 @@ public class GroupMinRunnerSecurityManagerTest {
                     .build();
             new Runner(opts).run();
         } finally {
-            System.setSecurityManager(null);
+            SecurityManagerTestUtils.remove();
         }
     }
 

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/security/GroupMinSecurityManagerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/security/GroupMinSecurityManagerTest.java
@@ -59,12 +59,12 @@ public class GroupMinSecurityManagerTest {
         Fixtures.work();
         URI policyFile = GroupMinSecurityManagerTest.class.getResource("/jmh-security-minimal.policy").toURI();
         Policy.setPolicy(Policy.getInstance("JavaPolicy", new URIParameter(policyFile)));
-        System.setSecurityManager(new SecurityManager());
+        SecurityManagerTestUtils.install();
     }
 
     @TearDown
     public void tearDown() {
-        System.setSecurityManager(null);
+        SecurityManagerTestUtils.remove();
     }
 
     @Benchmark

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/security/GroupSecurityManagerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/security/GroupSecurityManagerTest.java
@@ -59,12 +59,12 @@ public class GroupSecurityManagerTest {
         Fixtures.work();
         URI policyFile = GroupSecurityManagerTest.class.getResource("/jmh-security.policy").toURI();
         Policy.setPolicy(Policy.getInstance("JavaPolicy", new URIParameter(policyFile)));
-        System.setSecurityManager(new SecurityManager());
+        SecurityManagerTestUtils.install();
     }
 
     @TearDown
     public void tearDown() {
-        System.setSecurityManager(null);
+        SecurityManagerTestUtils.remove();
     }
 
     @Benchmark

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/security/SecurityManagerTestUtils.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/security/SecurityManagerTestUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jmh.it.security;
+
+public class SecurityManagerTestUtils {
+
+    public static void install() {
+        try {
+            System.setSecurityManager(new SecurityManager());
+        } catch (UnsupportedOperationException uoe) {
+            // Probably modern JDK without SecurityManager support.
+        }
+    }
+
+    public static void remove() {
+        try {
+            System.setSecurityManager(null);
+        } catch (UnsupportedOperationException uoe) {
+            // Probably modern JDK without SecurityManager support.
+        }
+    }
+
+}

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/security/ThreadMinRunnerSecurityManagerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/security/ThreadMinRunnerSecurityManagerTest.java
@@ -62,7 +62,7 @@ public class ThreadMinRunnerSecurityManagerTest {
     public void invokeAPI() throws RunnerException, URISyntaxException, NoSuchAlgorithmException {
         URI policyFile = ThreadMinRunnerSecurityManagerTest.class.getResource("/jmh-security-minimal-runner.policy").toURI();
         Policy.setPolicy(Policy.getInstance("JavaPolicy", new URIParameter(policyFile)));
-        System.setSecurityManager(new SecurityManager());
+        SecurityManagerTestUtils.install();
 
         try {
             Options opts = new OptionsBuilder()
@@ -71,7 +71,7 @@ public class ThreadMinRunnerSecurityManagerTest {
                     .build();
             new Runner(opts).run();
         } finally {
-            System.setSecurityManager(null);
+            SecurityManagerTestUtils.remove();
         }
     }
 

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/security/ThreadMinSecurityManagerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/security/ThreadMinSecurityManagerTest.java
@@ -57,12 +57,12 @@ public class ThreadMinSecurityManagerTest {
         Fixtures.work();
         URI policyFile = ThreadMinSecurityManagerTest.class.getResource("/jmh-security-minimal.policy").toURI();
         Policy.setPolicy(Policy.getInstance("JavaPolicy", new URIParameter(policyFile)));
-        System.setSecurityManager(new SecurityManager());
+        SecurityManagerTestUtils.install();
     }
 
     @TearDown
     public void tearDown() {
-        System.setSecurityManager(null);
+        SecurityManagerTestUtils.remove();
     }
 
     @Benchmark

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/security/ThreadSecurityManagerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/security/ThreadSecurityManagerTest.java
@@ -57,12 +57,12 @@ public class ThreadSecurityManagerTest {
         Fixtures.work();
         URI policyFile = ThreadSecurityManagerTest.class.getResource("/jmh-security.policy").toURI();
         Policy.setPolicy(Policy.getInstance("JavaPolicy", new URIParameter(policyFile)));
-        System.setSecurityManager(new SecurityManager());
+        SecurityManagerTestUtils.install();
     }
 
     @TearDown
     public void tearDown() {
-        System.setSecurityManager(null);
+        SecurityManagerTestUtils.remove();
     }
 
     @Benchmark


### PR DESCRIPTION
SecurityManager is deprecated, so runtime System.setSecurityManager fails with UOE.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903127](https://bugs.openjdk.java.net/browse/CODETOOLS-7903127): JMH: SecurityManager tests fail on modern JDK


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmh pull/67/head:pull/67` \
`$ git checkout pull/67`

Update a local copy of the PR: \
`$ git checkout pull/67` \
`$ git pull https://git.openjdk.java.net/jmh pull/67/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 67`

View PR using the GUI difftool: \
`$ git pr show -t 67`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmh/pull/67.diff">https://git.openjdk.java.net/jmh/pull/67.diff</a>

</details>
