### PR TITLE
Allow setting of opsPerInvocation from setup functions

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/infra/BenchmarkParams.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/infra/BenchmarkParams.java
@@ -192,7 +192,7 @@ abstract class BenchmarkParamsL2 extends BenchmarkParamsL1 implements Serializab
     protected final Mode mode;
     protected final WorkloadParams params;
     protected final TimeUnit timeUnit;
-    protected final int opsPerInvocation;
+    protected int opsPerInvocation;
     protected final String jvm;
     protected final Collection<String> jvmArgs;
     protected final String jdkVersion;
@@ -324,6 +324,14 @@ abstract class BenchmarkParamsL2 extends BenchmarkParamsL1 implements Serializab
      */
     public int getOpsPerInvocation() {
         return opsPerInvocation;
+    }
+
+    /**
+     * Sets operations per invocation.
+     * @param opsPerInvocation the number of operations per invocation
+     */
+    public void setOpsPerInvocation(int opsPerInvocation) {
+        this.opsPerInvocation = opsPerInvocation;
     }
 
     /**

--- a/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_40_InfraParamNormalization.java
+++ b/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_40_InfraParamNormalization.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2015, Oracle America, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of Oracle nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.openjdk.jmh.samples;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.profile.LinuxPerfNormProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.Arrays;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(5)
+@State(Scope.Benchmark)
+public class JMHSample_40_InfraParamNormalization {
+
+    /*
+     * This sample serves a dual purposes:
+     *
+     * First, it shows how to adjust opsPerSample from within the benchmarked project.
+     * A correct opsPerSample normalizes all performance numbers and makes interpretation
+     * of the benchmark results much simpler. In many cases this cannot be reasonably set
+     * via annotations (not constant / known at compile time) nor by the java API (Runner
+     * does not allow to set that on per-benchmark basis).
+     *
+     * Second, it serves as a warning against using shortish branching patterns that are
+     * constant across invocations. As this benchmark demonstrates, modern CPU can memorize
+     * surprisingly long branching patterns from one invocation to the next.
+     *
+     * This works via the branch history table. If our branch is taken half of the time,
+     * and the branching pattern repeats every size 1000 times (i.e. it is the same for
+     * each invocation and each invocation hits the branch 1000 times), then it is enough
+     * to know the last 10 branch outcomes to identify our position in the sequence and
+     * therefore almost perfectly predict the next branch outcome. This is the same way
+     * that e.g. genomic sequences are reconstructed from short reads.
+     *
+     * Cf e.g. https://discourse.julialang.org/t/psa-microbenchmarks-remember-branch-history/17436
+     */
+
+    byte[] bytes;
+
+    @Param({"100", "1000", "5000", "10000", "100000"})
+    int size;
+
+    @Setup
+    public void setup(BenchmarkParams params) {
+        bytes = new byte[size];
+        Random random = new Random(1234);
+        random.nextBytes(bytes);
+        try {
+            java.lang.reflect.Field field = BenchmarkParams.class.getSuperclass() // L4
+                    .getSuperclass() // L3
+                    .getSuperclass() // L2
+                    .getDeclaredField("opsPerInvocation");
+            field.setAccessible(true);
+            field.setInt(params, size);
+        } catch (Exception exc) { throw new RuntimeException("Could not set opsPerInvocation", exc);}
+    }
+
+    @Benchmark
+    public void memorizePattern(Blackhole bh1, Blackhole bh2) {
+        for (byte v : bytes) {
+            if (v > 0) {
+                bh1.consume(v);
+            } else {
+                bh2.consume(v);
+            }
+        }
+    }
+
+
+    /*
+        There is a substantial difference in performance for these benchmarks!
+
+        We see that the i9-9900K has a 20 cycle branch-miss penalty, can almost perfectly
+        memorize patterns of length 5k, and cannot memorize patterns of length 100k.
+
+        Benchmark                                                                     (size)  Mode  Cnt   Score    Error  Units
+        JMHSample_40_InfraParamNormalization.memorizePattern                             100  avgt   15   0.279 ±  0.001  ns/op
+        JMHSample_40_InfraParamNormalization.memorizePattern:branch-misses:u             100  avgt    3  ≈ 10⁻⁴            #/op
+        JMHSample_40_InfraParamNormalization.memorizePattern:branches:u                  100  avgt    3   1.476 ±  0.065   #/op
+        JMHSample_40_InfraParamNormalization.memorizePattern:cycles:u                    100  avgt    3   1.328 ±  0.080   #/op
+        JMHSample_40_InfraParamNormalization.memorizePattern                            1000  avgt   15   0.249 ±  0.001  ns/op
+        JMHSample_40_InfraParamNormalization.memorizePattern:branch-misses:u            1000  avgt    3  ≈ 10⁻³            #/op
+        JMHSample_40_InfraParamNormalization.memorizePattern:branches:u                 1000  avgt    3   1.371 ±  0.126   #/op
+        JMHSample_40_InfraParamNormalization.memorizePattern:cycles:u                   1000  avgt    3   1.179 ±  0.034   #/op
+        JMHSample_40_InfraParamNormalization.memorizePattern                            5000  avgt   15   0.297 ±  0.028  ns/op
+        JMHSample_40_InfraParamNormalization.memorizePattern:branch-misses:u            5000  avgt    3   0.011 ±  0.140   #/op
+        JMHSample_40_InfraParamNormalization.memorizePattern:branches:u                 5000  avgt    3   1.370 ±  0.024   #/op
+        JMHSample_40_InfraParamNormalization.memorizePattern:cycles:u                   5000  avgt    3   1.407 ±  2.656   #/op
+        JMHSample_40_InfraParamNormalization.memorizePattern                           10000  avgt   15   1.147 ±  0.127  ns/op
+        JMHSample_40_InfraParamNormalization.memorizePattern:branch-misses:u           10000  avgt    3   0.180 ±  0.587   #/op
+        JMHSample_40_InfraParamNormalization.memorizePattern:branches:u                10000  avgt    3   1.370 ±  0.073   #/op
+        JMHSample_40_InfraParamNormalization.memorizePattern:cycles:u                  10000  avgt    3   5.441 ± 11.936   #/op
+        JMHSample_40_InfraParamNormalization.memorizePattern                          100000  avgt   15   2.589 ±  0.011  ns/op
+        JMHSample_40_InfraParamNormalization.memorizePattern:branch-misses:u          100000  avgt    3   0.491 ±  0.021   #/op
+        JMHSample_40_InfraParamNormalization.memorizePattern:branches:u               100000  avgt    3   1.371 ±  0.024   #/op
+        JMHSample_40_InfraParamNormalization.memorizePattern:cycles:u                 100000  avgt    3  12.239 ±  0.450   #/op
+     */
+
+
+    /*
+     * ============================== HOW TO RUN THIS TEST: ====================================
+     *
+     * You can run this test:
+     *
+     * a) Via the command line:
+     *    $ mvn clean install
+     *    $ java -jar ./target/benchmarks.jar JMHSample_40_InfraParamNormalization -prof perfnorm -f 3
+     *
+     * b) Via the Java API:
+     *    (see the JMH homepage for possible caveats when running from IDE:
+     *      http://openjdk.java.net/projects/code-tools/jmh/)
+     */
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(".*" + JMHSample_40_InfraParamNormalization.class.getSimpleName() + ".*")
+                .addProfiler(LinuxPerfNormProfiler.class)
+                .build();
+
+        new Runner(opt).run();
+    }
+
+}

--- a/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_40_InfraParamNormalization.java
+++ b/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_40_InfraParamNormalization.java
@@ -84,14 +84,7 @@ public class JMHSample_40_InfraParamNormalization {
         bytes = new byte[size];
         Random random = new Random(1234);
         random.nextBytes(bytes);
-        try {
-            java.lang.reflect.Field field = BenchmarkParams.class.getSuperclass() // L4
-                    .getSuperclass() // L3
-                    .getSuperclass() // L2
-                    .getDeclaredField("opsPerInvocation");
-            field.setAccessible(true);
-            field.setInt(params, size);
-        } catch (Exception exc) { throw new RuntimeException("Could not set opsPerInvocation", exc);}
+        params.setOpsPerInvocation(size);
     }
 
     @Benchmark


### PR DESCRIPTION
In many cases, opsPerInvocation is known at the @Setup function, but cannot be reasonably known at any other point. This example is somewhat lame in that regard; I actually needed that for some not-quite-micro benchmarks (the setup function loads real-ish data from disk, and the opsPerInvocation depends on the data that has been loaded).

Since every good example teaches multiple things, I added one that also warns about the branch history table stitching together surprisingly long patterns.

The super-duper correct way of doing this example (cf https://discourse.julialang.org/t/psa-microbenchmarks-remember-branch-history/17436) would be to have constant opsPerInvocation and one large array; then a smaller (@Param) array is copied into that multiple times. Thus we could exclude effects of memory hierarchy. That would look quite unnatural and harder to relate to "normal looking" code (and there are no effects of memory anyway, since first, the benchmark is too slow to saturate DRAM bandwidth, and second even the largest set fits into L2).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/97/head:pull/97` \
`$ git checkout pull/97`

Update a local copy of the PR: \
`$ git checkout pull/97` \
`$ git pull https://git.openjdk.org/jmh.git pull/97/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 97`

View PR using the GUI difftool: \
`$ git pr show -t 97`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/97.diff">https://git.openjdk.org/jmh/pull/97.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/97#issuecomment-1482547153)