### PR TITLE
7903422: JMH: Add round-trip benchmarks to core tests

### DIFF
--- a/jmh-core-benchmarks/pom.xml
+++ b/jmh-core-benchmarks/pom.xml
@@ -55,6 +55,16 @@ questions.
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
+            <version>5.8.0</version>
+        </dependency>
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna-platform</artifactId>
+            <version>5.8.0</version>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/jmh-core-benchmarks/src/main/java/org/openjdk/jmh/benchmarks/RoundTripLatencyBench.java
+++ b/jmh-core-benchmarks/src/main/java/org/openjdk/jmh/benchmarks/RoundTripLatencyBench.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jmh.benchmarks;
+
+import org.openjdk.jmh.validation.SpinWaitSupport;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.validation.AffinitySupport;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+public class RoundTripLatencyBench {
+
+    static final boolean SPINWAIT = Boolean.getBoolean("spinWait");
+
+    @Param("-1")
+    int p;
+
+    @Param("-1")
+    int c;
+
+    Thread t;
+
+    volatile boolean ping;
+
+    @Setup
+    public void setup() {
+        if (c != -1) AffinitySupport.bind(c);
+        t = new Thread(() -> {
+            if (p != -1) AffinitySupport.bind(p);
+            Thread t = Thread.currentThread();
+            while (!t.isInterrupted()) {
+                while (!ping) {
+                    if (SPINWAIT) SpinWaitSupport.onSpinWait();
+                }
+                ping = false;
+            }
+        });
+        t.start();
+    }
+
+    @TearDown
+    public void tearDown() throws InterruptedException {
+        t.interrupt();
+        ping = true;
+        t.join();
+    }
+
+    @Benchmark
+    public void test() {
+        ping = true;
+        while (ping) {
+            if (SPINWAIT) SpinWaitSupport.onSpinWait();
+        }
+    }
+}

--- a/jmh-core-benchmarks/src/main/java/org/openjdk/jmh/validation/AffinitySupport.java
+++ b/jmh-core-benchmarks/src/main/java/org/openjdk/jmh/validation/AffinitySupport.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jmh.validation;
+
+import com.sun.jna.*;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class AffinitySupport {
+
+    public static boolean isLinux() {
+        return System.getProperty("os.name").toLowerCase().contains("linux");
+    }
+
+    public static boolean isSupported() {
+        return isLinux();
+    }
+
+    public static void bind(int cpu) {
+        if (isLinux()) {
+            Linux.bind(cpu);
+        } else {
+            throw new IllegalStateException("Not implemented");
+        }
+    }
+
+    public static void tryBind() {
+        if (isLinux()) {
+            Linux.tryBind();
+        } else {
+            throw new IllegalStateException("Not implemented");
+        }
+    }
+
+    public static List<String> prepare() {
+        if (isLinux()) {
+            return Linux.prepare();
+        } else {
+            throw new IllegalStateException("Not implemented");
+        }
+    }
+
+    public static void tryInit() {
+        if (isLinux()) {
+            Linux.tryInit();
+        }
+    }
+
+    static class Linux {
+        private static volatile CLibrary INSTANCE;
+        private static boolean BIND_TRIED;
+
+        /*
+           Unpacks the libraries, and replies additional options for forked VMs.
+         */
+        public static List<String> prepare() {
+            System.setProperty("jnidispatch.preserve", "true");
+            Native.load("c", CLibrary.class);
+
+            File file = new File(System.getProperty("jnidispatch.path"));
+            String bootLibraryPath = file.getParent();
+
+            // Need to rename the file to the proper name, otherwise JNA would not discover it
+            File proper = new File(bootLibraryPath + '/' + System.mapLibraryName("jnidispatch"));
+            file.renameTo(proper);
+
+            return Arrays.asList(
+                    "-Djna.nounpack=true",    // Should not unpack itself, but use predefined path
+                    "-Djna.nosys=true",       // Should load from explicit path
+                    "-Djna.noclasspath=true", // Should load from explicit path
+                    "-Djna.boot.library.path=" + bootLibraryPath,
+                    "-Djna.platform.library.path=" + System.getProperty("jna.platform.library.path")
+            );
+        }
+
+        public static void tryInit() {
+            if (INSTANCE == null) {
+                synchronized (Linux.class) {
+                    if (INSTANCE == null) {
+                        INSTANCE = Native.load("c", CLibrary.class);
+                    }
+                }
+            }
+        }
+
+        public static void bind(int cpu) {
+            tryInit();
+
+            final cpu_set_t cpuset = new cpu_set_t();
+            cpuset.set(cpu);
+
+            set(cpuset);
+        }
+
+        public static void tryBind() {
+            if (BIND_TRIED) return;
+
+            synchronized (Linux.class) {
+                if (BIND_TRIED) return;
+
+                tryInit();
+
+                cpu_set_t cs = new cpu_set_t();
+                get(cs);
+                set(cs);
+
+                BIND_TRIED = true;
+            }
+        }
+
+        private static void get(cpu_set_t cpuset) {
+            if (INSTANCE.sched_getaffinity(0, cpu_set_t.SIZE_OF, cpuset) != 0) {
+                throw new IllegalStateException("Failed: " + Native.getLastError());
+            }
+        }
+
+        private static void set(cpu_set_t cpuset) {
+            if (INSTANCE.sched_setaffinity(0, cpu_set_t.SIZE_OF, cpuset) != 0) {
+                throw new IllegalStateException("Failed: " + Native.getLastError());
+            }
+        }
+
+        interface CLibrary extends Library {
+            int sched_getaffinity(int pid, int size, cpu_set_t cpuset);
+            int sched_setaffinity(int pid, int size, cpu_set_t cpuset);
+        }
+
+        public static class cpu_set_t extends Structure {
+            private static final int CPUSET_SIZE = 1024;
+            private static final int NCPU_BITS = 8 * NativeLong.SIZE;
+            private static final int SIZE_OF = (CPUSET_SIZE / NCPU_BITS) * NativeLong.SIZE;
+
+            public NativeLong[] __bits = new NativeLong[CPUSET_SIZE / NCPU_BITS];
+
+            public cpu_set_t() {
+                for (int i = 0; i < __bits.length; i++) {
+                    __bits[i] = new NativeLong(0);
+                }
+            }
+
+            public void set(int cpu) {
+                int cIdx = cpu / NCPU_BITS;
+                long mask = 1L << (cpu % NCPU_BITS);
+                NativeLong bit = __bits[cIdx];
+                bit.setValue(bit.longValue() | mask);
+            }
+
+            @Override
+            protected List<String> getFieldOrder() {
+                return Collections.singletonList("__bits");
+            }
+        }
+    }
+
+}

--- a/jmh-core-benchmarks/src/main/java/org/openjdk/jmh/validation/Main.java
+++ b/jmh-core-benchmarks/src/main/java/org/openjdk/jmh/validation/Main.java
@@ -28,7 +28,6 @@ import joptsimple.*;
 import org.openjdk.jmh.runner.CompilerHints;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.*;
-import org.openjdk.jmh.util.JDKVersion;
 import org.openjdk.jmh.util.Utils;
 import org.openjdk.jmh.util.Version;
 import org.openjdk.jmh.validation.tests.*;
@@ -229,6 +228,10 @@ public class Main {
                     new BlackholeConsecutiveTest(BlackholeTestMode.full).runWith(pw, opts);
                     setBlackholeOpts(BlackholeTestMode.normal);
                     break;
+                case roundtrip_latency:
+                    new RoundTripLatencyTest(false).runWith(pw, opts);
+                    new RoundTripLatencyTest(true).runWith(pw, opts);
+                    break;
                 default:
                     throw new IllegalStateException();
             }
@@ -246,6 +249,7 @@ public class Main {
         blackhole_single,
         blackhole_pipelined,
         blackhole_consec,
+        roundtrip_latency,
     }
 
     public enum Mode {

--- a/jmh-core-benchmarks/src/main/java/org/openjdk/jmh/validation/SpinWaitSupport.java
+++ b/jmh-core-benchmarks/src/main/java/org/openjdk/jmh/validation/SpinWaitSupport.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jmh.validation;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+public class SpinWaitSupport {
+
+    // All critical code should fold with C2 compilation.
+    // This provides us with JDK 8 compatibility.
+
+    static final MethodHandle MH;
+
+    static {
+        MethodHandle mh;
+        try {
+            mh = MethodHandles.lookup().findStatic(Thread.class, "onSpinWait", MethodType.methodType(void.class));
+        } catch (NoSuchMethodException | IllegalAccessException e) {
+            mh = null;
+        }
+        MH = mh;
+    }
+
+    public static boolean available() {
+        return MH != null;
+    }
+
+    public static void onSpinWait() {
+        if (MH != null) {
+            try {
+                MH.invokeExact();
+            } catch (Throwable e) {
+                throw new IllegalStateException("Should not happen", e);
+            }
+        }
+    }
+
+}

--- a/jmh-core-benchmarks/src/main/java/org/openjdk/jmh/validation/tests/RoundTripLatencyTest.java
+++ b/jmh-core-benchmarks/src/main/java/org/openjdk/jmh/validation/tests/RoundTripLatencyTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jmh.validation.tests;
+
+import org.openjdk.jmh.benchmarks.RoundTripLatencyBench;
+import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+import org.openjdk.jmh.util.Utils;
+import org.openjdk.jmh.validation.AffinitySupport;
+import org.openjdk.jmh.validation.SpinWaitSupport;
+import org.openjdk.jmh.validation.ValidationTest;
+
+import java.io.PrintWriter;
+
+public class RoundTripLatencyTest extends ValidationTest {
+
+    private boolean spinWaitHints;
+
+    public RoundTripLatencyTest(boolean spinWaitHints) {
+        this.spinWaitHints = spinWaitHints;
+    }
+
+    @Override
+    public void runWith(PrintWriter pw, Options parent) throws RunnerException {
+        pw.println("--------- ROUND-TRIP LATENCY TEST" + (spinWaitHints ? " (SPIN-WAIT HINTS)" : ""));
+        pw.println();
+
+        org.openjdk.jmh.util.Utils.reflow(pw,
+                "This test tries to run latency benchmark across the entire system. " +
+                    "For many-core systems, it is normal to see large latency variations between CPU threads pairs. " +
+                    "This gives the idea how much the tests with communicating threads would differ when scheduled differently.",
+                80, 2);
+        pw.println();
+
+        pw.println("  Scores are nanoseconds per round-trip.");
+        pw.println("  Axes are CPU numbers as presented by OS.");
+        pw.println();
+
+        if (!AffinitySupport.isSupported()) {
+            pw.println("  Affinity control is not available on this machine, skipping the test.");
+            pw.println();
+            return;
+        }
+
+        if (spinWaitHints && !SpinWaitSupport.available()) {
+            pw.println("  Spin-wait hints are not supported, skipping the test.");
+            pw.println();
+            return;
+        }
+
+        Options basic = new OptionsBuilder()
+                .parent(parent)
+                .include(RoundTripLatencyBench.class.getCanonicalName())
+                .threads(1)
+                .jvmArgsAppend("-Xms512m", "-Xmx512m", "-XX:+AlwaysPreTouch", "-XX:+UseParallelGC", "-XX:+UseNUMA", "-DspinWait=" + spinWaitHints)
+                .verbosity(VerboseMode.SILENT)
+                .build();
+
+        int blockSize = 16;
+
+        int threads = Utils.figureOutHotCPUs();
+        int blocks = (threads / blockSize);
+        if (blocks*blockSize < threads) blocks++;
+
+        for (int pBlock = 0; pBlock < blocks; pBlock++) {
+            int fromP = pBlock*blockSize;
+            int toP = Math.min(threads, (pBlock+1)*blockSize);
+
+            for (int cBlock = 0; cBlock < blocks; cBlock++) {
+                int fromC = cBlock*blockSize;
+                int toC = Math.min(threads, (cBlock+1)*blockSize);
+                pw.printf("%5s  ", "");
+                for (int c = fromC; c < toC; c++) {
+                    pw.printf("%5d:", c);
+                }
+                pw.println();
+
+                for (int p = fromP; p < toP; p++) {
+                    pw.printf("%5d: ", p);
+
+                    for (int c = fromC; c < toC; c++) {
+                        if (p == c) {
+                            pw.print(" ----,");
+                            continue;
+                        }
+                        Options opts = new OptionsBuilder()
+                                .parent(basic)
+                                .param("p", String.valueOf(p))
+                                .param("c", String.valueOf(c))
+                                .build();
+                        Result r = new Runner(opts).runSingle().getPrimaryResult();
+                        pw.print(String.format("%5.0f,", r.getScore()));
+                        pw.flush();
+                    }
+                    pw.println();
+                }
+                pw.println();
+            }
+        }
+
+    }
+
+}


### PR DESCRIPTION
For some systems, it is instrumental to understand the latency figures between different CPU threads.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903422](https://bugs.openjdk.org/browse/CODETOOLS-7903422): JMH: Add round-trip benchmarks to core tests


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh pull/94/head:pull/94` \
`$ git checkout pull/94`

Update a local copy of the PR: \
`$ git checkout pull/94` \
`$ git pull https://git.openjdk.org/jmh pull/94/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 94`

View PR using the GUI difftool: \
`$ git pr show -t 94`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/94.diff">https://git.openjdk.org/jmh/pull/94.diff</a>

</details>
