### PR TITLE
7903322: JMH: Fix typo in JMHSample_11_Loops

### DIFF
--- a/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_11_Loops.java
+++ b/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_11_Loops.java
@@ -131,7 +131,7 @@ public class JMHSample_11_Loops {
      * well beyond what hardware can actually do.
      *
      * This happens because the loop is heavily unrolled/pipelined, and the operation
-     * to be measured is hoisted from the loop. Morale: don't overuse loops, rely on JMH
+     * to be measured is hoisted from the loop. Moral: don't overuse loops, rely on JMH
      * to get the measurement right.
      *
      * You can run this test:


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903322](https://bugs.openjdk.org/browse/CODETOOLS-7903322): JMH: Fix typo in JMHSample_11_Loops


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh pull/77/head:pull/77` \
`$ git checkout pull/77`

Update a local copy of the PR: \
`$ git checkout pull/77` \
`$ git pull https://git.openjdk.org/jmh pull/77/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 77`

View PR using the GUI difftool: \
`$ git pr show -t 77`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/77.diff">https://git.openjdk.org/jmh/pull/77.diff</a>

</details>
