### PR TITLE
7903439: JMH: Print help to stdout instead of stderr

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/options/CommandLineOptions.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/options/CommandLineOptions.java
@@ -454,7 +454,7 @@ public class CommandLineOptions implements Options {
     }
 
     public void showHelp() throws IOException {
-        parser.printHelpOn(System.err);
+        parser.printHelpOn(System.out);
     }
 
     public void listProfilers() {


### PR DESCRIPTION
I do not know the reason for using `System.err` for `help or -h`. I was expecting it to be in standard out not in error. 

Either of the things needs to be happen: 

- If it has to be `System.error` (for some reason) then it should be mentioned in `ReadMe.md` so that people like me does not get confused.
- If it is `System.out` then PR needs to be merged :)  

Change is just `3` characters so I did not report any issue before creating PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903439](https://bugs.openjdk.org/browse/CODETOOLS-7903439): JMH: Print help to stdout instead of stderr


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer) ⚠️ Review applies to [253b7704](https://git.openjdk.org/jmh/pull/95/files/253b77046bbb8290ef928251abf3821f241144ed)
 * @mamadaliev (no known openjdk.org user name / role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh pull/95/head:pull/95` \
`$ git checkout pull/95`

Update a local copy of the PR: \
`$ git checkout pull/95` \
`$ git pull https://git.openjdk.org/jmh pull/95/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 95`

View PR using the GUI difftool: \
`$ git pr show -t 95`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/95.diff">https://git.openjdk.org/jmh/pull/95.diff</a>

</details>
