### PR TITLE
7903478: JMH: Use different padding names for B1 and B3 classes to avoid "hiding fields with same name" warnings

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/generators/core/BenchmarkGenerator.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/generators/core/BenchmarkGenerator.java
@@ -459,7 +459,7 @@ public class BenchmarkGenerator {
         writer.println();
 
         // generate padding
-        Paddings.padding(writer);
+        Paddings.padding(writer, "p");
 
         writer.println(ident(1) + "int startRndMask;");
         writer.println(ident(1) + "BenchmarkParams benchmarkParams;");

--- a/jmh-core/src/main/java/org/openjdk/jmh/generators/core/Paddings.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/generators/core/Paddings.java
@@ -25,34 +25,37 @@
 package org.openjdk.jmh.generators.core;
 
 import java.io.PrintWriter;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.StringJoiner;
 
 public class Paddings {
 
-    private static final List<String> PADDING_CACHE;
+    private static final Map<String, String> PADDING_CACHE =
+            Collections.synchronizedMap(new HashMap<>());
 
-    static {
-        PADDING_CACHE = new ArrayList<>();
+    private static String generate(String prefix) {
+        if (prefix.isEmpty()) {
+            throw new IllegalArgumentException("prefix must not be empty");
+        }
+        StringJoiner sj = new StringJoiner("");
         for (int p = 0; p < 16; p++) {
-            StringBuilder sb = new StringBuilder();
-            sb.append("    ");
-            sb.append(String.format("byte p%03d", p * 16 + 0));
-            for (int q = 1; q < 16; q++) {
-                sb.append(String.format(", p%03d", p * 16 + q));
+            sj.add("    byte ");
+            for (int q = 0; q < 16; q++) {
+                if (q != 0) {
+                    sj.add(", ");
+                }
+                sj.add(prefix);
+                sj.add(String.format("%03d", p * 16 + q));
             }
-            sb.append(";");
-            PADDING_CACHE.add(sb.toString());
+            sj.add(";");
+            sj.add(System.lineSeparator());
         }
+        return sj.toString();
     }
 
-    public static void padding(List<String> lines) {
-        lines.addAll(PADDING_CACHE);
-    }
-
-    public static void padding(PrintWriter writer) {
-        for (String s : PADDING_CACHE) {
-            writer.println(s);
-        }
+    public static void padding(PrintWriter writer, String prefix) {
+        writer.print(PADDING_CACHE.computeIfAbsent(prefix, Paddings::generate));
     }
 }

--- a/jmh-core/src/main/java/org/openjdk/jmh/generators/core/StateObjectHandler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/generators/core/StateObjectHandler.java
@@ -966,8 +966,6 @@ class StateObjectHandler {
                 pw.println("import " + so.userType + ";");
 
                 pw.println("public class " + so.type + "_B1 extends " + so.userType + " {");
-                // The prefix for padding should be different from the one used in _B3 to avoid
-                // "hiding field of the same name in superclass" warning
                 Paddings.padding(pw, "b1_");
                 pw.println("}");
 
@@ -1017,8 +1015,6 @@ class StateObjectHandler {
 
                 pw.println("package " + so.packageName + ";");
                 pw.println("public class " + so.type + "_B3 extends " + so.type + "_B2 {");
-                // The prefix for padding should be different from the one used in _B1 to avoid
-                // "hiding field of the same name in superclass" warning
                 Paddings.padding(pw, "b3_");
                 pw.println("}");
                 pw.println("");

--- a/jmh-core/src/main/java/org/openjdk/jmh/generators/core/StateObjectHandler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/generators/core/StateObjectHandler.java
@@ -966,7 +966,9 @@ class StateObjectHandler {
                 pw.println("import " + so.userType + ";");
 
                 pw.println("public class " + so.type + "_B1 extends " + so.userType + " {");
-                Paddings.padding(pw);
+                // The prefix for padding should be different from the one used in _B3 to avoid
+                // "hiding field of the same name in superclass" warning
+                Paddings.padding(pw, "b1_");
                 pw.println("}");
 
                 pw.close();
@@ -1015,7 +1017,9 @@ class StateObjectHandler {
 
                 pw.println("package " + so.packageName + ";");
                 pw.println("public class " + so.type + "_B3 extends " + so.type + "_B2 {");
-                Paddings.padding(pw);
+                // The prefix for padding should be different from the one used in _B1 to avoid
+                // "hiding field of the same name in superclass" warning
+                Paddings.padding(pw, "b3_");
                 pw.println("}");
                 pw.println("");
 


### PR DESCRIPTION
see https://bugs.openjdk.org/browse/CODETOOLS-7903478


Sample output:

```java
public final class CustomTest_bench_jmhTest {

    byte p000, p001, p002, p003, p004, p005, p006, p007, p008, p009, p010, p011, p012, p013, p014, p015;
    byte p016, p017, p018, p019, p020, p021, p022, p023, p024, p025, p026, p027, p028, p029, p030, p031;
    byte p032, p033, p034, p035, p036, p037, p038, p039, p040, p041, p042, p043, p044, p045, p046, p047;
    byte p048, p049, p050, p051, p052, p053, p054, p055, p056, p057, p058, p059, p060, p061, p062, p063;
..
    byte p224, p225, p226, p227, p228, p229, p230, p231, p232, p233, p234, p235, p236, p237, p238, p239;
    byte p240, p241, p242, p243, p244, p245, p246, p247, p248, p249, p250, p251, p252, p253, p254, p255;
    int startRndMask;
    BenchmarkParams benchmarkParams;
```

```java
public class CustomTest_jmhType_B1 extends org.openjdk.jmh.it.annsteal.CustomTest {
    byte b1_000, b1_001, b1_002, b1_003, b1_004, b1_005, b1_006, b1_007, b1_008, b1_009, b1_010, b1_011, b1_012, b1_013, b1_014, b1_015;
    byte b1_016, b1_017, b1_018, b1_019, b1_020, b1_021, b1_022, b1_023, b1_024, b1_025, b1_026, b1_027, b1_028, b1_029, b1_030, b1_031;
...
    byte b1_224, b1_225, b1_226, b1_227, b1_228, b1_229, b1_230, b1_231, b1_232, b1_233, b1_234, b1_235, b1_236, b1_237, b1_238, b1_239;
    byte b1_240, b1_241, b1_242, b1_243, b1_244, b1_245, b1_246, b1_247, b1_248, b1_249, b1_250, b1_251, b1_252, b1_253, b1_254, b1_255;
}
```

```java
public class CustomTest_jmhType_B3 extends CustomTest_jmhType_B2 {
    byte b3_000, b3_001, b3_002, b3_003, b3_004, b3_005, b3_006, b3_007, b3_008, b3_009, b3_010, b3_011, b3_012, b3_013, b3_014, b3_015;
    byte b3_016, b3_017, b3_018, b3_019, b3_020, b3_021, b3_022, b3_023, b3_024, b3_025, b3_026, b3_027, b3_028, b3_029, b3_030, b3_031;
...
    byte b3_224, b3_225, b3_226, b3_227, b3_228, b3_229, b3_230, b3_231, b3_232, b3_233, b3_234, b3_235, b3_236, b3_237, b3_238, b3_239;
    byte b3_240, b3_241, b3_242, b3_243, b3_244, b3_245, b3_246, b3_247, b3_248, b3_249, b3_250, b3_251, b3_252, b3_253, b3_254, b3_255;
}
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903478](https://bugs.openjdk.org/browse/CODETOOLS-7903478): JMH: Use different padding names for B1 and B3 classes to avoid "hiding fields with same name" warnings


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/104/head:pull/104` \
`$ git checkout pull/104`

Update a local copy of the PR: \
`$ git checkout pull/104` \
`$ git pull https://git.openjdk.org/jmh.git pull/104/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 104`

View PR using the GUI difftool: \
`$ git pr show -t 104`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/104.diff">https://git.openjdk.org/jmh/pull/104.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/104#issuecomment-1566612651)