### PR TITLE
CODETOOLS-7903350: JMH: Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,26 +124,26 @@ If all these did not help, you are welcome to report the issue.
 
 ### Reporting Harness and Test Bugs
 
-If you have the access to [JDK Bug System](https://bugs.openjdk.java.net/browse/CODETOOLS-7902762?jql=project%20%3D%20CODETOOLS%20AND%20resolution%20%3D%20Unresolved%20AND%20component%20%3D%20tools%20AND%20Subcomponent%20%3D%20jmh), please submit the bug there:
+If you have the access to [OpenJDK Bug System](https://bugs.openjdk.org/browse/CODETOOLS-7902762?jql=project%20%3D%20CODETOOLS%20AND%20resolution%20%3D%20Unresolved%20AND%20component%20%3D%20tools%20AND%20Subcomponent%20%3D%20jmh), please submit the bug there:
  * Project: CODETOOLS
  * Component: tools
  * Sub-component: jmh
 
-If you don't have the access to JDK Bug System, submit the bug report at "Issues" here, and wait for maintainers to pick that up.
+Alternatively, you can join the [JMH Mailing List](https://mail.openjdk.org/mailman/listinfo/jmh-dev) and report the bugs there.
 
 ## Development
 
 JMH project accepts pull requests, like other OpenJDK projects.
-If you have never contributed to OpenJDK before, then bots would require you to [sign OCA first](http://openjdk.java.net/contribute).
+If you have never contributed to OpenJDK before, then bots would require you to [sign OCA first](http://openjdk.org/contribute).
 Normally, you don't need to post patches anywhere else, or post to mailing lists, etc.
-If you do want to have a wider discussion about JMH, please refer to [jmh-dev](https://mail.openjdk.java.net/mailman/listinfo/jmh-dev).
+If you do want to have a wider discussion about JMH, please refer to [jmh-dev](https://mail.openjdk.org/mailman/listinfo/jmh-dev).
 
 Short instructions to build, test bleeding-edge JMH, and install its JAR to local Maven repo:
 
     $ mvn clean install
 
 If you already have the benchmark project, then it is enough to change JMH dependencies version
-to the latest `SNAPSHOT` version (look up the actual latest version in [root `pom.xml`](https://github.com/openjdk/jmh/blob/9f5b990334bbcb27856740d6330ba2d0c928d2f1/pom.xml#L33)). If not, create the JMH benchmark project and change the version there.
+to the latest `SNAPSHOT` version (look up the actual latest version in [root `pom.xml`](https://github.com/openjdk/jmh/blob/master/pom.xml)). If not, create the JMH benchmark project and change the version there.
 
 GitHub workflow "JMH Pre-Integration Tests" should pass on the changes. It would be triggered
 for PRs. You can also trigger it manually for your branch.


### PR DESCRIPTION
The current README is old and accrued a few inconsistencies. It is a good time to revise it a bit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903350](https://bugs.openjdk.org/browse/CODETOOLS-7903350): JMH: Update README


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh pull/83/head:pull/83` \
`$ git checkout pull/83`

Update a local copy of the PR: \
`$ git checkout pull/83` \
`$ git pull https://git.openjdk.org/jmh pull/83/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 83`

View PR using the GUI difftool: \
`$ git pr show -t 83`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/83.diff">https://git.openjdk.org/jmh/pull/83.diff</a>

</details>
