### PR TITLE
7903144: Update URLs in Maven files

### DIFF
--- a/jmh-core/pom.xml
+++ b/jmh-core/pom.xml
@@ -140,13 +140,6 @@ questions.
         </resources>
     </build>
 
-    <repositories>
-        <repository>
-            <id>java.net</id>
-            <url>http://download.java.net/maven/2</url>
-        </repository>
-    </repositories>
-
     <reporting>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,8 @@ questions.
     </url>
 
     <scm>
-        <url>http://hg.openjdk.java.net/code-tools/jmh/</url>
-        <connection>scm:hg:http://hg.openjdk.java.net/code-tools/jmh/</connection>
+        <url>https://github.com/openjdk/jmh</url>
+        <connection>scm:git:https://github.com/openjdk/jmh.git</connection>
     </scm>
 
     <licenses>


### PR DESCRIPTION
- Removed the reference to http://download.java.net/maven/2. The build succeeds without it just fine, and Maven ignores plain http repositories anyway.
- Updated SCM links to point to github. `mvn scm:update` appears to work now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903144](https://bugs.openjdk.java.net/browse/CODETOOLS-7903144): Update URLs in Maven files


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmh pull/69/head:pull/69` \
`$ git checkout pull/69`

Update a local copy of the PR: \
`$ git checkout pull/69` \
`$ git pull https://git.openjdk.java.net/jmh pull/69/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 69`

View PR using the GUI difftool: \
`$ git pr show -t 69`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmh/pull/69.diff">https://git.openjdk.java.net/jmh/pull/69.diff</a>

</details>
