### PR TITLE
7903461: JMH: perfasm profiler misses some jump edges

### DIFF
--- a/jmh-core/src/test/java/org/openjdk/jmh/profile/PerfAsmAddressTest.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/profile/PerfAsmAddressTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jmh.profile;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+public class PerfAsmAddressTest {
+
+    static final HashMap<String, List<Long>> TESTS = new HashMap<>();
+
+    static long addr(String s) {
+        return Long.parseLong(s, 16);
+    }
+
+    static {
+        TESTS.put("0x00007f815c65724e:   test   %eax,(%r8)",
+                Arrays.asList(addr("7f815c65724e")));
+
+        TESTS.put("0x00007f815c657239:   je     0x00007f815c657290",
+                Arrays.asList(addr("7f815c657239"), addr("7f815c657290")));
+
+        TESTS.put("0x00007f815c657256:   movabs $0x7f8171798570,%r10",
+                Arrays.asList(addr("7f815c657256"), addr("7f8171798570")));
+
+        TESTS.put("0x0000ffff685c7d2c:   b   0x0000ffff685c7cf0",
+                Arrays.asList(addr("ffff685c7d2c"), addr("ffff685c7cf0")));
+
+        TESTS.put("0x0000ffff685c7d1c:   b.ne        0x0000ffff685c7cb4  // b.any",
+                Arrays.asList(addr("ffff685c7d1c"), addr("ffff685c7cb4")));
+
+        TESTS.put("0x0000ffff685c7d1c:   b.ne        0x0000ffff685c7cb4// b.any",
+                Arrays.asList(addr("ffff685c7d1c"), addr("ffff685c7cb4")));
+
+        TESTS.put("0x0000ffff685c7d1c:   b.ne        0x0000ffff685c7cb4;comment",
+                Arrays.asList(addr("ffff685c7d1c"), addr("ffff685c7cb4")));
+
+        TESTS.put("0x0000ffff685c7d1c:b.ne        0x0000ffff685c7cb4",
+                Arrays.asList(addr("ffff685c7d1c"), addr("ffff685c7cb4")));
+
+        TESTS.put("0x0000ffff685c7d1c: b.ne\t0x0000ffff685c7cb4",
+                Arrays.asList(addr("ffff685c7d1c"), addr("ffff685c7cb4")));
+    }
+
+    @Test
+    public void testNoPrefix() {
+        for (String line : TESTS.keySet()) {
+            List<Long> actual = AbstractPerfAsmProfiler.parseAddresses(line, true);
+            List<Long> expected = TESTS.get(line);
+            Assert.assertEquals(line, expected, actual);
+        }
+    }
+
+    @Test
+    public void testPrefix() {
+        for (String line : TESTS.keySet()) {
+            String testLine = "something " + line;
+            Assert.assertEquals(new ArrayList<>(), AbstractPerfAsmProfiler.parseAddresses(testLine, true));
+
+            List<Long> actual = AbstractPerfAsmProfiler.parseAddresses(testLine, false);
+            List<Long> expected = TESTS.get(line);
+            Assert.assertEquals(line, expected, actual);
+        }
+    }
+
+}

--- a/jmh-core/src/test/java/org/openjdk/jmh/profile/PerfAsmAddressTest.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/profile/PerfAsmAddressTest.java
@@ -71,22 +71,48 @@ public class PerfAsmAddressTest {
 
     @Test
     public void testNoPrefix() {
+        List<Long> empty = new ArrayList<>();
         for (String line : TESTS.keySet()) {
-            List<Long> actual = AbstractPerfAsmProfiler.parseAddresses(line, true);
             List<Long> expected = TESTS.get(line);
-            Assert.assertEquals(line, expected, actual);
+
+            String leadingSpace = "  " + line;
+            String trailingSpace = line + "  ";
+
+            Assert.assertEquals(line, expected, AbstractPerfAsmProfiler.parseAddresses(line,            false, true));
+
+            Assert.assertEquals(line, expected, AbstractPerfAsmProfiler.parseAddresses(leadingSpace,    false, true));
+            Assert.assertEquals(line, empty,    AbstractPerfAsmProfiler.parseAddresses(leadingSpace,     true, true));
+
+            Assert.assertEquals(line, expected, AbstractPerfAsmProfiler.parseAddresses(trailingSpace,   false, true));
+            Assert.assertEquals(line, expected, AbstractPerfAsmProfiler.parseAddresses(trailingSpace,    true, true));
         }
     }
 
     @Test
     public void testPrefix() {
+        List<Long> empty = new ArrayList<>();
         for (String line : TESTS.keySet()) {
-            String testLine = "something " + line;
-            Assert.assertEquals(new ArrayList<>(), AbstractPerfAsmProfiler.parseAddresses(testLine, true));
-
-            List<Long> actual = AbstractPerfAsmProfiler.parseAddresses(testLine, false);
             List<Long> expected = TESTS.get(line);
-            Assert.assertEquals(line, expected, actual);
+
+            String prefixedLine = "something " + line;
+            String prefixedLeadingLine = "  something " + line;
+            String prefixedTrailingLine = "something " + line + "  ";
+
+            Assert.assertEquals(line, empty,    AbstractPerfAsmProfiler.parseAddresses(prefixedLine,         false, true));
+            Assert.assertEquals(line, empty,    AbstractPerfAsmProfiler.parseAddresses(prefixedLeadingLine,  false, true));
+            Assert.assertEquals(line, empty,    AbstractPerfAsmProfiler.parseAddresses(prefixedTrailingLine, false, true));
+
+            Assert.assertEquals(line, empty,    AbstractPerfAsmProfiler.parseAddresses(prefixedLine,          true, true));
+            Assert.assertEquals(line, empty,    AbstractPerfAsmProfiler.parseAddresses(prefixedLeadingLine,   true, true));
+            Assert.assertEquals(line, empty,    AbstractPerfAsmProfiler.parseAddresses(prefixedTrailingLine,  true, true));
+
+            Assert.assertEquals(line, expected, AbstractPerfAsmProfiler.parseAddresses(prefixedLine,         false, false));
+            Assert.assertEquals(line, expected, AbstractPerfAsmProfiler.parseAddresses(prefixedLeadingLine,  false, false));
+            Assert.assertEquals(line, expected, AbstractPerfAsmProfiler.parseAddresses(prefixedTrailingLine, false, false));
+
+            Assert.assertEquals(line, expected, AbstractPerfAsmProfiler.parseAddresses(prefixedLine,          true, false));
+            Assert.assertEquals(line, expected, AbstractPerfAsmProfiler.parseAddresses(prefixedLeadingLine,   true, false));
+            Assert.assertEquals(line, expected, AbstractPerfAsmProfiler.parseAddresses(prefixedTrailingLine,  true, false));
         }
     }
 


### PR DESCRIPTION
On some platforms, JMH perfasm does not render the jump edges properly, because it fails to parse the address lines correctly in the presence of oddly formatted disassembly output. This happens almost reliably on AArch64 hosts:

```
....[Hottest Region 1]..............................................................................
c2, level 4, org.openjdk.jmh.samples.jmh_generated.EnumBench_testMethod_jmhTest::testMethod_avgt_jmhStub, version 6, compile id 778
   
             0x0000ffff9c5c7fd4:   nop                                 ;   {other}
             0x0000ffff9c5c7fd8:   movk xzr, #0x2c4
             0x0000ffff9c5c7fdc:   movk xzr, #0x0
             0x0000ffff9c5c7fe0:   mov  x19, x29
             0x0000ffff9c5c7fe4:   ldr  x14, [sp, #64]
             0x0000ffff9c5c7fe8:   ldp  x13, x12, [sp]
             0x0000ffff9c5c7fec:   ldp  x20, x15, [sp, #16]         ;*invokespecial hashCode {reexecute=0 rethrow=0 return_oop=0}
                                                                       ; - java.lang.Enum::hashCode@1 (line 175)
                                                                       ; - org.openjdk.jmh.samples.EnumBench::testMethod@3 (line 52)
                                                                       ; - org.openjdk.jmh.samples.jmh_generated.EnumBench_testMethod_jmhTest::testMethod_avgt_jmhStub@17 (line 186)
   3.10%     0x0000ffff9c5c7ff0:   ldarb        w11, [x15]                  ;*getfield isDone {reexecute=0 rethrow=0 return_oop=0}
                                                                       ; - org.openjdk.jmh.samples.jmh_generated.EnumBench_testMethod_jmhTest::testMethod_avgt_jmhStub@30 (line 188)
             0x0000ffff9c5c7ff4:   ldr  x10, [x28, #896]
             0x0000ffff9c5c7ff8:   add  x20, x20, #0x1              ; ImmutableOopMap {r12=Oop r13=Oop r15=Derived_oop_r13 r14=Oop r19=Oop }
                                                                       ;*ifeq {reexecute=1 rethrow=0 return_oop=0}
                                                                       ; - (reexecute) org.openjdk.jmh.samples.jmh_generated.EnumBench_testMethod_jmhTest::testMethod_avgt_jmhStub@33 (line 188)
             0x0000ffff9c5c7ffc:   ldr  wzr, [x10]                  ;   {poll}
   1.47%  ╭  0x0000ffff9c5c8000:   cbnz w11, 0x0000ffff9c5c8034     ;*aload_1 {reexecute=0 rethrow=0 return_oop=0}
          │                                                            ; - org.openjdk.jmh.samples.jmh_generated.EnumBench_testMethod_jmhTest::testMethod_avgt_jmhStub@36 (line 189)
  10.53%  │  0x0000ffff9c5c8004:   mov  x10, #0xcce0                    // #52448
          │                                                            ;   {oop(a &apos;org/openjdk/jmh/samples/EnumBench$E&apos;{0x0000000465dfcce0})}
          │  0x0000ffff9c5c8008:   movk x10, #0x65df, lsl #16
  12.19%  │  0x0000ffff9c5c800c:   movk x10, #0x4, lsl #32
          │  0x0000ffff9c5c8010:   ldr  x10, [x10]
   6.97%  │  0x0000ffff9c5c8014:   and  x11, x10, #0x3
          │  0x0000ffff9c5c8018:   cmp  x11, #0x1
          │  0x0000ffff9c5c801c:   b.ne 0x0000ffff9c5c7fb4  // b.any
  38.49%  │  0x0000ffff9c5c8020:   lsr  x10, x10, #8
          │  0x0000ffff9c5c8024:   and  w0, w10, #0x7fffffff
          │  0x0000ffff9c5c8028:   cbz  w0, 0x0000ffff9c5c7fb4      ;*invokespecial hashCode {reexecute=0 rethrow=0 return_oop=0}
          │                                                            ; - java.lang.Enum::hashCode@1 (line 175)
          │                                                            ; - org.openjdk.jmh.samples.EnumBench::testMethod@3 (line 52)
          │                                                            ; - org.openjdk.jmh.samples.jmh_generated.EnumBench_testMethod_jmhTest::testMethod_avgt_jmhStub@17 (line 186)
  23.96%  │  0x0000ffff9c5c802c:   b    0x0000ffff9c5c7ff0
          │  0x0000ffff9c5c8030:   orr  x20, xzr, #0x1              ;*aload_1 {reexecute=0 rethrow=0 return_oop=0}
          │                                                            ; - org.openjdk.jmh.samples.jmh_generated.EnumBench_testMethod_jmhTest::testMethod_avgt_jmhStub@36 (line 189)
          ↘  0x0000ffff9c5c8034:   adr  x9, 0x0000ffff9c5c804c
             0x0000ffff9c5c8038:   mov  x8, #0xb4c8                     // #46280
                                                                       ;   {runtime_call os::javaTimeNanos()}
             0x0000ffff9c5c803c:   movk x8, #0xb487, lsl #16
             0x0000ffff9c5c8040:   movk x8, #0xffff, lsl #32
....................................................................................................

```

Back branch to `0x0000ffff9c5c7ff0` is missing, for example.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903461](https://bugs.openjdk.org/browse/CODETOOLS-7903461): JMH: perfasm profiler misses some jump edges


### Reviewers
 * [Eric Caspole](https://openjdk.org/census#ecaspole) (@ericcaspole - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/100/head:pull/100` \
`$ git checkout pull/100`

Update a local copy of the PR: \
`$ git checkout pull/100` \
`$ git pull https://git.openjdk.org/jmh.git pull/100/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 100`

View PR using the GUI difftool: \
`$ git pr show -t 100`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/100.diff">https://git.openjdk.org/jmh/pull/100.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/100#issuecomment-1517754056)