### PR TITLE
7903479: JMH: Add .editorconfig so IDEs would pick up the common settings automatically: indent, trim whitespace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,50 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+ij_any_blank_lines_after_class_header = 0
+ij_any_block_brace_style = end_of_line
+ij_any_do_while_brace_force = always
+ij_any_for_brace_force = always
+ij_any_if_brace_force = always
+ij_any_keep_blank_lines_in_code = 1
+ij_any_keep_blank_lines_in_declarations = 1
+ij_any_keep_simple_blocks_in_one_line = true
+ij_any_keep_simple_methods_in_one_line = true
+ij_any_keep_simple_classes_in_one_line = true
+ij_any_spaces_around_additive_operators = true
+ij_any_spaces_around_assignment_operators = true
+ij_any_spaces_around_bitwise_operators = true
+ij_any_spaces_around_equality_operators = true
+ij_any_spaces_around_lambda_arrow = true
+ij_any_spaces_around_logical_operators = true
+ij_any_spaces_around_multiplicative_operators = true
+ij_any_spaces_around_relational_operators = true
+ij_any_spaces_around_shift_operators = true
+ij_any_while_brace_force = always
+ij_formatter_off_tag = @formatter:off
+ij_formatter_on_tag = @formatter:on
+ij_formatter_tags_enabled = true
+
+[*.md]
+# Trailing whitespace is important in Markdown (they distinguish a new line from a new paragraph)
+trim_trailing_whitespace = false
+
+[*.java]
+# See LineLength in checkstyle.xml
+max_line_length = 120
+# Doc: https://youtrack.jetbrains.com/issue/IDEA-170643#focus=streamItem-27-3708697.0-0
+# $ means "static"
+ij_java_imports_layout = *, |, javax.**, java.**, |, $*
+ij_java_continuation_indent_size = 8
+ij_java_align_multiline_parameters = false
+ij_java_use_single_class_imports = true
+ij_java_wrap_long_lines = true
+ij_java_class_count_to_use_import_on_demand = 2147483647
+ij_java_names_count_to_use_import_on_demand = 2147483647
+ij_java_packages_to_use_import_on_demand = unset
+ij_java_doc_do_not_wrap_if_one_line = true

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/SafepointsProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/SafepointsProfiler.java
@@ -170,6 +170,7 @@ public class SafepointsProfiler implements ExternalProfiler {
 
         @Override
         protected Collection<? extends Result> getDerivativeResults() {
+            // @formatter:off
             return Arrays.asList(
                 new ScalarDerivativeResult(Defaults.PREFIX + "safepoints." + suffix + ".avg",      statistics.getMean(),           "ms", AggregationPolicy.AVG),
                 new ScalarDerivativeResult(Defaults.PREFIX + "safepoints." + suffix + ".count",    statistics.getN(),              "#",  AggregationPolicy.SUM),
@@ -182,6 +183,7 @@ public class SafepointsProfiler implements ExternalProfiler {
                 new ScalarDerivativeResult(Defaults.PREFIX + "safepoints." + suffix + ".p0.9999",  statistics.getPercentile(99.99),"ms", AggregationPolicy.AVG),
                 new ScalarDerivativeResult(Defaults.PREFIX + "safepoints." + suffix + ".p1.00",    statistics.getMax(),            "ms", AggregationPolicy.MAX)
             );
+            // @formatter:on
         }
 
         /**


### PR DESCRIPTION
See https://bugs.openjdk.org/browse/CODETOOLS-7903479

I tried re-format random files from JMH, and they either kept intact, or the changes were minimal.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903479](https://bugs.openjdk.org/browse/CODETOOLS-7903479): JMH: Add .editorconfig so IDEs would pick up the common settings automatically: indent, trim whitespace (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/105/head:pull/105` \
`$ git checkout pull/105`

Update a local copy of the PR: \
`$ git checkout pull/105` \
`$ git pull https://git.openjdk.org/jmh.git pull/105/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 105`

View PR using the GUI difftool: \
`$ git pr show -t 105`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/105.diff">https://git.openjdk.org/jmh/pull/105.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/105#issuecomment-1566668488)