### PR TITLE
CODETOOLS-7903355: JMH: Drop support for JDK 7

### DIFF
--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java: [7, 8, 11, 17, 19-ea]
+        java: [8, 11, 17, 19-ea]
         os: [ubuntu-20.04, windows-2022, macos-11]
         profile: [default, reflection, asm]
       fail-fast: false

--- a/jmh-core-benchmarks/pom.xml
+++ b/jmh-core-benchmarks/pom.xml
@@ -66,11 +66,6 @@ questions.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <compilerVersion>1.7</compilerVersion>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/jmh-core-benchmarks/src/main/java/org/openjdk/jmh/benchmarks/BlackholePipelinePayloadBench.java
+++ b/jmh-core-benchmarks/src/main/java/org/openjdk/jmh/benchmarks/BlackholePipelinePayloadBench.java
@@ -71,7 +71,7 @@ public class BlackholePipelinePayloadBench {
             longs[c] = c;
             doubles[c] = c;
             objects[c] = (double) c;
-            arrays[c] = new Double[]{Double.valueOf(c)};
+            arrays[c] = new Double[]{(double) c};
         }
     }
 

--- a/jmh-core-ct/pom.xml
+++ b/jmh-core-ct/pom.xml
@@ -102,9 +102,6 @@ questions.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <compilerVersion>1.7</compilerVersion>
-                    <source>1.7</source>
-                    <target>1.7</target>
                     <compilerArgument>-proc:none</compilerArgument>
                 </configuration>
             </plugin>

--- a/jmh-core-it/pom.xml
+++ b/jmh-core-it/pom.xml
@@ -120,11 +120,6 @@ questions.
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-compiler-plugin</artifactId>
-                        <configuration>
-                            <compilerVersion>1.7</compilerVersion>
-                            <source>1.7</source>
-                            <target>1.7</target>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>
@@ -148,9 +143,6 @@ questions.
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-compiler-plugin</artifactId>
                         <configuration>
-                            <compilerVersion>1.7</compilerVersion>
-                            <source>1.7</source>
-                            <target>1.7</target>
                             <compilerArgument>-proc:none</compilerArgument>
                         </configuration>
                         <executions>
@@ -235,9 +227,6 @@ questions.
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-compiler-plugin</artifactId>
                         <configuration>
-                            <compilerVersion>1.7</compilerVersion>
-                            <source>1.7</source>
-                            <target>1.7</target>
                             <compilerArgument>-proc:none</compilerArgument>
                         </configuration>
                         <executions>

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/asymm/ExactThreadCountTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/asymm/ExactThreadCountTest.java
@@ -57,8 +57,8 @@ import java.util.concurrent.TimeUnit;
 @Fork(1)
 public class ExactThreadCountTest {
 
-    private final Set<Thread> test1threads = Collections.synchronizedSet(new HashSet<Thread>());
-    private final Set<Thread> test2threads = Collections.synchronizedSet(new HashSet<Thread>());
+    private final Set<Thread> test1threads = Collections.synchronizedSet(new HashSet<>());
+    private final Set<Thread> test2threads = Collections.synchronizedSet(new HashSet<>());
 
     @Setup(Level.Iteration)
     public void setup() {

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/asymm/Zero1ThreadCountTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/asymm/Zero1ThreadCountTest.java
@@ -55,8 +55,8 @@ import java.util.concurrent.TimeUnit;
 @Fork(1)
 public class Zero1ThreadCountTest {
 
-    private final Set<Thread> test1threads = Collections.synchronizedSet(new HashSet<Thread>());
-    private final Set<Thread> test2threads = Collections.synchronizedSet(new HashSet<Thread>());
+    private final Set<Thread> test1threads = Collections.synchronizedSet(new HashSet<>());
+    private final Set<Thread> test2threads = Collections.synchronizedSet(new HashSet<>());
 
     @TearDown
     public void check() {

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/asymm/Zero2ThreadCountTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/asymm/Zero2ThreadCountTest.java
@@ -55,8 +55,8 @@ import java.util.concurrent.TimeUnit;
 @Fork(1)
 public class Zero2ThreadCountTest {
 
-    private final Set<Thread> test1threads = Collections.synchronizedSet(new HashSet<Thread>());
-    private final Set<Thread> test2threads = Collections.synchronizedSet(new HashSet<Thread>());
+    private final Set<Thread> test1threads = Collections.synchronizedSet(new HashSet<>());
+    private final Set<Thread> test2threads = Collections.synchronizedSet(new HashSet<>());
 
     @TearDown
     public void check() {

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/errors/ForkedStuckShutdownHookTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/errors/ForkedStuckShutdownHookTest.java
@@ -44,16 +44,13 @@ public class ForkedStuckShutdownHookTest {
     @Setup
     public void setup() {
         Runtime.getRuntime().addShutdownHook(
-                new Thread() {
-                    @Override
-                    public void run() {
-                        try {
-                            TimeUnit.DAYS.sleep(1);
-                        } catch (InterruptedException e) {
-                            e.printStackTrace();
-                        }
+                new Thread(() -> {
+                    try {
+                        TimeUnit.DAYS.sleep(1);
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
                     }
-                }
+                })
         );
     }
 

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/errors/ForkedStuckThreadTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/errors/ForkedStuckThreadTest.java
@@ -43,14 +43,11 @@ public class ForkedStuckThreadTest {
 
     @Setup
     public void setup() {
-        Thread t = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    TimeUnit.DAYS.sleep(1);
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                }
+        Thread t = new Thread(() -> {
+            try {
+                TimeUnit.DAYS.sleep(1);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
             }
         });
         t.setDaemon(false);

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/infraparams/BenchmarkParamsTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/infraparams/BenchmarkParamsTest.java
@@ -47,7 +47,7 @@ public class BenchmarkParamsTest {
 
     @Setup(Level.Iteration)
     public void setup() {
-        set = Collections.synchronizedSet(Collections.newSetFromMap(new IdentityHashMap<BenchmarkParams, Boolean>()));
+        set = Collections.synchronizedSet(Collections.newSetFromMap(new IdentityHashMap<>()));
     }
 
     @TearDown(Level.Iteration)

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/infraparams/IterationParamsTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/infraparams/IterationParamsTest.java
@@ -47,7 +47,7 @@ public class IterationParamsTest {
 
     @Setup(Level.Iteration)
     public void setup() {
-        set = Collections.synchronizedSet(Collections.newSetFromMap(new IdentityHashMap<IterationParams, Boolean>()));
+        set = Collections.synchronizedSet(Collections.newSetFromMap(new IdentityHashMap<>()));
     }
 
     @TearDown(Level.Iteration)

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/infraparams/ThreadParamsTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/infraparams/ThreadParamsTest.java
@@ -44,7 +44,7 @@ public class ThreadParamsTest {
 
     @Setup(Level.Iteration)
     public void setup() {
-        set = Collections.synchronizedSet(Collections.newSetFromMap(new IdentityHashMap<ThreadParams, Boolean>()));
+        set = Collections.synchronizedSet(Collections.newSetFromMap(new IdentityHashMap<>()));
     }
 
     @TearDown(Level.Iteration)

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/sharing/BenchmarkBenchSharingTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/sharing/BenchmarkBenchSharingTest.java
@@ -51,7 +51,7 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Benchmark)
 public class BenchmarkBenchSharingTest {
 
-    final Set<Thread> visitors = Collections.synchronizedSet(new HashSet<Thread>());
+    final Set<Thread> visitors = Collections.synchronizedSet(new HashSet<>());
 
     @TearDown(Level.Trial)
     public void tearDown() {

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/sharing/BenchmarkStateSharingTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/sharing/BenchmarkStateSharingTest.java
@@ -52,7 +52,7 @@ public class BenchmarkStateSharingTest {
 
     @State(Scope.Benchmark)
     public static class MyState {
-        final Set<Thread> visitors = Collections.synchronizedSet(new HashSet<Thread>());
+        final Set<Thread> visitors = Collections.synchronizedSet(new HashSet<>());
 
         @TearDown(Level.Trial)
         public void tearDown() {

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/sharing/GroupBenchSharingTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/sharing/GroupBenchSharingTest.java
@@ -52,7 +52,7 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Group)
 public class GroupBenchSharingTest {
 
-    final Set<Thread> visitors = Collections.synchronizedSet(new HashSet<Thread>());
+    final Set<Thread> visitors = Collections.synchronizedSet(new HashSet<>());
 
     @TearDown(Level.Trial)
     public void tearDown() {

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/sharing/GroupDefaultBenchSharingTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/sharing/GroupDefaultBenchSharingTest.java
@@ -52,7 +52,7 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Group)
 public class GroupDefaultBenchSharingTest {
 
-    final Set<Thread> visitors = Collections.synchronizedSet(new HashSet<Thread>());
+    final Set<Thread> visitors = Collections.synchronizedSet(new HashSet<>());
 
     @TearDown(Level.Trial)
     public void tearDown() {

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/sharing/GroupDefaultStateSharingTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/sharing/GroupDefaultStateSharingTest.java
@@ -53,7 +53,7 @@ public class GroupDefaultStateSharingTest {
 
     @State(Scope.Group)
     public static class MyState {
-        final Set<Thread> visitors = Collections.synchronizedSet(new HashSet<Thread>());
+        final Set<Thread> visitors = Collections.synchronizedSet(new HashSet<>());
 
         @TearDown(Level.Trial)
         public void tearDown() {

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/sharing/GroupStateSharingTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/sharing/GroupStateSharingTest.java
@@ -53,7 +53,7 @@ public class GroupStateSharingTest {
 
     @State(Scope.Group)
     public static class MyState {
-        final Set<Thread> visitors = Collections.synchronizedSet(new HashSet<Thread>());
+        final Set<Thread> visitors = Collections.synchronizedSet(new HashSet<>());
 
         @TearDown(Level.Trial)
         public void tearDown() {

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/sharing/ThreadBenchSharingTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/sharing/ThreadBenchSharingTest.java
@@ -51,7 +51,7 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Thread)
 public class ThreadBenchSharingTest {
 
-    final Set<Thread> visitors = Collections.synchronizedSet(new HashSet<Thread>());
+    final Set<Thread> visitors = Collections.synchronizedSet(new HashSet<>());
 
     @TearDown(Level.Trial)
     public void tearDown() {

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/sharing/ThreadStateSharingTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/sharing/ThreadStateSharingTest.java
@@ -52,7 +52,7 @@ public class ThreadStateSharingTest {
 
     @State(Scope.Thread)
     public static class MyState {
-        final Set<Thread> visitors = Collections.synchronizedSet(new HashSet<Thread>());
+        final Set<Thread> visitors = Collections.synchronizedSet(new HashSet<>());
 
         @TearDown(Level.Trial)
         public void tearDown() {

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/BenchmarkBenchSameThreadTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/BenchmarkBenchSameThreadTest.java
@@ -55,13 +55,13 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Benchmark)
 public class BenchmarkBenchSameThreadTest {
 
-    private final Set<Thread> setupRunThread = Collections.synchronizedSet(new HashSet<Thread>());
-    private final Set<Thread> setupIterationThread = Collections.synchronizedSet(new HashSet<Thread>());
-    private final Set<Thread> setupInvocationThread = Collections.synchronizedSet(new HashSet<Thread>());
-    private final Set<Thread> teardownRunThread = Collections.synchronizedSet(new HashSet<Thread>());
-    private final Set<Thread> teardownIterationThread = Collections.synchronizedSet(new HashSet<Thread>());
-    private final Set<Thread> teardownInvocationThread = Collections.synchronizedSet(new HashSet<Thread>());
-    private final Set<Thread> testInvocationThread = Collections.synchronizedSet(new HashSet<Thread>());
+    private final Set<Thread> setupRunThread = Collections.synchronizedSet(new HashSet<>());
+    private final Set<Thread> setupIterationThread = Collections.synchronizedSet(new HashSet<>());
+    private final Set<Thread> setupInvocationThread = Collections.synchronizedSet(new HashSet<>());
+    private final Set<Thread> teardownRunThread = Collections.synchronizedSet(new HashSet<>());
+    private final Set<Thread> teardownIterationThread = Collections.synchronizedSet(new HashSet<>());
+    private final Set<Thread> teardownInvocationThread = Collections.synchronizedSet(new HashSet<>());
+    private final Set<Thread> testInvocationThread = Collections.synchronizedSet(new HashSet<>());
 
     @Setup(Level.Trial)
     public void setupRun() {

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/BenchmarkStateSameThreadTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/BenchmarkStateSameThreadTest.java
@@ -57,13 +57,13 @@ public class BenchmarkStateSameThreadTest {
     @State(Scope.Benchmark)
     public static class MyState {
 
-        private final Set<Thread> setupRunThread = Collections.synchronizedSet(new HashSet<Thread>());
-        private final Set<Thread> setupIterationThread = Collections.synchronizedSet(new HashSet<Thread>());
-        private final Set<Thread> setupInvocationThread = Collections.synchronizedSet(new HashSet<Thread>());
-        private final Set<Thread> teardownRunThread = Collections.synchronizedSet(new HashSet<Thread>());
-        private final Set<Thread> teardownIterationThread = Collections.synchronizedSet(new HashSet<Thread>());
-        private final Set<Thread> teardownInvocationThread = Collections.synchronizedSet(new HashSet<Thread>());
-        private final Set<Thread> testInvocationThread = Collections.synchronizedSet(new HashSet<Thread>());
+        private final Set<Thread> setupRunThread = Collections.synchronizedSet(new HashSet<>());
+        private final Set<Thread> setupIterationThread = Collections.synchronizedSet(new HashSet<>());
+        private final Set<Thread> setupInvocationThread = Collections.synchronizedSet(new HashSet<>());
+        private final Set<Thread> teardownRunThread = Collections.synchronizedSet(new HashSet<>());
+        private final Set<Thread> teardownIterationThread = Collections.synchronizedSet(new HashSet<>());
+        private final Set<Thread> teardownInvocationThread = Collections.synchronizedSet(new HashSet<>());
+        private final Set<Thread> testInvocationThread = Collections.synchronizedSet(new HashSet<>());
 
         @Setup(Level.Trial)
         public void setupRun() {

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/GroupBenchSameThreadTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/GroupBenchSameThreadTest.java
@@ -56,13 +56,13 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Group)
 public class GroupBenchSameThreadTest {
 
-    private final Set<Thread> setupRunThread = Collections.synchronizedSet(new HashSet<Thread>());
-    private final Set<Thread> setupIterationThread = Collections.synchronizedSet(new HashSet<Thread>());
-    private final Set<Thread> setupInvocationThread = Collections.synchronizedSet(new HashSet<Thread>());
-    private final Set<Thread> teardownRunThread = Collections.synchronizedSet(new HashSet<Thread>());
-    private final Set<Thread> teardownIterationThread = Collections.synchronizedSet(new HashSet<Thread>());
-    private final Set<Thread> teardownInvocationThread = Collections.synchronizedSet(new HashSet<Thread>());
-    private final Set<Thread> testInvocationThread = Collections.synchronizedSet(new HashSet<Thread>());
+    private final Set<Thread> setupRunThread = Collections.synchronizedSet(new HashSet<>());
+    private final Set<Thread> setupIterationThread = Collections.synchronizedSet(new HashSet<>());
+    private final Set<Thread> setupInvocationThread = Collections.synchronizedSet(new HashSet<>());
+    private final Set<Thread> teardownRunThread = Collections.synchronizedSet(new HashSet<>());
+    private final Set<Thread> teardownIterationThread = Collections.synchronizedSet(new HashSet<>());
+    private final Set<Thread> teardownInvocationThread = Collections.synchronizedSet(new HashSet<>());
+    private final Set<Thread> testInvocationThread = Collections.synchronizedSet(new HashSet<>());
 
     @Setup(Level.Trial)
     public void setupRun() {

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/GroupStateSameThreadTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/GroupStateSameThreadTest.java
@@ -58,13 +58,13 @@ public class GroupStateSameThreadTest {
     @State(Scope.Group)
     public static class MyState {
 
-        private final Set<Thread> setupRunThread = Collections.synchronizedSet(new HashSet<Thread>());
-        private final Set<Thread> setupIterationThread = Collections.synchronizedSet(new HashSet<Thread>());
-        private final Set<Thread> setupInvocationThread = Collections.synchronizedSet(new HashSet<Thread>());
-        private final Set<Thread> teardownRunThread = Collections.synchronizedSet(new HashSet<Thread>());
-        private final Set<Thread> teardownIterationThread = Collections.synchronizedSet(new HashSet<Thread>());
-        private final Set<Thread> teardownInvocationThread = Collections.synchronizedSet(new HashSet<Thread>());
-        private final Set<Thread> testInvocationThread = Collections.synchronizedSet(new HashSet<Thread>());
+        private final Set<Thread> setupRunThread = Collections.synchronizedSet(new HashSet<>());
+        private final Set<Thread> setupIterationThread = Collections.synchronizedSet(new HashSet<>());
+        private final Set<Thread> setupInvocationThread = Collections.synchronizedSet(new HashSet<>());
+        private final Set<Thread> teardownRunThread = Collections.synchronizedSet(new HashSet<>());
+        private final Set<Thread> teardownIterationThread = Collections.synchronizedSet(new HashSet<>());
+        private final Set<Thread> teardownInvocationThread = Collections.synchronizedSet(new HashSet<>());
+        private final Set<Thread> testInvocationThread = Collections.synchronizedSet(new HashSet<>());
 
         @Setup(Level.Trial)
         public void setupRun() {

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/GroupThreadGroupOrderTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/GroupThreadGroupOrderTest.java
@@ -48,9 +48,9 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Group)
 public class GroupThreadGroupOrderTest {
 
-    private final Set<Thread> abc = Collections.synchronizedSet(new HashSet<Thread>());
-    private final Set<Thread> def = Collections.synchronizedSet(new HashSet<Thread>());
-    private final Set<Thread> ghi = Collections.synchronizedSet(new HashSet<Thread>());
+    private final Set<Thread> abc = Collections.synchronizedSet(new HashSet<>());
+    private final Set<Thread> def = Collections.synchronizedSet(new HashSet<>());
+    private final Set<Thread> ghi = Collections.synchronizedSet(new HashSet<>());
 
     @Setup(Level.Iteration)
     public void prepare() {

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/MaxThreadCountTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/MaxThreadCountTest.java
@@ -52,7 +52,7 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Benchmark)
 public class MaxThreadCountTest {
 
-    private final Set<Thread> threads = Collections.synchronizedSet(new HashSet<Thread>());
+    private final Set<Thread> threads = Collections.synchronizedSet(new HashSet<>());
 
     @TearDown(Level.Iteration)
     public void tearDown() {

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/OneThreadCountTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/OneThreadCountTest.java
@@ -52,7 +52,7 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Benchmark)
 public class OneThreadCountTest {
 
-    private final Set<Thread> threads = Collections.synchronizedSet(new HashSet<Thread>());
+    private final Set<Thread> threads = Collections.synchronizedSet(new HashSet<>());
 
     @TearDown(Level.Iteration)
     public void tearDown() {

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/TwoThreadCountTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/TwoThreadCountTest.java
@@ -52,7 +52,7 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Benchmark)
 public class TwoThreadCountTest {
 
-    private final Set<Thread> threads = Collections.synchronizedSet(new HashSet<Thread>());
+    private final Set<Thread> threads = Collections.synchronizedSet(new HashSet<>());
 
     @TearDown(Level.Iteration)
     public void tearDown() {

--- a/jmh-core/pom.xml
+++ b/jmh-core/pom.xml
@@ -78,9 +78,6 @@ questions.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <compilerVersion>1.7</compilerVersion>
-                    <source>1.7</source>
-                    <target>1.7</target>
                     <fork>true</fork>
                     <compilerArgs>
                         <arg>-proc:none</arg>

--- a/jmh-core/src/main/java/org/openjdk/jmh/generators/core/CompilerControlPlugin.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/generators/core/CompilerControlPlugin.java
@@ -41,12 +41,7 @@ class CompilerControlPlugin {
 
     private final SortedSet<String> lines = new TreeSet<>();
 
-    private final Set<MethodInfo> defaultForceInlineMethods = new TreeSet<>(new Comparator<MethodInfo>() {
-        @Override
-        public int compare(MethodInfo o1, MethodInfo o2) {
-            return o1.getQualifiedName().compareTo(o2.getQualifiedName());
-        }
-    });
+    private final Set<MethodInfo> defaultForceInlineMethods = new TreeSet<>(Comparator.comparing(MethodInfo::getQualifiedName));
 
     private final Set<String> alwaysDontInlineMethods = new TreeSet<>();
 

--- a/jmh-core/src/main/java/org/openjdk/jmh/generators/core/StateObject.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/generators/core/StateObject.java
@@ -33,12 +33,7 @@ import java.util.*;
 
 class StateObject {
 
-    public static final Comparator<StateObject> ID_COMPARATOR = new Comparator<StateObject>() {
-        @Override
-        public int compare(StateObject o1, StateObject o2) {
-            return o1.fieldIdentifier.compareTo(o2.fieldIdentifier);
-        }
-    };
+    public static final Comparator<StateObject> ID_COMPARATOR = Comparator.comparing(o -> o.fieldIdentifier);
 
     public final String packageName;
     public final String userType;

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/AbstractPerfAsmProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/AbstractPerfAsmProfiler.java
@@ -453,13 +453,8 @@ public abstract class AbstractPerfAsmProfiler implements ExternalProfiler {
 
         final String mainEvent = evNames.get(0);
 
-        Collections.sort(regions, new Comparator<Region>() {
-            @Override
-            public int compare(Region o1, Region o2) {
-                return Long.compare(o2.getEventCount(events, mainEvent),
-                                    o1.getEventCount(events, mainEvent));
-            }
-        });
+        regions.sort((o1, o2) -> Long.compare(o2.getEventCount(events, mainEvent),
+                      o1.getEventCount(events, mainEvent)));
 
         long threshold = (long) (regionRateThreshold * events.getTotalEvents(mainEvent));
 
@@ -556,8 +551,8 @@ public abstract class AbstractPerfAsmProfiler implements ExternalProfiler {
         final Map<String, Multiset<MethodDesc>> methods = new HashMap<>();
 
         for (String event : evNames) {
-            methodsByType.put(event, new HashMultiset<String>());
-            methods.put(event, new HashMultiset<MethodDesc>());
+            methodsByType.put(event, new HashMultiset<>());
+            methods.put(event, new HashMultiset<>());
         }
 
         for (Region r : regions) {

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/GCProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/GCProfiler.java
@@ -267,28 +267,25 @@ public class GCProfiler implements InternalProfiler {
                 final Method getMemoryUsageBeforeGc = getGcInfo.getReturnType().getMethod("getMemoryUsageBeforeGc");
                 final Method getMemoryUsageAfterGc = getGcInfo.getReturnType().getMethod("getMemoryUsageAfterGc");
 
-                return new NotificationListener() {
-                    @Override
-                    public void handleNotification(Notification n, Object o) {
-                        try {
-                            if (n.getType().equals(notifNameField.get(null))) {
-                                Object info = infoMethod.invoke(null, n.getUserData());
-                                Object gcInfo = getGcInfo.invoke(info);
-                                Map<String, MemoryUsage> mapBefore = (Map<String, MemoryUsage>) getMemoryUsageBeforeGc.invoke(gcInfo);
-                                Map<String, MemoryUsage> mapAfter = (Map<String, MemoryUsage>) getMemoryUsageAfterGc.invoke(gcInfo);
-                                for (Map.Entry<String, MemoryUsage> entry : mapAfter.entrySet()) {
-                                    String name = entry.getKey();
-                                    MemoryUsage after = entry.getValue();
-                                    MemoryUsage before = mapBefore.get(name);
-                                    long c = before.getUsed() - after.getUsed();
-                                    if (c > 0) {
-                                        churn.add(name, c);
-                                    }
+                return (n, o) -> {
+                    try {
+                        if (n.getType().equals(notifNameField.get(null))) {
+                            Object info = infoMethod.invoke(null, n.getUserData());
+                            Object gcInfo = getGcInfo.invoke(info);
+                            Map<String, MemoryUsage> mapBefore = (Map<String, MemoryUsage>) getMemoryUsageBeforeGc.invoke(gcInfo);
+                            Map<String, MemoryUsage> mapAfter = (Map<String, MemoryUsage>) getMemoryUsageAfterGc.invoke(gcInfo);
+                            for (Map.Entry<String, MemoryUsage> entry : mapAfter.entrySet()) {
+                                String name = entry.getKey();
+                                MemoryUsage after = entry.getValue();
+                                MemoryUsage before = mapBefore.get(name);
+                                long c = before.getUsed() - after.getUsed();
+                                if (c > 0) {
+                                    churn.add(name, c);
                                 }
                             }
-                        } catch (IllegalAccessException | InvocationTargetException e) {
-                            // Do nothing, counters would not get populated
                         }
+                    } catch (IllegalAccessException | InvocationTargetException e) {
+                        // Do nothing, counters would not get populated
                     }
                 };
             } catch (Throwable e) {
@@ -343,7 +340,7 @@ public class GCProfiler implements InternalProfiler {
         }
 
         public static synchronized Multiset<String> getChurn() {
-            return (churn != null) ? churn : new HashMultiset<String>();
+            return (churn != null) ? churn : new HashMultiset<>();
         }
     }
 

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfAsmProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfAsmProfiler.java
@@ -228,7 +228,7 @@ public class LinuxPerfAsmProfiler extends AbstractPerfAsmProfiler {
             Multimap<MethodDesc, Long> methods = new HashMultimap<>();
             Map<String, Multiset<Long>> events = new LinkedHashMap<>();
             for (String evName : evNames) {
-                events.put(evName, new TreeMultiset<Long>());
+                events.put(evName, new TreeMultiset<>());
             }
 
             Double startTime = null;

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/StackProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/StackProfiler.java
@@ -141,7 +141,7 @@ public class StackProfiler implements InternalProfiler {
         public SamplingTask() {
             stacks = new EnumMap<>(Thread.State.class);
             for (Thread.State s : Thread.State.values()) {
-                stacks.put(s, new HashMultiset<StackRecord>());
+                stacks.put(s, new HashMultiset<>());
             }
             thread = new Thread(this);
             thread.setName("Sampling Thread");
@@ -279,7 +279,7 @@ public class StackProfiler implements InternalProfiler {
 
         public String getStack(final Map<Thread.State, Multiset<StackRecord>> stacks) {
             List<Thread.State> sortedStates = new ArrayList<>(stacks.keySet());
-            Collections.sort(sortedStates, new Comparator<Thread.State>() {
+            sortedStates.sort(new Comparator<Thread.State>() {
 
                 private long stateSize(Thread.State state) {
                     Multiset<StackRecord> set = stacks.get(state);
@@ -383,7 +383,7 @@ public class StackProfiler implements InternalProfiler {
             for (StackResult r : results) {
                 for (Map.Entry<Thread.State, Multiset<StackRecord>> entry : r.stacks.entrySet()) {
                     if (!sum.containsKey(entry.getKey())) {
-                        sum.put(entry.getKey(), new HashMultiset<StackRecord>());
+                        sum.put(entry.getKey(), new HashMultiset<>());
                     }
                     Multiset<StackRecord> sumSet = sum.get(entry.getKey());
                     for (StackRecord rec : entry.getValue().keys()) {

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/WinPerfAsmProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/WinPerfAsmProfiler.java
@@ -195,7 +195,7 @@ public class WinPerfAsmProfiler extends AbstractPerfAsmProfiler {
             Multimap<MethodDesc, Long> methods = new HashMultimap<>();
             Map<String, Multiset<Long>> events = new LinkedHashMap<>();
             for (String evName : requestedEventNames) {
-                events.put(evName, new TreeMultiset<Long>());
+                events.put(evName, new TreeMultiset<>());
             }
 
             String line;

--- a/jmh-core/src/main/java/org/openjdk/jmh/results/RunResult.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/results/RunResult.java
@@ -90,11 +90,6 @@ public class RunResult implements Serializable {
         return params;
     }
 
-    public static final Comparator<RunResult> DEFAULT_SORT_COMPARATOR = new Comparator<RunResult>() {
-        @Override
-        public int compare(RunResult o1, RunResult o2) {
-            return o1.params.compareTo(o2.params);
-        }
-    };
+    public static final Comparator<RunResult> DEFAULT_SORT_COMPARATOR = Comparator.comparing(o -> o.params);
 
 }

--- a/jmh-core/src/main/java/org/openjdk/jmh/results/format/ResultFormatFactory.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/results/format/ResultFormatFactory.java
@@ -41,18 +41,15 @@ public class ResultFormatFactory {
      * @return result format
      */
     public static ResultFormat getInstance(final ResultFormatType type, final String file) {
-        return new ResultFormat() {
-            @Override
-            public void writeOut(Collection<RunResult> results) {
-                try {
-                    PrintStream pw = new PrintStream(file, "UTF-8");
-                    ResultFormat rf = getInstance(type, pw);
-                    rf.writeOut(results);
-                    pw.flush();
-                    pw.close();
-                } catch (IOException e) {
-                    throw new IllegalStateException(e);
-                }
+        return results -> {
+            try {
+                PrintStream pw = new PrintStream(file, "UTF-8");
+                ResultFormat rf = getInstance(type, pw);
+                rf.writeOut(results);
+                pw.flush();
+                pw.close();
+            } catch (IOException e) {
+                throw new IllegalStateException(e);
             }
         };
     }

--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/link/BinaryLinkClient.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/link/BinaryLinkClient.java
@@ -82,12 +82,9 @@ public final class BinaryLinkClient {
         this.outputFormat = (OutputFormat) Proxy.newProxyInstance(
                 Thread.currentThread().getContextClassLoader(),
                 new Class[]{OutputFormat.class},
-                new InvocationHandler() {
-                    @Override
-                    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-                        pushFrame(new OutputFormatFrame(ClassConventions.getMethodName(method), args));
-                        return null; // expect null
-                    }
+                (proxy, method, args) -> {
+                    pushFrame(new OutputFormatFrame(ClassConventions.getMethodName(method), args));
+                    return null; // expect null
                 }
         );
 

--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/link/BinaryLinkServer.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/link/BinaryLinkServer.java
@@ -103,7 +103,7 @@ public final class BinaryLinkServer {
 
         handler = new AtomicReference<>();
         metadata = new AtomicReference<>();
-        results = new AtomicReference<List<IterationResult>>(new ArrayList<IterationResult>());
+        results = new AtomicReference<>(new ArrayList<>());
         exception = new AtomicReference<>();
         plan = new AtomicReference<>();
     }
@@ -142,7 +142,7 @@ public final class BinaryLinkServer {
     }
 
     public List<IterationResult> getResults() {
-        List<IterationResult> res = results.getAndSet(new ArrayList<IterationResult>());
+        List<IterationResult> res = results.getAndSet(new ArrayList<>());
         if (res != null) {
             return res;
         } else {

--- a/jmh-core/src/main/java/org/openjdk/jmh/util/HashMultimap.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/util/HashMultimap.java
@@ -32,6 +32,6 @@ public class HashMultimap<K, V> extends DelegatingMultimap<K, V> implements Seri
     private static final long serialVersionUID = 2484428623123444998L;
 
     public HashMultimap() {
-        super(new HashMap<K, Collection<V>>());
+        super(new HashMap<>());
     }
 }

--- a/jmh-core/src/main/java/org/openjdk/jmh/util/HashMultiset.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/util/HashMultiset.java
@@ -31,6 +31,6 @@ public class HashMultiset<T> extends DelegatingMultiset<T> implements Serializab
     private static final long serialVersionUID = 8149201968248505516L;
 
     public HashMultiset() {
-        super(new HashMap<T, Long>());
+        super(new HashMap<>());
     }
 }

--- a/jmh-core/src/main/java/org/openjdk/jmh/util/HashsetMultimap.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/util/HashsetMultimap.java
@@ -33,7 +33,7 @@ public class HashsetMultimap<K, V> extends DelegatingMultimap<K, V> implements S
     private static final long serialVersionUID = -4236100656731956836L;
 
     public HashsetMultimap() {
-        super(new HashMap<K, Collection<V>>());
+        super(new HashMap<>());
     }
 
     @Override

--- a/jmh-core/src/main/java/org/openjdk/jmh/util/Multisets.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/util/Multisets.java
@@ -29,12 +29,7 @@ import java.util.*;
 public class Multisets {
 
     public static <T> List<T> countHighest(Multiset<T> set, int top) {
-        Queue<Map.Entry<T, Long>> q = new BoundedPriorityQueue<>(top, new Comparator<Map.Entry<T, Long>>() {
-            @Override
-            public int compare(Map.Entry<T, Long> o1, Map.Entry<T, Long> o2) {
-                return o2.getValue().compareTo(o1.getValue());
-            }
-        });
+        Queue<Map.Entry<T, Long>> q = new BoundedPriorityQueue<>(top, Map.Entry.<T, Long>comparingByValue().reversed());
 
         q.addAll(set.entrySet());
 
@@ -52,15 +47,8 @@ public class Multisets {
     }
 
     public static <T> List<T> sortedDesc(final Multiset<T> set) {
-        List<T> sorted = new ArrayList<>();
-        sorted.addAll(set.keys());
-
-        Collections.sort(sorted, new Comparator<T>() {
-            @Override
-            public int compare(T o1, T o2) {
-                return Long.compare(set.count(o2), set.count(o1));
-            }
-        });
+        List<T> sorted = new ArrayList<>(set.keys());
+        sorted.sort((o1, o2) -> Long.compare(set.count(o2), set.count(o1)));
         return sorted;
     }
 

--- a/jmh-core/src/main/java/org/openjdk/jmh/util/TreeMultimap.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/util/TreeMultimap.java
@@ -32,6 +32,6 @@ public class TreeMultimap<K, V> extends DelegatingMultimap<K, V> implements Seri
     private static final long serialVersionUID = 1323519395777393861L;
 
     public TreeMultimap() {
-        super(new TreeMap<K, Collection<V>>());
+        super(new TreeMap<>());
     }
 }

--- a/jmh-core/src/main/java/org/openjdk/jmh/util/TreeMultiset.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/util/TreeMultiset.java
@@ -31,6 +31,6 @@ public class TreeMultiset<T extends Comparable<T>> extends DelegatingMultiset<T>
     private static final long serialVersionUID = 3571810468402616517L;
 
     public TreeMultiset() {
-        super(new TreeMap<T, Long>());
+        super(new TreeMap<>());
     }
 }

--- a/jmh-core/src/main/java/org/openjdk/jmh/util/Utils.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/util/Utils.java
@@ -602,12 +602,7 @@ public class Utils {
      * @return iterable for given iterator
      */
     public static <T> Iterable<T> adaptForLoop(final Iterator<T> it) {
-        return new Iterable<T>() {
-            @Override
-            public Iterator<T> iterator() {
-                return it;
-            }
-        };
+        return () -> it;
     }
 
 }

--- a/jmh-generator-annprocess/pom.xml
+++ b/jmh-generator-annprocess/pom.xml
@@ -60,9 +60,6 @@ questions.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <compilerVersion>1.7</compilerVersion>
-                    <source>1.7</source>
-                    <target>1.7</target>
                     <compilerArgument>-proc:none</compilerArgument>
                 </configuration>
             </plugin>

--- a/jmh-generator-annprocess/src/main/java/org/openjdk/jmh/generators/annotations/APGeneratorSource.java
+++ b/jmh-generator-annprocess/src/main/java/org/openjdk/jmh/generators/annotations/APGeneratorSource.java
@@ -57,12 +57,7 @@ public class APGeneratorSource implements GeneratorSource {
             return classInfos;
         }
 
-        Collection<TypeElement> discoveredClasses = new TreeSet<>(new Comparator<TypeElement>() {
-            @Override
-            public int compare(TypeElement o1, TypeElement o2) {
-                return o1.getQualifiedName().toString().compareTo(o2.getQualifiedName().toString());
-            }
-        });
+        Collection<TypeElement> discoveredClasses = new TreeSet<>(Comparator.comparing(o -> o.getQualifiedName().toString()));
 
         // Need to do a few rollovers to find all classes that have @Benchmark-annotated methods in their
         // subclasses. This is mostly due to some of the nested classes not discoverable at once,

--- a/jmh-generator-asm/pom.xml
+++ b/jmh-generator-asm/pom.xml
@@ -68,9 +68,6 @@ questions.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <compilerVersion>1.7</compilerVersion>
-                    <source>1.7</source>
-                    <target>1.7</target>
                     <compilerArgument>-proc:none</compilerArgument>
                 </configuration>
             </plugin>

--- a/jmh-generator-asm/src/main/java/org/openjdk/jmh/generators/asm/ASMClassInfo.java
+++ b/jmh-generator-asm/src/main/java/org/openjdk/jmh/generators/asm/ASMClassInfo.java
@@ -62,7 +62,7 @@ class ASMClassInfo extends ClassVisitor implements ClassInfo {
     private String origQualifiedName;
 
     public ASMClassInfo(ClassInfoRepo classInfos) {
-        super(Opcodes.ASM4);
+        super(Opcodes.ASM5);
         this.classInfos = classInfos;
         this.methods = new ArrayList<>();
         this.constructors = new ArrayList<>();

--- a/jmh-generator-asm/src/main/java/org/openjdk/jmh/generators/asm/ASMFieldInfo.java
+++ b/jmh-generator-asm/src/main/java/org/openjdk/jmh/generators/asm/ASMFieldInfo.java
@@ -45,7 +45,7 @@ class ASMFieldInfo extends FieldVisitor implements FieldInfo {
     private final Map<String, AnnotationInvocationHandler> annotations;
 
     public ASMFieldInfo(FieldVisitor fieldVisitor, ASMClassInfo declaringClass, int access, String name, ClassInfo type) {
-        super(Opcodes.ASM4, fieldVisitor);
+        super(Opcodes.ASM5, fieldVisitor);
         this.declaringClass = declaringClass;
         this.access = access;
         this.name = name;

--- a/jmh-generator-asm/src/main/java/org/openjdk/jmh/generators/asm/ASMMethodInfo.java
+++ b/jmh-generator-asm/src/main/java/org/openjdk/jmh/generators/asm/ASMMethodInfo.java
@@ -50,7 +50,7 @@ class ASMMethodInfo extends MethodVisitor implements MethodInfo  {
     private final ClassInfoRepo repo;
 
     public ASMMethodInfo(MethodVisitor methodVisitor, ClassInfoRepo repo, ASMClassInfo declaringClass, int access, String name, String desc, String signature) {
-        super(Opcodes.ASM4, methodVisitor);
+        super(Opcodes.ASM5, methodVisitor);
         this.declaringClass = declaringClass;
         this.repo = repo;
         this.access = access;

--- a/jmh-generator-asm/src/main/java/org/openjdk/jmh/generators/asm/AnnotationInvocationHandler.java
+++ b/jmh-generator-asm/src/main/java/org/openjdk/jmh/generators/asm/AnnotationInvocationHandler.java
@@ -42,7 +42,7 @@ class AnnotationInvocationHandler extends AnnotationVisitor implements Invocatio
     private final Multimap<String, Object> values;
 
     public AnnotationInvocationHandler(String className, AnnotationVisitor annotationVisitor) {
-        super(Opcodes.ASM4, annotationVisitor);
+        super(Opcodes.ASM5, annotationVisitor);
         this.className = className;
         this.values = new HashMultimap<>();
     }
@@ -211,7 +211,7 @@ class AnnotationInvocationHandler extends AnnotationVisitor implements Invocatio
 
     @Override
     public AnnotationVisitor visitArray(final String name) {
-        return new AnnotationVisitor(Opcodes.ASM4, super.visitArray(name)) {
+        return new AnnotationVisitor(Opcodes.ASM5, super.visitArray(name)) {
             @Override
             public void visitEnum(String n, String desc, String value) {
                 values.put(name, value);

--- a/jmh-generator-bytecode/pom.xml
+++ b/jmh-generator-bytecode/pom.xml
@@ -69,9 +69,6 @@ questions.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <compilerVersion>1.7</compilerVersion>
-                    <source>1.7</source>
-                    <target>1.7</target>
                     <compilerArgument>-proc:none</compilerArgument>
                 </configuration>
             </plugin>

--- a/jmh-generator-reflection/pom.xml
+++ b/jmh-generator-reflection/pom.xml
@@ -59,9 +59,6 @@ questions.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <compilerVersion>1.7</compilerVersion>
-                    <source>1.7</source>
-                    <target>1.7</target>
                     <compilerArgument>-proc:none</compilerArgument>
                 </configuration>
             </plugin>

--- a/jmh-samples/pom.xml
+++ b/jmh-samples/pom.xml
@@ -74,9 +74,6 @@ THE POSSIBILITY OF SUCH DAMAGE.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <compilerVersion>1.7</compilerVersion>
-                    <source>1.7</source>
-                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,11 @@ questions.
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.8.0</version>
+                    <configuration>
+                        <compilerVersion>1.8</compilerVersion>
+                        <source>1.8</source>
+                        <target>1.8</target>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Head JDK 20-ea does not support building with -source/target 7 anymore. JDK 7 is very old and unlikely to be used widely. We can bump the minimal version to JDK 8 to get... ahem... all the new features that release brings! 

If you have a strong opinion that we should **not** drop JDK 7 support, please speak up soon.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903355](https://bugs.openjdk.org/browse/CODETOOLS-7903355): JMH: Drop support for JDK 7


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh pull/86/head:pull/86` \
`$ git checkout pull/86`

Update a local copy of the PR: \
`$ git checkout pull/86` \
`$ git pull https://git.openjdk.org/jmh pull/86/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 86`

View PR using the GUI difftool: \
`$ git pr show -t 86`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/86.diff">https://git.openjdk.org/jmh/pull/86.diff</a>

</details>
