### PR TITLE
7903161: JMH: Remove perfasm "printCompilationInfo" option

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/AbstractPerfAsmProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/AbstractPerfAsmProfiler.java
@@ -66,7 +66,6 @@ public abstract class AbstractPerfAsmProfiler implements ExternalProfiler {
     private final String saveLogTo;
     private final String saveLogToFile;
 
-    private final boolean printCompilationInfo;
     private final boolean intelSyntax;
 
     protected final TempFile hsLog;
@@ -184,11 +183,6 @@ public abstract class AbstractPerfAsmProfiler implements ExternalProfiler {
                 "Override the annotated Hotspot log filename.")
                 .withRequiredArg().ofType(String.class).describedAs("file");
 
-        OptionSpec<Boolean> optPrintCompilationInfo = parser.accepts("printCompilationInfo",
-                        "Print the collateral compilation information. Enabling this might corrupt the " +
-                        "assembly output, see https://bugs.openjdk.java.net/browse/CODETOOLS-7901102.")
-                .withRequiredArg().ofType(Boolean.class).describedAs("bool").defaultsTo(false);
-
         OptionSpec<Boolean> optIntelSyntax = parser.accepts("intelSyntax",
                         "Should perfasm use intel syntax?")
                 .withRequiredArg().ofType(Boolean.class).describedAs("boolean").defaultsTo(false);
@@ -240,7 +234,6 @@ public abstract class AbstractPerfAsmProfiler implements ExternalProfiler {
             saveLogToFile = set.valueOf(optSaveLogToFile);
 
             intelSyntax = set.valueOf(optIntelSyntax);
-            printCompilationInfo = set.valueOf(optPrintCompilationInfo);
             drawIntraJumps = set.valueOf(optDrawInterJumps);
             drawInterJumps = set.valueOf(optDrawIntraJumps);
 
@@ -271,11 +264,6 @@ public abstract class AbstractPerfAsmProfiler implements ExternalProfiler {
                 opts.add("-XX:+PrintSignatureHandlers");
                 opts.add("-XX:+PrintAdapterHandlers");
                 opts.add("-XX:+PrintStubCode");
-            }
-            if (printCompilationInfo) {
-                opts.add("-XX:+PrintCompilation");
-                opts.add("-XX:+PrintInlining");
-                opts.add("-XX:+TraceClassLoading");
             }
             if (intelSyntax) {
                 opts.add("-XX:PrintAssemblyOptions=intel");


### PR DESCRIPTION
This option was added in early days of perfasm, but now it is both bitrotten (TraceClassLoading flag got deprecated), it serves little purpose given how perfasm is now tracking the compilation versions for every method, and the output would be hard to correlate with perfasm anyway.

We should just remove this option to avoid confusion.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903161](https://bugs.openjdk.java.net/browse/CODETOOLS-7903161): JMH: Remove perfasm "printCompilationInfo" option


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmh pull/70/head:pull/70` \
`$ git checkout pull/70`

Update a local copy of the PR: \
`$ git checkout pull/70` \
`$ git pull https://git.openjdk.java.net/jmh pull/70/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 70`

View PR using the GUI difftool: \
`$ git pr show -t 70`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmh/pull/70.diff">https://git.openjdk.java.net/jmh/pull/70.diff</a>

</details>
