### PR TITLE
7903440: JMH: Add automatic module names

### DIFF
--- a/jmh-core/pom.xml
+++ b/jmh-core/pom.xml
@@ -120,6 +120,18 @@ questions.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.openjdk.jmh.core</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
         </plugins>
 
         <extensions>

--- a/jmh-core/pom.xml
+++ b/jmh-core/pom.xml
@@ -127,7 +127,7 @@ questions.
                 <configuration>
                     <archive>
                         <manifestEntries>
-                            <Automatic-Module-Name>org.openjdk.jmh.core</Automatic-Module-Name>
+                            <Automatic-Module-Name>org.openjdk.jmh</Automatic-Module-Name>
                         </manifestEntries>
                     </archive>
                 </configuration>

--- a/jmh-generator-annprocess/pom.xml
+++ b/jmh-generator-annprocess/pom.xml
@@ -92,6 +92,17 @@ questions.
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.openjdk.jmh.generators.annprocess</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/jmh-generator-asm/pom.xml
+++ b/jmh-generator-asm/pom.xml
@@ -100,7 +100,17 @@ questions.
                     </execution>
                 </executions>
             </plugin>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.openjdk.jmh.generators.asm</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/jmh-generator-bytecode/pom.xml
+++ b/jmh-generator-bytecode/pom.xml
@@ -123,7 +123,17 @@ questions.
                     </execution>
                 </executions>
             </plugin>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.openjdk.jmh.generators.bytecode</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/jmh-generator-reflection/pom.xml
+++ b/jmh-generator-reflection/pom.xml
@@ -91,6 +91,17 @@ questions.
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.openjdk.jmh.generators.reflection</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -208,6 +208,11 @@ questions.
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.3.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
                     <version>3.0.1</version>
                 </plugin>


### PR DESCRIPTION
`maven-jar-plugin` is used to add "Automatic-Module-Name" to `MANIFEST.MF` at buildtime. This is the minimum that is needed if you want to use the lib on the module path in a project.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903440](https://bugs.openjdk.org/browse/CODETOOLS-7903440): JMH: Add automatic module names (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/90/head:pull/90` \
`$ git checkout pull/90`

Update a local copy of the PR: \
`$ git checkout pull/90` \
`$ git pull https://git.openjdk.org/jmh.git pull/90/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 90`

View PR using the GUI difftool: \
`$ git pr show -t 90`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/90.diff">https://git.openjdk.org/jmh/pull/90.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/90#issuecomment-1405850677)