### PR TITLE
Remove suggestion that's not possible.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,6 @@ If you have the access to [JDK Bug System](https://bugs.openjdk.java.net/browse/
  * Component: tools
  * Sub-component: jmh
 
-If you don't have the access to JDK Bug System, submit the bug report at "Issues" here, and wait for maintainers to pick that up.
-
 ## Development
 
 JMH project accepts pull requests, like other OpenJDK projects.


### PR DESCRIPTION
I want to report a bug, but it's extremely hard since https://bugs.openjdk.java.net doesn't have a register button.

I'm removing this sentence from README.md as it's misleading since this project doesn't have GitHub Issues enabled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh pull/82/head:pull/82` \
`$ git checkout pull/82`

Update a local copy of the PR: \
`$ git checkout pull/82` \
`$ git pull https://git.openjdk.org/jmh pull/82/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 82`

View PR using the GUI difftool: \
`$ git pr show -t 82`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/82.diff">https://git.openjdk.org/jmh/pull/82.diff</a>

</details>
