### PR TITLE
CODETOOLS-7903215: JMH: xperfasm throws incorrect error when xperf is not available

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/WinPerfAsmProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/WinPerfAsmProfiler.java
@@ -94,18 +94,12 @@ public class WinPerfAsmProfiler extends AbstractPerfAsmProfiler {
 
         Collection<String> errsOn = Utils.tryWith(path, "-on", xperfProviders);
         if (!errsOn.isEmpty()) {
-            if (errsOn instanceof ArrayList) {
-                errsOn.add(MSG_UNABLE_START);
-            }
-            throw new ProfilerException(errsOn.toString());
+            throw new ProfilerException(MSG_UNABLE_START + ": " + errsOn);
         }
 
         Collection<String> errsStop = Utils.tryWith(path, "-stop");
         if (!errsStop.isEmpty()) {
-            if (errsStop instanceof ArrayList) {
-                errsStop.add(MSG_UNABLE_STOP);
-            }
-            throw new ProfilerException(errsStop.toString());
+            throw new ProfilerException(MSG_UNABLE_STOP + ": " + errsStop);
         }
     }
 
@@ -136,10 +130,7 @@ public class WinPerfAsmProfiler extends AbstractPerfAsmProfiler {
         Collection<String> errs = Utils.tryWith(path, "-on", xperfProviders);
 
         if (!errs.isEmpty()) {
-            if (errs instanceof ArrayList) {
-                errs.add(MSG_UNABLE_START);
-            }
-            throw new IllegalStateException(errs.toString());
+            throw new IllegalStateException(MSG_UNABLE_START + ": " + errs);
         }
     }
 
@@ -163,10 +154,7 @@ public class WinPerfAsmProfiler extends AbstractPerfAsmProfiler {
         Collection<String> errs = Utils.tryWith(path, "-d", perfBinData.getAbsolutePath());
 
         if (!errs.isEmpty()) {
-            if (errs instanceof ArrayList) {
-                errs.add(MSG_UNABLE_STOP);
-            }
-            throw new IllegalStateException(errs.toString());
+            throw new IllegalStateException(MSG_UNABLE_STOP + ": " + errs);
         }
 
         // 2. Convert binary data to text form.

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/WinPerfAsmProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/WinPerfAsmProfiler.java
@@ -94,13 +94,17 @@ public class WinPerfAsmProfiler extends AbstractPerfAsmProfiler {
 
         Collection<String> errsOn = Utils.tryWith(path, "-on", xperfProviders);
         if (!errsOn.isEmpty()) {
-            errsOn.add(MSG_UNABLE_START);
+            if (errsOn instanceof ArrayList) {
+                errsOn.add(MSG_UNABLE_START);
+            }
             throw new ProfilerException(errsOn.toString());
         }
 
         Collection<String> errsStop = Utils.tryWith(path, "-stop");
         if (!errsStop.isEmpty()) {
-            errsStop.add(MSG_UNABLE_STOP);
+            if (errsStop instanceof ArrayList) {
+                errsStop.add(MSG_UNABLE_STOP);
+            }
             throw new ProfilerException(errsStop.toString());
         }
     }
@@ -132,7 +136,9 @@ public class WinPerfAsmProfiler extends AbstractPerfAsmProfiler {
         Collection<String> errs = Utils.tryWith(path, "-on", xperfProviders);
 
         if (!errs.isEmpty()) {
-            errs.add(MSG_UNABLE_START);
+            if (errs instanceof ArrayList) {
+                errs.add(MSG_UNABLE_START);
+            }
             throw new IllegalStateException(errs.toString());
         }
     }
@@ -157,7 +163,9 @@ public class WinPerfAsmProfiler extends AbstractPerfAsmProfiler {
         Collection<String> errs = Utils.tryWith(path, "-d", perfBinData.getAbsolutePath());
 
         if (!errs.isEmpty()) {
-            errs.add(MSG_UNABLE_STOP);
+            if (errs instanceof ArrayList) {
+                errs.add(MSG_UNABLE_STOP);
+            }
             throw new IllegalStateException(errs.toString());
         }
 


### PR DESCRIPTION
When Windows Performance Toolkit is not installed in Windows environment, WinPerAsmProfiler will start abnormally and throw wrong message due to wrong operation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903215](https://bugs.openjdk.org/browse/CODETOOLS-7903215): JMH: xperfasm throws incorrect error when xperf is not available


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh pull/72/head:pull/72` \
`$ git checkout pull/72`

Update a local copy of the PR: \
`$ git checkout pull/72` \
`$ git pull https://git.openjdk.org/jmh pull/72/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 72`

View PR using the GUI difftool: \
`$ git pr show -t 72`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/72.diff">https://git.openjdk.org/jmh/pull/72.diff</a>

</details>
