### PR TITLE
7903448: JMH: Override the use of compiler hints using a system property

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/format/TextReportFormat.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/format/TextReportFormat.java
@@ -81,7 +81,7 @@ class TextReportFormat extends AbstractOutputFormat {
         println("# VM invoker: " + params.getJvm());
         println("# VM options: " + opts);
 
-        CompilerHints.printBlackhole(out);
+        CompilerHints.printHints(out);
 
         IterationParams warmup = params.getWarmup();
         if (warmup.getCount() > 0) {

--- a/jmh-core/src/test/java/org/openjdk/jmh/runner/CompilerHintsTest.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/runner/CompilerHintsTest.java
@@ -47,6 +47,7 @@ public class CompilerHintsTest {
     public void testListNotEmptyForCompliantJvms() {
         for (String name : CompilerHints.HINT_COMPATIBLE_JVMS) {
             System.setProperty("java.vm.name", name);
+            CompilerHints.resetCompilerHintsSelect();
             List<String> args = new ArrayList<>();
             CompilerHints.addCompilerHints(args);
             assertFalse(args.isEmpty());
@@ -57,6 +58,7 @@ public class CompilerHintsTest {
     public void testListEmptyForOldZingJvms() {
         System.setProperty("java.vm.name", "Zing");
         System.setProperty("java.version", "1.7.0-zing_5.9.2.0");
+        CompilerHints.resetCompilerHintsSelect();
         // load up some default hints
         List<String> args = new ArrayList<>();
         CompilerHints.addCompilerHints(args);
@@ -67,6 +69,7 @@ public class CompilerHintsTest {
     public void testListNotEmptyForNewerZingJvms() {
         System.setProperty("java.vm.name", "Zing");
         System.setProperty("java.version", "1.7.0-zing_5.10.2.0");
+        CompilerHints.resetCompilerHintsSelect();
         // load up some default hints
         List<String> args = new ArrayList<>();
         CompilerHints.addCompilerHints(args);
@@ -76,6 +79,7 @@ public class CompilerHintsTest {
     @Test
     public void testListEmptyForNonCompliantJvms() {
         System.setProperty("java.vm.name", "StupidVmCantTakeAHint");
+        CompilerHints.resetCompilerHintsSelect();
         List<String> args = new ArrayList<>();
         CompilerHints.addCompilerHints(args);
         assertTrue(args.isEmpty());
@@ -84,5 +88,6 @@ public class CompilerHintsTest {
     @After
     public void restoreCurrentVM() {
         System.setProperty("java.vm.name", vmName);
+        CompilerHints.resetCompilerHintsSelect();
     }
 }


### PR DESCRIPTION
Using `-Djmh.compilerhints.mode=true` will force the use of compiler hints. `-Djmh.compilerhints.mode=false` will prevent the use of compiler hints. When the system property is not set, the current beahviour based on vm name and version will be used by default.

This is especially useful when working with uncommon / rare JVMs or when adding compiler hints support to a new JVM.

I considered auto-detecting support for compiler hints but that didn't fit very well in the current code and required much more intrusive changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903448](https://bugs.openjdk.org/browse/CODETOOLS-7903448): JMH: Override the use of compiler hints using a system property


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/96/head:pull/96` \
`$ git checkout pull/96`

Update a local copy of the PR: \
`$ git checkout pull/96` \
`$ git pull https://git.openjdk.org/jmh.git pull/96/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 96`

View PR using the GUI difftool: \
`$ git pr show -t 96`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/96.diff">https://git.openjdk.org/jmh/pull/96.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/96#issuecomment-1458491507)