### PR TITLE
7903319: The methods 'getAllMethods' and 'getMethods' in class 'BenchmarkGeneratorUtils' have the same feature

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/generators/core/BenchmarkGeneratorUtils.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/generators/core/BenchmarkGeneratorUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -131,14 +131,6 @@ class BenchmarkGeneratorUtils {
     }
 
     public static Collection<MethodInfo> getAllMethods(ClassInfo ci) {
-        List<MethodInfo> ls = new ArrayList<>();
-        do {
-            ls.addAll(ci.getMethods());
-        } while ((ci = ci.getSuperClass()) != null);
-        return ls;
-    }
-
-    public static Collection<MethodInfo> getMethods(ClassInfo ci) {
         List<MethodInfo> ls = new ArrayList<>();
         do {
             ls.addAll(ci.getMethods());

--- a/jmh-core/src/main/java/org/openjdk/jmh/generators/core/StateObjectHandler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/generators/core/StateObjectHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -128,7 +128,7 @@ class StateObjectHandler {
         }
 
         // validate rogue annotations on methods
-        for (MethodInfo mi : BenchmarkGeneratorUtils.getMethods(state)) {
+        for (MethodInfo mi : BenchmarkGeneratorUtils.getAllMethods(state)) {
             BenchmarkGeneratorUtils.checkAnnotations(mi);
         }
 
@@ -252,7 +252,7 @@ class StateObjectHandler {
             Set<ClassQName> nextSeen = new HashSet<>();
             nextSeen.addAll(alreadySeen);
             nextSeen.add(ci);
-            for (MethodInfo mi : BenchmarkGeneratorUtils.getMethods(ci.ci)) {
+            for (MethodInfo mi : BenchmarkGeneratorUtils.getAllMethods(ci.ci)) {
                 if (mi.getAnnotation(Setup.class) != null || mi.getAnnotation(TearDown.class) != null) {
                     validateNoCyclesStep(nextSeen, mi, false);
                 }
@@ -286,7 +286,7 @@ class StateObjectHandler {
      */
     private void resolveDependencies(MethodInfo method, ClassInfo pci, StateObject pso) {
 
-        for (MethodInfo mi : BenchmarkGeneratorUtils.getMethods(pci)) {
+        for (MethodInfo mi : BenchmarkGeneratorUtils.getAllMethods(pci)) {
             if (mi.getAnnotation(Setup.class) != null || mi.getAnnotation(TearDown.class) != null) {
                 for (ParameterInfo pi : mi.getParameters()) {
                     ClassInfo ci = pi.getType();
@@ -372,7 +372,7 @@ class StateObjectHandler {
         }
 
         // put the @State objects helper methods
-        for (MethodInfo mi : BenchmarkGeneratorUtils.getMethods(ci)) {
+        for (MethodInfo mi : BenchmarkGeneratorUtils.getAllMethods(ci)) {
             Setup setupAnn = mi.getAnnotation(Setup.class);
             if (setupAnn != null) {
                 checkHelpers(mi, Setup.class);


### PR DESCRIPTION
Hi all,

Currently, the methods `getAllMethods` and `getMethods` in class 'BenchmarkGeneratorUtils' have the same feature. This patch removes `getMethods` and keeps `getAllMethods`  because `getAllMethods` is consistent with `getAllFields`.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903319](https://bugs.openjdk.org/browse/CODETOOLS-7903319): The methods 'getAllMethods' and 'getMethods' in class 'BenchmarkGeneratorUtils' have the same feature


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh pull/78/head:pull/78` \
`$ git checkout pull/78`

Update a local copy of the PR: \
`$ git checkout pull/78` \
`$ git pull https://git.openjdk.org/jmh pull/78/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 78`

View PR using the GUI difftool: \
`$ git pr show -t 78`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/78.diff">https://git.openjdk.org/jmh/pull/78.diff</a>

</details>
