### PR TITLE
7903328: Introduce a new method 'clear' in interface 'Multiset'

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/GCProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/GCProfiler.java
@@ -309,7 +309,7 @@ public class GCProfiler implements InternalProfiler {
                 throw new IllegalStateException("Churn profile already started");
             }
             started = true;
-            churn = new HashMultiset<>();
+            churn.clear();
             try {
                 for (GarbageCollectorMXBean bean : ManagementFactory.getGarbageCollectorMXBeans()) {
                     ((NotificationEmitter) bean).addNotificationListener(listener, null, null);

--- a/jmh-core/src/main/java/org/openjdk/jmh/util/DelegatingMultiset.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/util/DelegatingMultiset.java
@@ -109,8 +109,6 @@ public class DelegatingMultiset<T> implements Multiset<T>, Serializable {
     @Override
     public void clear() {
         size = 0;
-        if (map != null) {
-            map.clear();
-        }
+        map.clear();
     }
 }

--- a/jmh-core/src/main/java/org/openjdk/jmh/util/DelegatingMultiset.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/util/DelegatingMultiset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -104,5 +104,13 @@ public class DelegatingMultiset<T> implements Multiset<T>, Serializable {
         int result = map.hashCode();
         result = 31 * result + (int) (size ^ (size >>> 32));
         return result;
+    }
+
+    @Override
+    public void clear() {
+        size = 0;
+        if (map != null) {
+            map.clear();
+        }
     }
 }

--- a/jmh-core/src/main/java/org/openjdk/jmh/util/Multiset.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/util/Multiset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,4 +82,9 @@ public interface Multiset<T> {
      * @return the collections of keys
      */
     Collection<T> keys();
+
+    /**
+     * Remove all the elements.
+     */
+    void clear();
 }

--- a/jmh-core/src/test/java/org/openjdk/jmh/util/MultisetTest.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/util/MultisetTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jmh.util;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+public class MultisetTest {
+    @Test
+    public void testClear() {
+        Multiset<String> set = new HashMultiset<>();
+        set.add("one");
+        set.add("two", 2);
+        assertFalse(set.isEmpty());
+        assertEquals(3, set.size());
+        assertEquals(2, set.keys().size());
+        assertEquals(1, set.count("one"));
+        assertEquals(2, set.count("two"));
+
+        // clear the set
+        set.clear();
+        assertTrue(set.isEmpty());
+        assertEquals(0, set.size());
+        assertEquals(0, set.keys().size());
+        assertEquals(0, set.count("one"));
+        assertEquals(0, set.count("two"));
+
+        // reuse the set
+        set.add("one");
+        set.add("two", 2);
+        assertFalse(set.isEmpty());
+        assertEquals(3, set.size());
+        assertEquals(2, set.keys().size());
+        assertEquals(1, set.count("one"));
+        assertEquals(2, set.count("two"));
+    }
+}


### PR DESCRIPTION
Hi all,

This patch adds a method named `clear` in interface `Multset` and implements the method in its sub-class. A corresponding test case is added and all the test passed locally.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903328](https://bugs.openjdk.org/browse/CODETOOLS-7903328): Introduce a new method 'clear' in interface 'Multiset'


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh pull/81/head:pull/81` \
`$ git checkout pull/81`

Update a local copy of the PR: \
`$ git checkout pull/81` \
`$ git pull https://git.openjdk.org/jmh pull/81/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 81`

View PR using the GUI difftool: \
`$ git pr show -t 81`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/81.diff">https://git.openjdk.org/jmh/pull/81.diff</a>

</details>
