### PR TITLE
7903368: JMH: GC profiler misreports allocation and churn rates

### DIFF
--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/GCProfilerAllocRateTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/GCProfilerAllocRateTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jmh.it.profilers;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.it.Fixtures;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+public class GCProfilerAllocRateTest {
+
+    @Benchmark
+    public Object allocate() {
+        return new byte[1000];
+    }
+
+    @Test
+    public void test() throws RunnerException {
+        Options opts = new OptionsBuilder()
+                .include(Fixtures.getTestMask(this.getClass()))
+                .addProfiler(GCProfiler.class)
+                .build();
+
+        RunResult rr = new Runner(opts).runSingle();
+
+        double opsPerSec = rr.getPrimaryResult().getScore();
+
+        Map<String, Result> sr = rr.getSecondaryResults();
+        double allocRateMB = sr.get("·gc.alloc.rate").getScore();
+        double allocRateNormB = sr.get("·gc.alloc.rate.norm").getScore();
+        double allocRatePrimaryMB = opsPerSec * allocRateNormB / 1024 / 1024;
+
+        // Allow 20% slack
+        if (Math.abs(1 - allocRatePrimaryMB / allocRateMB) > 0.2) {
+            Assert.fail("Allocation rates disagree. " +
+                    "Reported by profiler: " + allocRateMB +
+                    ", computed from primary score: " + allocRatePrimaryMB);
+        }
+    }
+}

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/GCProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/GCProfiler.java
@@ -71,8 +71,9 @@ public class GCProfiler implements InternalProfiler {
 
     @Override
     public Collection<? extends Result> afterIteration(BenchmarkParams benchmarkParams, IterationParams iterationParams, IterationResult iResult) {
-        VMSupport.finishChurnProfile();
         long afterTime = System.nanoTime();
+
+        VMSupport.finishChurnProfile();
 
         long gcTime = 0;
         long gcCount = 0;


### PR DESCRIPTION
Look at the new test. If you multiply the allocation rate from `gc.alloc.rate.norm` by the benchmark throughput, it would disagree with `gc.alloc.rate`. This is because `gc.alloc.rate` is computed by GC profiler using its own timer, which accidentally includes the artificial delay before deregistering the GC notifications.

The current delay is 500ms. With 1000ms iterations, the disagreement would be about (1000+500)/1000 = 1.5x!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903368](https://bugs.openjdk.org/browse/CODETOOLS-7903368): JMH: GC profiler misreports allocation and churn rates


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh pull/87/head:pull/87` \
`$ git checkout pull/87`

Update a local copy of the PR: \
`$ git checkout pull/87` \
`$ git pull https://git.openjdk.org/jmh pull/87/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 87`

View PR using the GUI difftool: \
`$ git pr show -t 87`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/87.diff">https://git.openjdk.org/jmh/pull/87.diff</a>

</details>
