### PR TITLE
Archetype: move jmh-generator-annprocess into configuration of maven-compiler-plugin

### DIFF
--- a/jmh-archetypes/jmh-java-benchmark-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/jmh-archetypes/jmh-java-benchmark-archetype/src/main/resources/archetype-resources/pom.xml
@@ -51,12 +51,6 @@ THE POSSIBILITY OF SUCH DAMAGE.
             <artifactId>jmh-core</artifactId>
             <version>\${jmh.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.openjdk.jmh</groupId>
-            <artifactId>jmh-generator-annprocess</artifactId>
-            <version>\${jmh.version}</version>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
     <properties>
@@ -88,6 +82,13 @@ THE POSSIBILITY OF SUCH DAMAGE.
                     <compilerVersion>\${javac.target}</compilerVersion>
                     <source>\${javac.target}</source>
                     <target>\${javac.target}</target>
+                    <annotationProcessorPaths>
+                        <annotationProcessorPath>
+                            <groupId>org.openjdk.jmh</groupId>
+                            <artifactId>jmh-generator-annprocess</artifactId>
+                            <version>\${jmh.version}</version>
+                        </annotationProcessorPath>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
I found out that sometimes IDEA does not pick-up annotation processor from `pom.xml` of a project generated from archetype. If I then move annotation processor into compiler's config and reimport the project the issue is gone. So it seems reasonable to move annotation processor into dedicated section of compiler plugin's config.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh pull/74/head:pull/74` \
`$ git checkout pull/74`

Update a local copy of the PR: \
`$ git checkout pull/74` \
`$ git pull https://git.openjdk.org/jmh pull/74/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 74`

View PR using the GUI difftool: \
`$ git pr show -t 74`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/74.diff">https://git.openjdk.org/jmh/pull/74.diff</a>

</details>
