### PR TITLE
CODETOOLS-7903351: JMH: Update pre-integration testing workflows

### DIFF
--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java: [7, 8, 11, 17, 19, 20-ea]
+        java: [8, 11, 17, 19, 20-ea]
         os: [ubuntu-22.04, windows-2022, macos-11]
         profile: [default, reflection, asm]
       fail-fast: false

--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -16,24 +16,20 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java: [7, 8, 11, 17, 19-ea]
-        os: [ubuntu-20.04, windows-2022, macos-11]
+        java: [7, 8, 11, 17, 19, 20-ea]
+        os: [ubuntu-22.04, windows-2022, macos-11]
         profile: [default, reflection, asm]
       fail-fast: false
     name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}, ${{ matrix.profile }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v1
       with:
+        distribution: temurin
         java-version: ${{ matrix.java }}
-    - name: Cache Maven packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml', '.github/workflows/pre-integration.yml') }}
-        restore-keys: ${{ runner.os }}-maven
+        cache: maven
     - name: Run build with tests
       run: mvn clean install -P ${{ matrix.profile }} -B --file pom.xml
       if: (runner.os == 'Linux') || (matrix.profile == 'default')

--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
         distribution: temurin
         java-version: ${{ matrix.java }}

--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         distribution: temurin
         java-version: ${{ matrix.java }}


### PR DESCRIPTION
Time to update our workflows: new JDKs, new OSes, new GH plugins.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903351](https://bugs.openjdk.org/browse/CODETOOLS-7903351): JMH: Update pre-integration testing workflows


### Reviewers
 * [Eric Caspole](https://openjdk.org/census#ecaspole) (@ericcaspole - Committer) ⚠️ Review applies to [15943288](https://git.openjdk.org/jmh/pull/84/files/159432883ce89fc73b1e871aab94e0fe09cd17e7)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh pull/84/head:pull/84` \
`$ git checkout pull/84`

Update a local copy of the PR: \
`$ git checkout pull/84` \
`$ git pull https://git.openjdk.org/jmh pull/84/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 84`

View PR using the GUI difftool: \
`$ git pr show -t 84`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/84.diff">https://git.openjdk.org/jmh/pull/84.diff</a>

</details>
