### PR TITLE
7903413: JMH: Safepoint profiler should parse JDK 13+ -Xlog:safepoint

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/SafepointsProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/SafepointsProfiler.java
@@ -128,6 +128,10 @@ public class SafepointsProfiler implements ExternalProfiler {
     }
 
     static long parseNs(String str) {
+        return (long) (Double.parseDouble(str.replace(',', '.')));
+    }
+
+    static long parseSecToNs(String str) {
         return (long) (Double.parseDouble(str.replace(',', '.')) * TimeUnit.SECONDS.toNanos(1));
     }
 
@@ -212,6 +216,9 @@ public class SafepointsProfiler implements ExternalProfiler {
     private static final Pattern JDK_9_LINE =
             Pattern.compile("\\[([0-9\\.,]*)s\\]\\[info\\]\\[safepoint( *)\\] (.*) stopped: ([0-9\\.,]*) seconds, (.*) took: ([0-9\\.,]*) seconds");
 
+    private static final Pattern JDK_13_LINE =
+            Pattern.compile("\\[([0-9\\.,]*)s\\]\\[info\\]\\[safepoint( *)\\] (.*) Reaching safepoint: ([0-9\\.,]*) ns, (.*) Total: ([0-9\\.,]*) ns");
+
     /**
      * Parse the line into the triplet. This is tested with unit tests, make sure to
      * update those if changing this code.
@@ -222,8 +229,8 @@ public class SafepointsProfiler implements ExternalProfiler {
             if (m.matches()) {
                 return new ParsedData(
                         7,
-                        parseNs(m.group(1)),
-                        parseNs(m.group(3)),
+                        parseSecToNs(m.group(1)),
+                        parseSecToNs(m.group(3)),
                         NO_LONG_VALUE
                 );
             }
@@ -234,9 +241,9 @@ public class SafepointsProfiler implements ExternalProfiler {
             if (m.matches()) {
                 return new ParsedData(
                         8,
-                        parseNs(m.group(1)),
-                        parseNs(m.group(3)),
-                        parseNs(m.group(5))
+                        parseSecToNs(m.group(1)),
+                        parseSecToNs(m.group(3)),
+                        parseSecToNs(m.group(5))
                 );
             }
         }
@@ -246,9 +253,21 @@ public class SafepointsProfiler implements ExternalProfiler {
             if (m.matches()) {
                 return new ParsedData(
                         9,
-                        parseNs(m.group(1)),
-                        parseNs(m.group(4)),
-                        parseNs(m.group(6))
+                        parseSecToNs(m.group(1)),
+                        parseSecToNs(m.group(4)),
+                        parseSecToNs(m.group(6))
+                );
+            }
+        }
+
+        {
+            Matcher m = JDK_13_LINE.matcher(line);
+            if (m.matches()) {
+                return new ParsedData(
+                        13,
+                        parseSecToNs(m.group(1)),
+                        parseNs(m.group(6)),
+                        parseNs(m.group(4))
                 );
             }
         }


### PR DESCRIPTION
[JDK-8219436](https://bugs.openjdk.org/browse/JDK-8219436) changed the -Xlog:safepoint logging, and JMH's parser breaks. We need to capture the new format.

Note this was further improved by [JDK-8297154](https://bugs.openjdk.org/browse/JDK-8297154), and needs to be tested with more modern JDKs too.

Additional testing:
 - [x] `-prof safepoints` with JDK 8
 - [x] `-prof safepoints` with JDK 11
 - [x] `-prof safepoints` with JDK 17
 - [x] `-prof safepoints` with JDK 21

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903413](https://bugs.openjdk.org/browse/CODETOOLS-7903413): JMH: Safepoint profiler should parse JDK 13+ -Xlog:safepoint


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh pull/93/head:pull/93` \
`$ git checkout pull/93`

Update a local copy of the PR: \
`$ git checkout pull/93` \
`$ git pull https://git.openjdk.org/jmh pull/93/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 93`

View PR using the GUI difftool: \
`$ git pr show -t 93`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/93.diff">https://git.openjdk.org/jmh/pull/93.diff</a>

</details>
