### PR TITLE
CODETOOLS-7903369: JMH: GC profiler options

### DIFF
--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/GCProfilerAllocRateTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/GCProfilerAllocRateTest.java
@@ -53,10 +53,24 @@ public class GCProfilerAllocRateTest {
     }
 
     @Test
-    public void test() throws RunnerException {
+    public void testDefault() throws RunnerException {
+        testWith("");
+    }
+
+    @Test
+    public void testAlloc() throws RunnerException {
+        testWith("alloc=true");
+    }
+
+    @Test
+    public void testAll() throws RunnerException {
+        testWith("alloc=true;churn=true");
+    }
+
+    private void testWith(String initLine) throws RunnerException {
         Options opts = new OptionsBuilder()
                 .include(Fixtures.getTestMask(this.getClass()))
-                .addProfiler(GCProfiler.class)
+                .addProfiler(GCProfiler.class, initLine)
                 .build();
 
         RunResult rr = new Runner(opts).runSingle();

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/GCProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/GCProfilerTest.java
@@ -36,23 +36,20 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import java.util.concurrent.TimeUnit;
 
-/**
- * Tests allocation profiler.
- */
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Fork(1) // 0 to enable debugging
 public class GCProfilerTest {
 
     @Benchmark
     @Warmup(iterations = 0)
-    @Measurement(iterations = 20, time = 10, timeUnit = TimeUnit.MILLISECONDS)
+    @Measurement(iterations = 10, time = 10, timeUnit = TimeUnit.MILLISECONDS)
     @BenchmarkMode(Mode.AverageTime)
     public Object allocateObjectNoWarmup() {
         return new Object();
     }
 
     @Benchmark
-    @Warmup(iterations = 2)
+    @Warmup(iterations = 2, time = 1, timeUnit = TimeUnit.SECONDS)
     @Measurement(iterations = 2, time = 2, timeUnit = TimeUnit.SECONDS)
     @BenchmarkMode(Mode.AverageTime)
     public Object allocateObject() {
@@ -68,7 +65,7 @@ public class GCProfilerTest {
     }
 
     @Benchmark
-    @Warmup(iterations = 2)
+    @Warmup(iterations = 2, time = 1, timeUnit = TimeUnit.SECONDS)
     @Measurement(iterations = 1, time = 2, timeUnit = TimeUnit.SECONDS)
     @BenchmarkMode(Mode.SampleTime)
     public Object allocateObjectSampleTime() {
@@ -76,10 +73,37 @@ public class GCProfilerTest {
     }
 
     @Test
-    public void testAllocationProfiler() throws RunnerException {
+    public void testDefault() throws RunnerException {
         Options opts = new OptionsBuilder()
                 .include(Fixtures.getTestMask(this.getClass()))
                 .addProfiler(GCProfiler.class)
+                .build();
+        new Runner(opts).run();
+    }
+
+    @Test
+    public void testAlloc() throws RunnerException {
+        Options opts = new OptionsBuilder()
+                .include(Fixtures.getTestMask(this.getClass()))
+                .addProfiler(GCProfiler.class, "alloc=true")
+                .build();
+        new Runner(opts).run();
+    }
+
+    @Test
+    public void testChurn() throws RunnerException {
+        Options opts = new OptionsBuilder()
+                .include(Fixtures.getTestMask(this.getClass()))
+                .addProfiler(GCProfiler.class, "churn=true;churnWait=1")
+                .build();
+        new Runner(opts).run();
+    }
+
+    @Test
+    public void testAll() throws RunnerException {
+        Options opts = new OptionsBuilder()
+                .include(Fixtures.getTestMask(this.getClass()))
+                .addProfiler(GCProfiler.class, "alloc=true;churn=true;churnWait=1")
                 .build();
         new Runner(opts).run();
     }

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/GCProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/GCProfiler.java
@@ -24,9 +24,14 @@
  */
 package org.openjdk.jmh.profile;
 
+import joptsimple.OptionException;
+import joptsimple.OptionParser;
+import joptsimple.OptionSet;
+import joptsimple.OptionSpec;
 import org.openjdk.jmh.infra.BenchmarkParams;
 import org.openjdk.jmh.infra.IterationParams;
 import org.openjdk.jmh.results.*;
+import org.openjdk.jmh.runner.options.IntegerValueConverter;
 import org.openjdk.jmh.util.HashMultiset;
 import org.openjdk.jmh.util.Multiset;
 
@@ -48,14 +53,56 @@ public class GCProfiler implements InternalProfiler {
     private long beforeGCTime;
     private HotspotAllocationSnapshot beforeAllocated;
 
+    private boolean churnEnabled;
+    private boolean allocEnabled;
+    private long churnWait;
+
     @Override
     public String getDescription() {
         return "GC profiling via standard MBeans";
     }
 
+    public GCProfiler(String initLine) throws ProfilerException {
+        OptionParser parser = new OptionParser();
+        parser.formatHelpWith(new ProfilerOptionFormatter(PausesProfiler.class.getCanonicalName()));
+
+        OptionSpec<Boolean> optAllocEnable = parser.accepts("alloc", "Enable GC allocation measurement.")
+                .withRequiredArg().ofType(Boolean.class).describedAs("bool").defaultsTo(true);
+
+        OptionSpec<Boolean> optChurnEnable = parser.accepts("churn", "Enable GC churn measurement.")
+                .withRequiredArg().ofType(Boolean.class).describedAs("bool").defaultsTo(false);
+
+        OptionSpec<Integer> optChurnWait = parser.accepts("churnWait", "Time to wait for churn notifications to arrive.")
+                .withRequiredArg().withValuesConvertedBy(IntegerValueConverter.POSITIVE).describedAs("ms").defaultsTo(500);
+
+        OptionSet set = ProfilerUtils.parseInitLine(initLine, parser);
+
+        try {
+            churnWait = set.valueOf(optChurnWait);
+            churnEnabled = set.valueOf(optChurnEnable);
+            allocEnabled = set.valueOf(optAllocEnable);
+        } catch (OptionException e) {
+            throw new ProfilerException(e.getMessage());
+        }
+
+        if (churnEnabled) {
+            if (!VMSupport.tryInitChurn()) {
+                churnEnabled = false;
+            }
+        }
+
+        if (allocEnabled) {
+            if (!VMSupport.tryInitAlloc()) {
+                allocEnabled = false;
+            }
+        }
+    }
+
     @Override
     public void beforeIteration(BenchmarkParams benchmarkParams, IterationParams iterationParams) {
-        VMSupport.startChurnProfile();
+        if (churnEnabled) {
+            VMSupport.startChurnProfile();
+        }
 
         long gcTime = 0;
         long gcCount = 0;
@@ -65,7 +112,10 @@ public class GCProfiler implements InternalProfiler {
         }
         this.beforeGCCount = gcCount;
         this.beforeGCTime = gcTime;
-        this.beforeAllocated = VMSupport.getSnapshot();
+
+        if (allocEnabled) {
+            this.beforeAllocated = VMSupport.getSnapshot();
+        }
         this.beforeTime = System.nanoTime();
     }
 
@@ -73,39 +123,17 @@ public class GCProfiler implements InternalProfiler {
     public Collection<? extends Result> afterIteration(BenchmarkParams benchmarkParams, IterationParams iterationParams, IterationResult iResult) {
         long afterTime = System.nanoTime();
 
-        VMSupport.finishChurnProfile();
+        if (churnEnabled) {
+            VMSupport.finishChurnProfile(churnWait);
+        }
+
+        List<ScalarResult> results = new ArrayList<>();
 
         long gcTime = 0;
         long gcCount = 0;
         for (GarbageCollectorMXBean bean : ManagementFactory.getGarbageCollectorMXBeans()) {
             gcCount += bean.getCollectionCount();
             gcTime += bean.getCollectionTime();
-        }
-
-        List<ScalarResult> results = new ArrayList<>();
-
-        if (beforeAllocated == HotspotAllocationSnapshot.EMPTY) {
-            // When allocation profiling fails, make sure it is distinguishable in report
-            results.add(new ScalarResult(Defaults.PREFIX + "gc.alloc.rate",
-                    Double.NaN,
-                    "MB/sec", AggregationPolicy.AVG));
-        } else {
-            HotspotAllocationSnapshot newSnapshot = VMSupport.getSnapshot();
-            long allocated = newSnapshot.subtract(beforeAllocated);
-            // When no allocations measured, we still need to report results to avoid user confusion
-            results.add(new ScalarResult(Defaults.PREFIX + "gc.alloc.rate",
-                            (afterTime != beforeTime) ?
-                                    1.0 * allocated / 1024 / 1024 * TimeUnit.SECONDS.toNanos(1) / (afterTime - beforeTime) :
-                                    Double.NaN,
-                            "MB/sec", AggregationPolicy.AVG));
-            if (allocated != 0) {
-                long allOps = iResult.getMetadata().getAllOps();
-                results.add(new ScalarResult(Defaults.PREFIX + "gc.alloc.rate.norm",
-                                (allOps != 0) ?
-                                        1.0 * allocated / allOps :
-                                        Double.NaN,
-                                "B/op", AggregationPolicy.AVG));
-            }
         }
 
         results.add(new ScalarResult(
@@ -122,27 +150,55 @@ public class GCProfiler implements InternalProfiler {
                     AggregationPolicy.SUM));
         }
 
-        Multiset<String> churn = VMSupport.getChurn();
-        for (String space : churn.keys()) {
-            double churnRate = (afterTime != beforeTime) ?
-                    1.0 * churn.count(space) * TimeUnit.SECONDS.toNanos(1) / (afterTime - beforeTime) / 1024 / 1024 :
-                    Double.NaN;
+        if (allocEnabled) {
+            if (beforeAllocated != HotspotAllocationSnapshot.EMPTY) {
+                HotspotAllocationSnapshot newSnapshot = VMSupport.getSnapshot();
+                long allocated = newSnapshot.subtract(beforeAllocated);
+                // When no allocations measured, we still need to report results to avoid user confusion
+                results.add(new ScalarResult(Defaults.PREFIX + "gc.alloc.rate",
+                        (afterTime != beforeTime) ?
+                                1.0 * allocated / 1024 / 1024 * TimeUnit.SECONDS.toNanos(1) / (afterTime - beforeTime) :
+                                Double.NaN,
+                        "MB/sec", AggregationPolicy.AVG));
+                if (allocated != 0) {
+                    long allOps = iResult.getMetadata().getAllOps();
+                    results.add(new ScalarResult(Defaults.PREFIX + "gc.alloc.rate.norm",
+                            (allOps != 0) ?
+                                    1.0 * allocated / allOps :
+                                    Double.NaN,
+                            "B/op", AggregationPolicy.AVG));
+                }
+            } else {
+                // When allocation profiling fails, make sure it is distinguishable in report
+                results.add(new ScalarResult(Defaults.PREFIX + "gc.alloc.rate",
+                        Double.NaN,
+                        "MB/sec", AggregationPolicy.AVG));
+            }
+        }
 
-            double churnNorm = 1.0 * churn.count(space) / iResult.getMetadata().getAllOps();
+        if (churnEnabled) {
+            Multiset<String> churn = VMSupport.getChurn();
+            for (String space : churn.keys()) {
+                double churnRate = (afterTime != beforeTime) ?
+                        1.0 * churn.count(space) * TimeUnit.SECONDS.toNanos(1) / (afterTime - beforeTime) / 1024 / 1024 :
+                        Double.NaN;
 
-            String spaceName = space.replaceAll(" ", "_");
+                double churnNorm = 1.0 * churn.count(space) / iResult.getMetadata().getAllOps();
 
-            results.add(new ScalarResult(
-                    Defaults.PREFIX + "gc.churn." + spaceName + "",
-                    churnRate,
-                    "MB/sec",
-                    AggregationPolicy.AVG));
+                String spaceName = space.replaceAll(" ", "_");
 
-            results.add(new ScalarResult(
-                    Defaults.PREFIX + "gc.churn." + spaceName + ".norm",
-                    churnNorm,
-                    "B/op",
-                    AggregationPolicy.AVG));
+                results.add(new ScalarResult(
+                        Defaults.PREFIX + "gc.churn." + spaceName + "",
+                        churnRate,
+                        "MB/sec",
+                        AggregationPolicy.AVG));
+
+                results.add(new ScalarResult(
+                        Defaults.PREFIX + "gc.churn." + spaceName + ".norm",
+                        churnNorm,
+                        "B/op",
+                        AggregationPolicy.AVG));
+            }
         }
 
         return results;
@@ -197,18 +253,10 @@ public class GCProfiler implements InternalProfiler {
      * Reflection to enable building against a standard JDK.
      */
     static class VMSupport {
-        private static final boolean ALLOC_AVAILABLE;
         private static ThreadMXBean ALLOC_MX_BEAN;
         private static Method ALLOC_MX_BEAN_GETTER;
-        private static final boolean CHURN_AVAILABLE;
-        private static NotificationListener listener;
-        private static Multiset<String> churn;
-        private static boolean started;
-
-        static {
-            ALLOC_AVAILABLE = tryInitAlloc();
-            CHURN_AVAILABLE = tryInitChurn();
-        }
+        private static NotificationListener LISTENER;
+        private static Multiset<String> CHURN;
 
         private static boolean tryInitAlloc() {
             try {
@@ -241,8 +289,8 @@ public class GCProfiler implements InternalProfiler {
                         throw new UnsupportedOperationException("GarbageCollectorMXBean cannot notify");
                     }
                 }
-                churn = new HashMultiset<>();
-                listener = newListener();
+                CHURN = new HashMultiset<>();
+                LISTENER = newListener();
                 return true;
             } catch (Throwable e) {
                 System.out.println("Churn profiling is not available: " + e.getMessage());
@@ -283,7 +331,7 @@ public class GCProfiler implements InternalProfiler {
                                     MemoryUsage before = mapBefore.get(name);
                                     long c = before.getUsed() - after.getUsed();
                                     if (c > 0) {
-                                        churn.add(name, c);
+                                        CHURN.add(name, c);
                                     }
                                 }
                             }
@@ -298,53 +346,41 @@ public class GCProfiler implements InternalProfiler {
         }
 
         public static HotspotAllocationSnapshot getSnapshot() {
-            if (!ALLOC_AVAILABLE) return HotspotAllocationSnapshot.EMPTY;
             long[] threadIds = ALLOC_MX_BEAN.getAllThreadIds();
             long[] allocatedBytes = getAllocatedBytes(threadIds);
             return new HotspotAllocationSnapshot(threadIds, allocatedBytes);
         }
 
         public static synchronized void startChurnProfile() {
-            if (!CHURN_AVAILABLE) return;
-            if (started) {
-                throw new IllegalStateException("Churn profile already started");
-            }
-            started = true;
-            churn.clear();
+            CHURN.clear();
             try {
                 for (GarbageCollectorMXBean bean : ManagementFactory.getGarbageCollectorMXBeans()) {
-                    ((NotificationEmitter) bean).addNotificationListener(listener, null, null);
+                    ((NotificationEmitter) bean).addNotificationListener(LISTENER, null, null);
                 }
             } catch (Exception e) {
                 throw new IllegalStateException("Should not be here");
             }
         }
 
-        public static synchronized void finishChurnProfile() {
-            if (!CHURN_AVAILABLE) return;
-            if (!started) {
-                throw new IllegalStateException("Churn profile already stopped");
-            }
-
+        public static synchronized void finishChurnProfile(long churnWait) {
             // Notifications are asynchronous, need to wait a bit before deregistering the listener.
             try {
-                Thread.sleep(500);
+                Thread.sleep(churnWait);
             } catch (InterruptedException e) {
                 // do not care
             }
 
             for (GarbageCollectorMXBean bean : ManagementFactory.getGarbageCollectorMXBeans()) {
                 try {
-                    ((NotificationEmitter) bean).removeNotificationListener(listener);
+                    ((NotificationEmitter) bean).removeNotificationListener(LISTENER);
                 } catch (ListenerNotFoundException e) {
                     // Do nothing
                 }
             }
-            started = false;
         }
 
         public static synchronized Multiset<String> getChurn() {
-            return (churn != null) ? churn : new HashMultiset<String>();
+            return (CHURN != null) ? CHURN : new HashMultiset<String>();
         }
     }
 


### PR DESCRIPTION
GC profiler has two large parts: measuring allocs and measuring churn. Churn measurement was the first thing implemented in this profiler, and then allocation measurement was added. At this point, churn is seldom used for performance benchmarks, as it is noisy. Additionally, it depends on asynchronous GC notifications, and thus introduces iteration delays to catch up with them.

We can add options to GC profiler and turn off "churn" by default.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903369](https://bugs.openjdk.org/browse/CODETOOLS-7903369): JMH: GC profiler options


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh pull/88/head:pull/88` \
`$ git checkout pull/88`

Update a local copy of the PR: \
`$ git checkout pull/88` \
`$ git pull https://git.openjdk.org/jmh pull/88/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 88`

View PR using the GUI difftool: \
`$ git pr show -t 88`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/88.diff">https://git.openjdk.org/jmh/pull/88.diff</a>

</details>
