### PR TITLE
CODETOOLS-7903484: JMH: Use ThreadMXBean.getTotalThreadAllocatedBytes for -prof gc

### DIFF
--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v3
       with:
-        distribution: zulu
+        distribution: temurin
         java-version: ${{ matrix.java }}
         cache: maven
 

--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -31,6 +31,7 @@ jobs:
         distribution: temurin
         java-version: ${{ matrix.java }}
         cache: maven
+        check-latest: true
 
     - name: Run build with tests (Default)
       run: mvn clean install -P ${{ matrix.profile }} -B --file pom.xml

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/GCProfilerSeparateThreadTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/GCProfilerSeparateThreadTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jmh.it.profilers;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.it.Fixtures;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.util.JDKVersion;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1, jvmArgs = {"-Xms1g", "-Xmx1g", "-XX:+UseParallelGC"})
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+public class GCProfilerSeparateThreadTest {
+
+    static final int SIZE = 1_000_000;
+
+    @Benchmark
+    public void separateAlloc(Blackhole bh) throws InterruptedException {
+        Thread t = new Thread(() -> bh.consume(new byte[SIZE]));
+        t.start();
+        t.join();
+    }
+
+    @Test
+    public void testDefault() throws RunnerException {
+        Options opts = new OptionsBuilder()
+                .include(Fixtures.getTestMask(this.getClass()))
+                .addProfiler(GCProfiler.class)
+                .build();
+
+        RunResult rr = new Runner(opts).runSingle();
+
+        Map<String, Result> sr = rr.getSecondaryResults();
+        double allocRateNormB = sr.get("·gc.alloc.rate.norm").getScore();
+
+        boolean globalProfiler = JDKVersion.parseMajor(System.getProperty("java.version")) >= 21;
+        String msg = "Reported by profiler: " + allocRateNormB + ", target: " + SIZE;
+
+        // Allow 1% slack
+        if (globalProfiler && (Math.abs(1 - allocRateNormB / SIZE) > 0.01)) {
+            Assert.fail("Allocation rate failure. Reported by profiler: " + allocRateNormB + ", target: " + SIZE);
+        } else {
+            System.out.println(msg);
+        }
+    }
+}

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/GCProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/GCProfiler.java
@@ -378,10 +378,13 @@ public class GCProfiler implements InternalProfiler {
         }
 
         public static HotspotAllocationSnapshot getSnapshot() {
-            // Try the global getter first, if available.
+            // Try the global getter first, if available
             if (ALLOC_MX_BEAN_GETTER_GLOBAL != null) {
                 try {
                     long allocatedBytes = (long) ALLOC_MX_BEAN_GETTER_GLOBAL.invoke(ALLOC_MX_BEAN);
+                    if (allocatedBytes == -1L) {
+                        throw new IllegalStateException("getTotalThreadAllocatedBytes is disabled");
+                    }
                     return new GlobalHotspotAllocationSnapshot(allocatedBytes);
                 } catch (InvocationTargetException | IllegalAccessException e) {
                     throw new IllegalStateException(e);

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/GCProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/GCProfiler.java
@@ -36,7 +36,6 @@ import org.openjdk.jmh.util.HashMultiset;
 import org.openjdk.jmh.util.Multiset;
 
 import javax.management.ListenerNotFoundException;
-import javax.management.Notification;
 import javax.management.NotificationEmitter;
 import javax.management.NotificationListener;
 import javax.management.openmbean.CompositeData;
@@ -151,9 +150,9 @@ public class GCProfiler implements InternalProfiler {
         }
 
         if (allocEnabled) {
-            if (beforeAllocated != HotspotAllocationSnapshot.EMPTY) {
+            if (beforeAllocated != null) {
                 HotspotAllocationSnapshot newSnapshot = VMSupport.getSnapshot();
-                long allocated = newSnapshot.subtract(beforeAllocated);
+                long allocated = newSnapshot.difference(beforeAllocated);
                 // When no allocations measured, we still need to report results to avoid user confusion
                 results.add(new ScalarResult(Defaults.PREFIX + "gc.alloc.rate",
                         (afterTime != beforeTime) ?
@@ -204,13 +203,40 @@ public class GCProfiler implements InternalProfiler {
         return results;
     }
 
-    static class HotspotAllocationSnapshot {
-        public final static HotspotAllocationSnapshot EMPTY = new HotspotAllocationSnapshot(new long[0], new long[0]);
+    interface HotspotAllocationSnapshot {
+        long difference(HotspotAllocationSnapshot before);
+    }
 
+    static class GlobalHotspotAllocationSnapshot implements HotspotAllocationSnapshot {
+        private final long allocatedBytes;
+
+        public GlobalHotspotAllocationSnapshot(long allocatedBytes) {
+            this.allocatedBytes = allocatedBytes;
+        }
+
+        @Override
+        public long difference(HotspotAllocationSnapshot before) {
+            if (!(before instanceof GlobalHotspotAllocationSnapshot)) {
+                throw new IllegalArgumentException();
+            }
+
+            GlobalHotspotAllocationSnapshot other = (GlobalHotspotAllocationSnapshot) before;
+
+            long beforeAllocs = other.allocatedBytes;
+            if (allocatedBytes >= beforeAllocs) {
+                return allocatedBytes - beforeAllocs;
+            } else {
+                // Do not allow negative values
+                return 0;
+            }
+        }
+    }
+
+    static class PerThreadHotspotAllocationSnapshot implements HotspotAllocationSnapshot {
         private final long[] threadIds;
         private final long[] allocatedBytes;
 
-        private HotspotAllocationSnapshot(long[] threadIds, long[] allocatedBytes) {
+        private PerThreadHotspotAllocationSnapshot(long[] threadIds, long[] allocatedBytes) {
             this.threadIds = threadIds;
             this.allocatedBytes = allocatedBytes;
         }
@@ -224,7 +250,13 @@ public class GCProfiler implements InternalProfiler {
          *
          * @return estimated number of allocated bytes between profiler calls
          */
-        public long subtract(HotspotAllocationSnapshot other) {
+        public long difference(HotspotAllocationSnapshot before) {
+            if (!(before instanceof PerThreadHotspotAllocationSnapshot)) {
+                throw new IllegalArgumentException();
+            }
+
+            PerThreadHotspotAllocationSnapshot other = (PerThreadHotspotAllocationSnapshot) before;
+
             HashMap<Long, Integer> prevIndex = new HashMap<>();
             for (int i = 0; i < other.threadIds.length; i++) {
                 long id = other.threadIds[i];
@@ -254,7 +286,8 @@ public class GCProfiler implements InternalProfiler {
      */
     static class VMSupport {
         private static ThreadMXBean ALLOC_MX_BEAN;
-        private static Method ALLOC_MX_BEAN_GETTER;
+        private static Method ALLOC_MX_BEAN_GETTER_PER_THREAD;
+        private static Method ALLOC_MX_BEAN_GETTER_GLOBAL;
         private static NotificationListener LISTENER;
         private static Multiset<String> CHURN;
 
@@ -272,9 +305,19 @@ public class GCProfiler implements InternalProfiler {
                 }
 
                 ALLOC_MX_BEAN = bean;
-                ALLOC_MX_BEAN_GETTER = internalIntf.getMethod("getThreadAllocatedBytes", long[].class);
-                getAllocatedBytes(bean.getAllThreadIds());
 
+                // See if global getter is available in this JVM
+                try {
+                    ALLOC_MX_BEAN_GETTER_GLOBAL = internalIntf.getMethod("getTotalThreadAllocatedBytes");
+                    getSnapshot();
+                    return true;
+                } catch (Exception e) {
+                    // Fall through
+                }
+
+                // See if per-thread getter is available in this JVM
+                ALLOC_MX_BEAN_GETTER_PER_THREAD = internalIntf.getMethod("getThreadAllocatedBytes", long[].class);
+                getSnapshot();
                 return true;
             } catch (Throwable e) {
                 System.out.println("Allocation profiling is not available: " + e.getMessage());
@@ -297,14 +340,6 @@ public class GCProfiler implements InternalProfiler {
             }
 
             return false;
-        }
-
-        private static long[] getAllocatedBytes(long[] threadIds) {
-            try {
-                return (long[]) ALLOC_MX_BEAN_GETTER.invoke(ALLOC_MX_BEAN, (Object) threadIds);
-            } catch (InvocationTargetException | IllegalAccessException e) {
-                throw new IllegalStateException(e);
-            }
         }
 
         private static NotificationListener newListener() {
@@ -343,9 +378,24 @@ public class GCProfiler implements InternalProfiler {
         }
 
         public static HotspotAllocationSnapshot getSnapshot() {
+            // Try the global getter first, if available.
+            if (ALLOC_MX_BEAN_GETTER_GLOBAL != null) {
+                try {
+                    long allocatedBytes = (long) ALLOC_MX_BEAN_GETTER_GLOBAL.invoke(ALLOC_MX_BEAN);
+                    return new GlobalHotspotAllocationSnapshot(allocatedBytes);
+                } catch (InvocationTargetException | IllegalAccessException e) {
+                    throw new IllegalStateException(e);
+                }
+            }
+
+            // Fall back to per-thread getter
             long[] threadIds = ALLOC_MX_BEAN.getAllThreadIds();
-            long[] allocatedBytes = getAllocatedBytes(threadIds);
-            return new HotspotAllocationSnapshot(threadIds, allocatedBytes);
+            try {
+                long[] allocatedBytes = (long[]) ALLOC_MX_BEAN_GETTER_PER_THREAD.invoke(ALLOC_MX_BEAN, (Object) threadIds);
+                return new PerThreadHotspotAllocationSnapshot(threadIds, allocatedBytes);
+            } catch (InvocationTargetException | IllegalAccessException e) {
+                throw new IllegalStateException(e);
+            }
         }
 
         public static synchronized void startChurnProfile() {


### PR DESCRIPTION
JDK 21 comes with a new method that gives the total allocated rate for all the threads, [JDK-8304074](https://bugs.openjdk.org/browse/JDK-8304074). JMH -prof gc can use it, when available. This allows catching the totality of the thread allocations, regardless whether the threads went in or out during the lifetime of the benchmark. Current `-prof gc` is missing those threads most of the time. 

Example benchmark:

```
@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
@Fork(value = 1, jvmArgsAppend = {"-Xmx1g", "-Xms1g", "-XX:+AlwaysPreTouch", "-XX:+UseParallelGC"})
@BenchmarkMode(Mode.Throughput)
@OutputTimeUnit(TimeUnit.SECONDS)
@State(Scope.Thread)
public class TAB {

    @Benchmark
    public void inline(Blackhole bh) throws InterruptedException {
        bh.consume(new byte[1_000_000]);
    }

    @Benchmark
    public void separate(Blackhole bh) throws InterruptedException {
        Thread thread = new Thread(() -> { bh.consume(new byte[1_000_000]); });
        thread.start();
        thread.join();
    }
}
```

Current JDK 20:

```
Benchmark                          Mode  Cnt        Score      Error   Units

TAB.inline                        thrpt    5   100632,205 ± 1237,322   ops/s
TAB.inline:·gc.alloc.rate         thrpt    5    95961,825 ± 1181,577  MB/sec
TAB.inline:·gc.alloc.rate.norm    thrpt    5  1000016,004 ±    0,001    B/op
TAB.inline:·gc.count              thrpt    5     1432,000             counts
TAB.inline:·gc.time               thrpt    5      207,000                 ms

TAB.separate                      thrpt    5    18169,567 ±  374,656   ops/s
TAB.separate:·gc.alloc.rate       thrpt    5        5,822 ±    0,120  MB/sec  ; <--- missing allocations
TAB.separate:·gc.alloc.rate.norm  thrpt    5      336,024 ±    0,010    B/op  ; <--- missing allocations
TAB.separate:·gc.count            thrpt    5     2023,000             counts
TAB.separate:·gc.time             thrpt    5      229,000                 ms
```

Self-built JDK 21-ea:

```
Benchmark                          Mode  Cnt        Score      Error   Units

TAB.inline                        thrpt    5   103061,266 ± 2086,154   ops/s
TAB.inline:·gc.alloc.rate         thrpt    5    98277,065 ± 1988,502  MB/sec
TAB.inline:·gc.alloc.rate.norm    thrpt    5  1000016,056 ±    0,001    B/op
TAB.inline:·gc.count              thrpt    5     1466,000             counts
TAB.inline:·gc.time               thrpt    5      180,000                 ms

TAB.separate                      thrpt    5    18105,424 ± 1444,031   ops/s
TAB.separate:·gc.alloc.rate       thrpt    5    17270,918 ± 1378,016  MB/sec
TAB.separate:·gc.alloc.rate.norm  thrpt    5  1000360,319 ±    0,030    B/op ; <--- same alloc rate
TAB.separate:·gc.count            thrpt    5     2015,000             counts
TAB.separate:·gc.time             thrpt    5      197,000                 ms
```

Note: GHA testing would not be clean until `21-ea` release catches up and contains JDK-8304074.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903484](https://bugs.openjdk.org/browse/CODETOOLS-7903484): JMH: Use ThreadMXBean.getTotalThreadAllocatedBytes for -prof gc


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - no project role) ⚠️ Review applies to [4d52144c](https://git.openjdk.org/jmh/pull/106/files/4d52144c2e33a2b057b939a6e0338b391faff80c)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/106/head:pull/106` \
`$ git checkout pull/106`

Update a local copy of the PR: \
`$ git checkout pull/106` \
`$ git pull https://git.openjdk.org/jmh.git pull/106/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 106`

View PR using the GUI difftool: \
`$ git pr show -t 106`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/106.diff">https://git.openjdk.org/jmh/pull/106.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/106#issuecomment-1571869342)