### PR TITLE
7903451: JMH: Refactor internal Optional usages

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/Runner.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/Runner.java
@@ -42,7 +42,6 @@ import org.openjdk.jmh.util.Optional;
 
 import java.io.*;
 import java.lang.management.ManagementFactory;
-import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.channels.OverlappingFileLockException;
 import java.nio.file.Files;
@@ -475,14 +474,11 @@ public class Runner extends BaseRunner {
                 benchmark.getJvmArgsPrepend().orElse(Collections.<String>emptyList())));
 
         // We want to be extra lazy when accessing ManagementFactory, because security manager
-        // may prevent us doing so. When JMH upgrades to Java 8, replaces this with proper Optional
-        // and lazy Supplier.
-        Optional<Collection<String>> jvmArgsMid = options.getJvmArgs().orAnother(benchmark.getJvmArgs());
-        if (jvmArgsMid.hasValue()) {
-            jvmArgs.addAll(jvmArgsMid.get());
-        } else {
-            jvmArgs.addAll(ManagementFactory.getRuntimeMXBean().getInputArguments());
-        }
+        // may prevent us doing so.
+        jvmArgs.addAll(options.getJvmArgs().orElseGet(
+                () -> benchmark.getJvmArgs().orElseGet(
+                        () -> ManagementFactory.getRuntimeMXBean().getInputArguments())));
+
 
         jvmArgs.addAll(options.getJvmArgsAppend().orElse(
                 benchmark.getJvmArgsAppend().orElse(Collections.<String>emptyList())));

--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/Runner.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/Runner.java
@@ -475,9 +475,10 @@ public class Runner extends BaseRunner {
 
         // We want to be extra lazy when accessing ManagementFactory, because security manager
         // may prevent us doing so.
-        jvmArgs.addAll(options.getJvmArgs().orElseGet(
-                () -> benchmark.getJvmArgs().orElseGet(
-                        () -> ManagementFactory.getRuntimeMXBean().getInputArguments())));
+        jvmArgs.addAll(options.getJvmArgs()
+                .orElseGet(() -> benchmark.getJvmArgs()
+                .orElseGet(() -> ManagementFactory.getRuntimeMXBean().getInputArguments())
+        ));
 
 
         jvmArgs.addAll(options.getJvmArgsAppend().orElse(

--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/options/OptionsBuilder.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/options/OptionsBuilder.java
@@ -620,9 +620,9 @@ public class OptionsBuilder implements Options, ChainedOptionsBuilder {
     @Override
     public Optional<Collection<String>> getJvmArgs() {
         if (otherOptions != null) {
-            return jvmArgs.orAnother(otherOptions.getJvmArgs().orAnother(Optional.<Collection<String>>none()));
+            return jvmArgs.orAnother(otherOptions.getJvmArgs());
         } else {
-            return jvmArgs.orAnother(Optional.<Collection<String>>none());
+            return jvmArgs;
         }
     }
 
@@ -639,9 +639,9 @@ public class OptionsBuilder implements Options, ChainedOptionsBuilder {
     @Override
     public Optional<Collection<String>> getJvmArgsAppend() {
         if (otherOptions != null) {
-            return jvmArgsAppend.orAnother(otherOptions.getJvmArgsAppend().orAnother(Optional.<Collection<String>>none()));
+            return jvmArgsAppend.orAnother(otherOptions.getJvmArgsAppend());
         } else {
-            return jvmArgsAppend.orAnother(Optional.<Collection<String>>none());
+            return jvmArgsAppend;
         }
     }
 
@@ -658,9 +658,9 @@ public class OptionsBuilder implements Options, ChainedOptionsBuilder {
     @Override
     public Optional<Collection<String>> getJvmArgsPrepend() {
         if (otherOptions != null) {
-            return jvmArgsPrepend.orAnother(otherOptions.getJvmArgsPrepend().orAnother(Optional.<Collection<String>>none()));
+            return jvmArgsPrepend.orAnother(otherOptions.getJvmArgsPrepend());
         } else {
-            return jvmArgsPrepend.orAnother(Optional.<Collection<String>>none());
+            return jvmArgsPrepend;
         }
     }
 

--- a/jmh-core/src/main/java/org/openjdk/jmh/util/Optional.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/util/Optional.java
@@ -26,6 +26,7 @@ package org.openjdk.jmh.util;
 
 import java.io.Serializable;
 import java.util.Objects;
+import java.util.function.Supplier;
 
 /**
  * Option class
@@ -49,6 +50,10 @@ public class Optional<T> implements Serializable {
 
     public T orElse(T elseVal) {
         return (val == null) ? elseVal : val;
+    }
+
+    public T orElseGet(Supplier<T> alternativeSupplier) {
+        return val != null ? val : alternativeSupplier.get();
     }
 
     public Optional<T> orAnother(Optional<T> alternative) {

--- a/jmh-core/src/main/java/org/openjdk/jmh/util/Optional.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/util/Optional.java
@@ -53,7 +53,7 @@ public class Optional<T> implements Serializable {
     }
 
     public T orElseGet(Supplier<T> alternativeSupplier) {
-        return val != null ? val : alternativeSupplier.get();
+        return (val == null) ? alternativeSupplier.get() : val;
     }
 
     public Optional<T> orAnother(Optional<T> alternative) {


### PR DESCRIPTION
This is a follow-up to the email https://mail.openjdk.org/pipermail/jmh-dev/2023-January/003562.html

`java.util.Optional` isn't `Serializeable`. Because of that `org.openjdk.jmh.runner.options.TestOptions` fails with `java.io.NotSerializableException: java.util.Optional`, when  `org.openjdk.jmh.util.Optional` is completely replaced with `java.util.Optional`. See [test results on branch `java-util-optional`](https://github.com/rybak/jmh/actions/runs/4326921418), ([one commit](https://github.com/rybak/jmh/commit/25b9cb382be7285a51446976247d036ac855fc91) on top of initial state of this PR).

I didn't look further into possibility of removing `Optional`s as fields of class `CommandLineOptions`. I think that the refactoring up until the drop-in replacement to `java.util.Optional` might still be worth it, at least from the point of making it more approachable for people who are familiar with `java.util.Optional`.  So here are these changes for your consideration. Details are in the commit messages.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903451](https://bugs.openjdk.org/browse/CODETOOLS-7903451): JMH: Refactor internal Optional usages


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/98/head:pull/98` \
`$ git checkout pull/98`

Update a local copy of the PR: \
`$ git checkout pull/98` \
`$ git pull https://git.openjdk.org/jmh.git pull/98/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 98`

View PR using the GUI difftool: \
`$ git pr show -t 98`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/98.diff">https://git.openjdk.org/jmh/pull/98.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/98#issuecomment-1484033209)