### PR TITLE
CODETOOLS-7903476: JMH: Threading model should not assume stable threads

### DIFF
--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         java: [8, 11, 17, 20, 21-ea]
         os: [ubuntu-22.04, windows-2022, macos-11]
-        profile: [default, reflection, asm, executor-virtual-tpe, executor-fjp, executor-custom]
+        profile: [default, reflection, asm, executor-virtual, executor-fjp, executor-custom]
       fail-fast: false
     name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}, ${{ matrix.profile }}
     timeout-minutes: 60
@@ -62,4 +62,4 @@ jobs:
 
     - name: Run build with tests (Virtual Executor)
       run: mvn clean install -P ${{ matrix.profile }} -B --file pom.xml
-      if: (runner.os == 'Linux') && (matrix.java == '21-ea') && (matrix.profile == 'executor-virtual-tpe')
+      if: (runner.os == 'Linux') && (matrix.java == '21-ea') && (matrix.profile == 'executor-virtual')

--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -41,7 +41,7 @@ jobs:
       if: (runner.os == 'Linux') && (matrix.profile == 'executor-custom')
     - name: Run build with tests (Virtual Executor)
       run: mvn clean install -P ${{ matrix.profile }} -B --file pom.xml
-      if: (runner.os == 'Linux') && (matrix.java == "21-ea") && (matrix.profile == 'executor-virtual-tpe')
+      if: (runner.os == 'Linux') && (matrix.java == '21-ea') && (matrix.profile == 'executor-virtual-tpe')
     - name: Run build without tests
       run: mvn clean install -DskipTests -P ${{ matrix.profile }} -B --file pom.xml
       if: (runner.os != 'Linux') && (matrix.profile != 'default')

--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         java: [8, 11, 17, 20, 21-ea]
         os: [ubuntu-22.04, windows-2022, macos-11]
-        profile: [default, reflection, asm, executor-virtual-tpe, executor-fjp-common, executor-custom]
+        profile: [default, reflection, asm, executor-virtual-tpe, executor-fjp, executor-custom]
       fail-fast: false
     name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}, ${{ matrix.profile }}
 
@@ -49,7 +49,7 @@ jobs:
 
     - name: Run build with tests (FJP Executor)
       run: mvn clean install -P ${{ matrix.profile }} -B --file pom.xml
-      if: (runner.os == 'Linux') && (matrix.profile == 'executor-fjp-common')
+      if: (runner.os == 'Linux') && (matrix.profile == 'executor-fjp')
 
     - name: Run build with tests (Custom Executor)
       run: mvn clean install -P ${{ matrix.profile }} -B --file pom.xml

--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -31,11 +31,7 @@ jobs:
         java-version: ${{ matrix.java }}
         cache: maven
 
-    - name: Run build without tests
-      run: mvn clean install -DskipTests -P ${{ matrix.profile }} -B --file pom.xml
-      if: (runner.os != 'Linux') && (matrix.profile != 'default')
-
-    - name: Run build with tests
+    - name: Run build with tests (Default)
       run: mvn clean install -P ${{ matrix.profile }} -B --file pom.xml
       if: (matrix.profile == 'default')
 
@@ -43,9 +39,17 @@ jobs:
       run: mvn clean install -P ${{ matrix.profile }} -B --file pom.xml
       if: (runner.os == 'Linux') && (matrix.profile == 'reflection')
 
+    - name: Run build without tests (Reflection)
+      run: mvn clean install -P ${{ matrix.profile }} -B --file pom.xml -DskipTests
+      if: (runner.os != 'Linux') && (matrix.profile == 'reflection')
+
     - name: Run build with tests (ASM)
       run: mvn clean install -P ${{ matrix.profile }} -B --file pom.xml
       if: (runner.os == 'Linux') && (matrix.profile == 'asm')
+
+    - name: Run build without tests (ASM)
+      run: mvn clean install -P ${{ matrix.profile }} -B --file pom.xml -DskipTests
+      if: (runner.os != 'Linux') && (matrix.profile == 'asm')
 
     - name: Run build with tests (FJP Executor)
       run: mvn clean install -P ${{ matrix.profile }} -B --file pom.xml

--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -21,6 +21,7 @@ jobs:
         profile: [default, reflection, asm, executor-virtual-tpe, executor-fjp, executor-custom]
       fail-fast: false
     name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}, ${{ matrix.profile }}
+    timeout-minutes: 60
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         java: [8, 11, 17, 20, 21-ea]
         os: [ubuntu-22.04, windows-2022, macos-11]
-        profile: [default, reflection, asm]
+        profile: [default, reflection, asm, executor-virtual-tpe, executor-fjp-common, executor-custom]
       fail-fast: false
     name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}, ${{ matrix.profile }}
 
@@ -33,6 +33,15 @@ jobs:
     - name: Run build with tests
       run: mvn clean install -P ${{ matrix.profile }} -B --file pom.xml
       if: (runner.os == 'Linux') || (matrix.profile == 'default')
+    - name: Run build with tests (FJP Common)
+      run: mvn clean install -P ${{ matrix.profile }} -B --file pom.xml
+      if: (runner.os == 'Linux') && (matrix.profile == 'executor-fjp-common')
+    - name: Run build with tests (Custom)
+      run: mvn clean install -P ${{ matrix.profile }} -B --file pom.xml
+      if: (runner.os == 'Linux') && (matrix.profile == 'executor-custom')
+    - name: Run build with tests (Virtual Executor)
+      run: mvn clean install -P ${{ matrix.profile }} -B --file pom.xml
+      if: (runner.os == 'Linux') && (matrix.java == "21-ea") && (matrix.profile == 'executor-virtual-tpe')
     - name: Run build without tests
       run: mvn clean install -DskipTests -P ${{ matrix.profile }} -B --file pom.xml
       if: (runner.os != 'Linux') && (matrix.profile != 'default')

--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -30,18 +30,31 @@ jobs:
         distribution: zulu
         java-version: ${{ matrix.java }}
         cache: maven
-    - name: Run build with tests
-      run: mvn clean install -P ${{ matrix.profile }} -B --file pom.xml
-      if: (runner.os == 'Linux') || (matrix.profile == 'default')
-    - name: Run build with tests (FJP Common)
-      run: mvn clean install -P ${{ matrix.profile }} -B --file pom.xml
-      if: (runner.os == 'Linux') && (matrix.profile == 'executor-fjp-common')
-    - name: Run build with tests (Custom)
-      run: mvn clean install -P ${{ matrix.profile }} -B --file pom.xml
-      if: (runner.os == 'Linux') && (matrix.profile == 'executor-custom')
-    - name: Run build with tests (Virtual Executor)
-      run: mvn clean install -P ${{ matrix.profile }} -B --file pom.xml
-      if: (runner.os == 'Linux') && (matrix.java == '21-ea') && (matrix.profile == 'executor-virtual-tpe')
+
     - name: Run build without tests
       run: mvn clean install -DskipTests -P ${{ matrix.profile }} -B --file pom.xml
       if: (runner.os != 'Linux') && (matrix.profile != 'default')
+
+    - name: Run build with tests
+      run: mvn clean install -P ${{ matrix.profile }} -B --file pom.xml
+      if: (matrix.profile == 'default')
+
+    - name: Run build with tests (Reflection)
+      run: mvn clean install -P ${{ matrix.profile }} -B --file pom.xml
+      if: (runner.os == 'Linux') && (matrix.profile == 'reflection')
+
+    - name: Run build with tests (ASM)
+      run: mvn clean install -P ${{ matrix.profile }} -B --file pom.xml
+      if: (runner.os == 'Linux') && (matrix.profile == 'asm')
+
+    - name: Run build with tests (FJP Executor)
+      run: mvn clean install -P ${{ matrix.profile }} -B --file pom.xml
+      if: (runner.os == 'Linux') && (matrix.profile == 'executor-fjp-common')
+
+    - name: Run build with tests (Custom Executor)
+      run: mvn clean install -P ${{ matrix.profile }} -B --file pom.xml
+      if: (runner.os == 'Linux') && (matrix.profile == 'executor-custom')
+
+    - name: Run build with tests (Virtual Executor)
+      run: mvn clean install -P ${{ matrix.profile }} -B --file pom.xml
+      if: (runner.os == 'Linux') && (matrix.java == '21-ea') && (matrix.profile == 'executor-virtual-tpe')

--- a/jmh-core-it/pom.xml
+++ b/jmh-core-it/pom.xml
@@ -149,7 +149,7 @@ questions.
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <argLine>${jmh.testjvmargs} --enable-preview -Djmh.executor=VIRTUAL_TPE</argLine>
+                            <argLine>${jmh.testjvmargs} -Djmh.executor=VIRTUAL_TPE</argLine>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/jmh-core-it/pom.xml
+++ b/jmh-core-it/pom.xml
@@ -157,9 +157,9 @@ questions.
         </profile>
 
         <profile>
-            <id>executor-fjp-common</id>
+            <id>executor-fjp</id>
             <properties>
-                <jmh.core.it.profile>executor-fjp-common</jmh.core.it.profile>
+                <jmh.core.it.profile>executor-fjp</jmh.core.it.profile>
             </properties>
             <dependencies>
                 <dependency>
@@ -179,7 +179,7 @@ questions.
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <argLine>${jmh.testjvmargs} -Djmh.executor=FJP_COMMON</argLine>
+                            <argLine>${jmh.testjvmargs} -Djmh.executor=FJP</argLine>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/jmh-core-it/pom.xml
+++ b/jmh-core-it/pom.xml
@@ -58,6 +58,8 @@ questions.
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!-- Integration tests are not measuring performance, OK to run them concurrently -->
+        <jmh.testjvmargs>-Djmh.ignoreLock=true -Xms256m -Xmx256m -Djmh.core.it.profile=${jmh.core.it.profile}</jmh.testjvmargs>
     </properties>
 
     <build>
@@ -66,8 +68,7 @@ questions.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <!-- Integration tests are not measuring performance, OK to run them concurrently -->
-                    <argLine>-Djmh.ignoreLock=true -Xms256m -Xmx256m -Djmh.core.it.profile=${jmh.core.it.profile}</argLine>
+                    <argLine>${jmh.testjvmargs}</argLine>
                     <forkCount>1C</forkCount>
                     <!-- Integration tests sometimes set system properties, do not let them leak to other tests -->
                     <reuseForks>false</reuseForks>
@@ -120,6 +121,96 @@ questions.
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-compiler-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>executor-virtual-tpe</id>
+            <properties>
+                <jmh.core.it.profile>executor-virtual-tpe</jmh.core.it.profile>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.openjdk.jmh</groupId>
+                    <artifactId>jmh-generator-annprocess</artifactId>
+                    <version>${project.version}</version>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <argLine>${jmh.testjvmargs} --enable-preview -Djmh.executor=VIRTUAL_TPE</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>executor-fjp-common</id>
+            <properties>
+                <jmh.core.it.profile>executor-fjp-common</jmh.core.it.profile>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.openjdk.jmh</groupId>
+                    <artifactId>jmh-generator-annprocess</artifactId>
+                    <version>${project.version}</version>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <argLine>${jmh.testjvmargs} -Djmh.executor=FJP_COMMON</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>executor-custom</id>
+            <properties>
+                <jmh.core.it.profile>executor-custom</jmh.core.it.profile>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.openjdk.jmh</groupId>
+                    <artifactId>jmh-generator-annprocess</artifactId>
+                    <version>${project.version}</version>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <argLine>${jmh.testjvmargs} -Djmh.executor=CUSTOM -Djmh.executor.class=org.openjdk.jmh.it.CustomExecutorService</argLine>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/jmh-core-it/pom.xml
+++ b/jmh-core-it/pom.xml
@@ -127,9 +127,9 @@ questions.
         </profile>
 
         <profile>
-            <id>executor-virtual-tpe</id>
+            <id>executor-virtual</id>
             <properties>
-                <jmh.core.it.profile>executor-virtual-tpe</jmh.core.it.profile>
+                <jmh.core.it.profile>executor-virtual</jmh.core.it.profile>
             </properties>
             <dependencies>
                 <dependency>
@@ -149,7 +149,7 @@ questions.
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <argLine>${jmh.testjvmargs} -Djmh.executor=VIRTUAL_TPE</argLine>
+                            <argLine>${jmh.testjvmargs} -Djmh.executor=VIRTUAL</argLine>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/jmh-core-it/src/main/java/org/openjdk/jmh/it/CustomExecutorService.java
+++ b/jmh-core-it/src/main/java/org/openjdk/jmh/it/CustomExecutorService.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jmh.it;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.*;
+
+/**
+ * Synthetic executor service to test the corner case where executor always starts
+ * the task in the separate thread. Tests JMH invariants to the limit.
+ */
+public class CustomExecutorService implements ExecutorService {
+    public CustomExecutorService(int maxThreads, String prefix) {
+        // Do nothing
+    }
+
+    @Override
+    public void shutdown() {
+        // Do nothing
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return false;
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return false;
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) {
+        return true;
+    }
+
+    @Override
+    public <T> Future<T> submit(Callable<T> task) {
+        FutureTask<T> ft = new FutureTask<>(task);
+        new Thread(ft).start();
+        return ft;
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        new Thread(command).start();
+    }
+
+    @Override
+    public <T> Future<T> submit(Runnable task, T result) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Future<?> submit(Runnable task) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) {
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/Fixtures.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/Fixtures.java
@@ -47,4 +47,13 @@ public class Fixtures {
         }
     }
 
+    public static boolean expectStableThreads() {
+        return isDefaultProfile();
+    }
+
+    public static boolean isDefaultProfile() {
+        String profile = System.getProperty("jmh.core.it.profile");
+        return profile.equals("default");
+    }
+
 }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/Fixtures.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/Fixtures.java
@@ -24,11 +24,27 @@
  */
 package org.openjdk.jmh.it;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.concurrent.TimeUnit;
 
 public class Fixtures {
 
-    private static final int REPS = Integer.getInteger("jmh.it.reps", 1);
+    private static final int REPS;
+    private static final String PROFILE;
+
+    static {
+        REPS = AccessController.doPrivileged(new PrivilegedAction<Integer>() {
+            public Integer run() {
+                return Integer.getInteger("jmh.it.reps", 1);
+            }
+        });
+        PROFILE = AccessController.doPrivileged(new PrivilegedAction<String>() {
+            public String run() {
+                return System.getProperty("jmh.core.it.profile");
+            }
+        });
+    }
 
     public static int repetitionCount() {
         return REPS;
@@ -52,8 +68,7 @@ public class Fixtures {
     }
 
     public static boolean isDefaultProfile() {
-        String profile = System.getProperty("jmh.core.it.profile");
-        return profile.equals("default");
+        return PROFILE.equals("default");
     }
 
 }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/asymm/Zero1ThreadCountTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/asymm/Zero1ThreadCountTest.java
@@ -26,17 +26,7 @@ package org.openjdk.jmh.it.asymm;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.Group;
-import org.openjdk.jmh.annotations.GroupThreads;
-import org.openjdk.jmh.annotations.Measurement;
-import org.openjdk.jmh.annotations.Mode;
-import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
-import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.it.Fixtures;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
@@ -61,7 +51,11 @@ public class Zero1ThreadCountTest {
     @TearDown
     public void check() {
         Assert.assertEquals(0, test1threads.size());
-        Assert.assertEquals(2, test2threads.size());
+        if (Fixtures.expectStableThreads()) {
+            Assert.assertEquals(2, test2threads.size());
+        } else {
+            Assert.assertTrue(test2threads.size() >= 2);
+        }
     }
 
     @Benchmark

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/asymm/Zero2ThreadCountTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/asymm/Zero2ThreadCountTest.java
@@ -60,7 +60,11 @@ public class Zero2ThreadCountTest {
 
     @TearDown
     public void check() {
-        Assert.assertEquals(1, test1threads.size());
+        if (Fixtures.expectStableThreads()) {
+            Assert.assertEquals(1, test1threads.size());
+        } else {
+            Assert.assertTrue(test1threads.size() >= 1);
+        }
         Assert.assertEquals(0, test2threads.size());
     }
 

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/GCProfilerAllocRateTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/GCProfilerAllocRateTest.java
@@ -68,6 +68,12 @@ public class GCProfilerAllocRateTest {
     }
 
     private void testWith(String initLine) throws RunnerException {
+        if (!Fixtures.expectStableThreads()) {
+            // This test assumes threads survive until the end of run to get their
+            // allocation data.
+            return;
+        }
+
         Options opts = new OptionsBuilder()
                 .include(Fixtures.getTestMask(this.getClass()))
                 .addProfiler(GCProfiler.class, initLine)

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/security/SecurityManagerTestUtils.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/security/SecurityManagerTestUtils.java
@@ -24,11 +24,19 @@
  */
 package org.openjdk.jmh.it.security;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
 public class SecurityManagerTestUtils {
 
     public static void install() {
         try {
-            System.setSecurityManager(new SecurityManager());
+            AccessController.doPrivileged(new PrivilegedAction<Void>() {
+                public Void run() {
+                    System.setSecurityManager(new SecurityManager());
+                    return null;
+                }
+            });
         } catch (UnsupportedOperationException uoe) {
             // Probably modern JDK without SecurityManager support.
         }
@@ -36,7 +44,12 @@ public class SecurityManagerTestUtils {
 
     public static void remove() {
         try {
-            System.setSecurityManager(null);
+            AccessController.doPrivileged(new PrivilegedAction<Void>() {
+                public Void run() {
+                    System.setSecurityManager(null);
+                    return null;
+                }
+            });
         } catch (UnsupportedOperationException uoe) {
             // Probably modern JDK without SecurityManager support.
         }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/sharing/BenchmarkBenchSharingTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/sharing/BenchmarkBenchSharingTest.java
@@ -55,7 +55,11 @@ public class BenchmarkBenchSharingTest {
 
     @TearDown(Level.Trial)
     public void tearDown() {
-        Assert.assertEquals("All the threads have visited this state", 2, visitors.size());
+        if (Fixtures.expectStableThreads()) {
+            Assert.assertEquals(2, visitors.size());
+        } else {
+            Assert.assertTrue(visitors.size() >= 2);
+        }
     }
 
     @Benchmark

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/sharing/BenchmarkStateSharingTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/sharing/BenchmarkStateSharingTest.java
@@ -56,7 +56,11 @@ public class BenchmarkStateSharingTest {
 
         @TearDown(Level.Trial)
         public void tearDown() {
-            Assert.assertEquals("All the threads have visited this state", 2, visitors.size());
+            if (Fixtures.expectStableThreads()) {
+                Assert.assertEquals(2, visitors.size());
+            } else {
+                Assert.assertTrue(visitors.size() >= 2);
+            }
         }
     }
 

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/sharing/GroupBenchSharingTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/sharing/GroupBenchSharingTest.java
@@ -56,7 +56,11 @@ public class GroupBenchSharingTest {
 
     @TearDown(Level.Trial)
     public void tearDown() {
-        Assert.assertEquals("All the threads have visited this state", 4, visitors.size());
+        if (Fixtures.expectStableThreads()) {
+            Assert.assertEquals(4, visitors.size());
+        } else {
+            Assert.assertTrue(visitors.size() >= 4);
+        }
     }
 
     @Benchmark

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/sharing/GroupDefaultBenchSharingTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/sharing/GroupDefaultBenchSharingTest.java
@@ -56,7 +56,11 @@ public class GroupDefaultBenchSharingTest {
 
     @TearDown(Level.Trial)
     public void tearDown() {
-        Assert.assertEquals("All the threads have visited this state", 2, visitors.size());
+        if (Fixtures.expectStableThreads()) {
+            Assert.assertEquals(2, visitors.size());
+        } else {
+            Assert.assertTrue(visitors.size() >= 2);
+        }
     }
 
     @Benchmark

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/sharing/GroupDefaultStateSharingTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/sharing/GroupDefaultStateSharingTest.java
@@ -57,7 +57,11 @@ public class GroupDefaultStateSharingTest {
 
         @TearDown(Level.Trial)
         public void tearDown() {
-            Assert.assertEquals("All the threads have visited this state", 2, visitors.size());
+            if (Fixtures.expectStableThreads()) {
+                Assert.assertEquals(2, visitors.size());
+            } else {
+                Assert.assertTrue(visitors.size() >= 2);
+            }
         }
     }
 

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/sharing/GroupStateSharingTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/sharing/GroupStateSharingTest.java
@@ -57,7 +57,11 @@ public class GroupStateSharingTest {
 
         @TearDown(Level.Trial)
         public void tearDown() {
-            Assert.assertEquals("All the threads have visited this state", 4, visitors.size());
+            if (Fixtures.expectStableThreads()) {
+                Assert.assertEquals(4, visitors.size());
+            } else {
+                Assert.assertTrue(visitors.size() >= 4);
+            }
         }
     }
 

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/sharing/ThreadBenchSharingTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/sharing/ThreadBenchSharingTest.java
@@ -55,7 +55,11 @@ public class ThreadBenchSharingTest {
 
     @TearDown(Level.Trial)
     public void tearDown() {
-        Assert.assertEquals("Single thread have visited this state", 1, visitors.size());
+        if (Fixtures.expectStableThreads()) {
+            Assert.assertEquals(1, visitors.size());
+        } else {
+            Assert.assertTrue(visitors.size() >= 1);
+        }
     }
 
     @Benchmark

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/sharing/ThreadStateSharingTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/sharing/ThreadStateSharingTest.java
@@ -56,7 +56,11 @@ public class ThreadStateSharingTest {
 
         @TearDown(Level.Trial)
         public void tearDown() {
-            Assert.assertEquals("Single thread has visited this state", 1, visitors.size());
+            if (Fixtures.expectStableThreads()) {
+                Assert.assertEquals(1, visitors.size());
+            } else {
+                Assert.assertTrue(visitors.size() >= 1);
+            }
         }
     }
 

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/MaxThreadCountTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/MaxThreadCountTest.java
@@ -56,7 +56,11 @@ public class MaxThreadCountTest {
 
     @TearDown(Level.Iteration)
     public void tearDown() {
-        Assert.assertEquals("amount of threads should be Runtime.getRuntime().availableProcessors()", threads.size(), Runtime.getRuntime().availableProcessors());
+        if (Fixtures.expectStableThreads()) {
+            Assert.assertEquals(threads.size(), Runtime.getRuntime().availableProcessors());
+        } else {
+            Assert.assertTrue(threads.size() >= Runtime.getRuntime().availableProcessors());
+        }
     }
 
     @Benchmark

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/OneThreadCountTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/OneThreadCountTest.java
@@ -56,7 +56,11 @@ public class OneThreadCountTest {
 
     @TearDown(Level.Iteration)
     public void tearDown() {
-        Assert.assertEquals("amount of threads should be 1", threads.size(), 1);
+        if (Fixtures.expectStableThreads()) {
+            Assert.assertEquals(1, threads.size());
+        } else {
+            Assert.assertTrue(threads.size() >= 1);
+        }
     }
 
     @Benchmark

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/ThreadBenchSameThreadTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/ThreadBenchSameThreadTest.java
@@ -57,65 +57,49 @@ public class ThreadBenchSameThreadTest {
     private Thread setupInvocationThread;
     private Thread teardownRunThread;
     private Thread teardownIterationThread;
-    private Thread tearDownInvocationThread;
+    private Thread teardownInvocationThread;
     private Thread testInvocationThread;
 
     @Setup(Level.Trial)
     public void setupRun() {
-        if (setupRunThread == null) {
-            setupRunThread = Thread.currentThread();
-        }
-        Assert.assertEquals("setupRun", setupRunThread, Thread.currentThread());
+        setupRunThread = Thread.currentThread();
     }
 
     @Setup(Level.Iteration)
     public void setupIteration() {
-        if (setupIterationThread == null) {
-            setupIterationThread = Thread.currentThread();
-        }
-        Assert.assertEquals("setupIteration", setupIterationThread, Thread.currentThread());
+        setupIterationThread = Thread.currentThread();
     }
 
     @Setup(Level.Invocation)
     public void setupInvocation() {
-        if (setupInvocationThread == null) {
-            setupInvocationThread = Thread.currentThread();
-        }
-        Assert.assertEquals("setupInvocation", setupInvocationThread, Thread.currentThread());
+        setupInvocationThread = Thread.currentThread();
     }
 
     @TearDown(Level.Trial)
     public void tearDownRun() {
-        if (teardownRunThread == null) {
-            teardownRunThread = Thread.currentThread();
+        teardownRunThread = Thread.currentThread();
+
+        // Threads can change iteration to iteration
+        if (Fixtures.expectStableThreads()) {
+            Assert.assertEquals("test == setupRun",      testInvocationThread, setupRunThread);
+            Assert.assertEquals("test == teardownRun",   testInvocationThread, teardownRunThread);
         }
-        Assert.assertEquals("teardownRun", teardownRunThread, Thread.currentThread());
     }
 
     @TearDown(Level.Iteration)
     public void tearDownIteration() {
-        if (teardownIterationThread == null) {
-            teardownIterationThread = Thread.currentThread();
-        }
-        Assert.assertEquals("teardownIteration", teardownIterationThread, Thread.currentThread());
+        teardownIterationThread = Thread.currentThread();
+
+        // Within iteration, expect the same thread
+        Assert.assertEquals("test == setupIteration",     testInvocationThread, setupIterationThread);
+        Assert.assertEquals("test == teardownIteration",  testInvocationThread, teardownIterationThread);
+        Assert.assertEquals("test == setupInvocation",    testInvocationThread, setupInvocationThread);
+        Assert.assertEquals("test == teardownInvocation", testInvocationThread, teardownInvocationThread);
     }
 
     @TearDown(Level.Invocation)
     public void tearDownInvocation() {
-        if (tearDownInvocationThread == null) {
-            tearDownInvocationThread = Thread.currentThread();
-        }
-        Assert.assertEquals("tearDownInvocation", tearDownInvocationThread, Thread.currentThread());
-    }
-
-    @TearDown(Level.Trial)
-    public void teardownZZZ() { // should perform last
-        Assert.assertEquals("test != setupRun",           testInvocationThread, setupRunThread);
-        Assert.assertEquals("test != setupIteration",     testInvocationThread, setupIterationThread);
-        Assert.assertEquals("test != setupInvocation",    testInvocationThread, setupInvocationThread);
-        Assert.assertEquals("test != teardownRun",        testInvocationThread, teardownRunThread);
-        Assert.assertEquals("test != teardownIteration",  testInvocationThread, teardownIterationThread);
-        Assert.assertEquals("test != teardownInvocation", testInvocationThread, tearDownInvocationThread);
+        teardownInvocationThread = Thread.currentThread();
     }
 
     @Benchmark
@@ -125,10 +109,7 @@ public class ThreadBenchSameThreadTest {
     @Fork(1)
     @Threads(4)
     public void test() {
-        if (testInvocationThread == null) {
-            testInvocationThread = Thread.currentThread();
-        }
-        Assert.assertEquals("test", testInvocationThread, Thread.currentThread());
+        testInvocationThread = Thread.currentThread();
         Fixtures.work();
     }
 

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/ThreadBenchSameThreadTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/ThreadBenchSameThreadTest.java
@@ -44,6 +44,9 @@ import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -52,43 +55,46 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Thread)
 public class ThreadBenchSameThreadTest {
 
-    private Thread setupRunThread;
-    private Thread setupIterationThread;
-    private Thread setupInvocationThread;
-    private Thread teardownRunThread;
-    private Thread teardownIterationThread;
-    private Thread teardownInvocationThread;
-    private Thread testInvocationThread;
+    private final Set<Thread> setupRunThread = Collections.synchronizedSet(new HashSet<>());
+    private final Set<Thread> setupIterationThread = Collections.synchronizedSet(new HashSet<>());
+    private final Set<Thread> setupInvocationThread = Collections.synchronizedSet(new HashSet<>());
+    private final Set<Thread> teardownRunThread = Collections.synchronizedSet(new HashSet<>());
+    private final Set<Thread> teardownIterationThread = Collections.synchronizedSet(new HashSet<>());
+    private final Set<Thread> teardownInvocationThread = Collections.synchronizedSet(new HashSet<>());
+    private final Set<Thread> testInvocationThread = Collections.synchronizedSet(new HashSet<>());
 
     @Setup(Level.Trial)
     public void setupRun() {
-        setupRunThread = Thread.currentThread();
+        setupRunThread.add(Thread.currentThread());
     }
 
     @Setup(Level.Iteration)
     public void setupIteration() {
-        setupIterationThread = Thread.currentThread();
+        setupIterationThread.add(Thread.currentThread());
     }
 
     @Setup(Level.Invocation)
     public void setupInvocation() {
-        setupInvocationThread = Thread.currentThread();
+        setupInvocationThread.add(Thread.currentThread());
     }
 
     @TearDown(Level.Trial)
     public void tearDownRun() {
-        teardownRunThread = Thread.currentThread();
+        teardownRunThread.add(Thread.currentThread());
 
         // Threads can change iteration to iteration
         if (Fixtures.expectStableThreads()) {
             Assert.assertEquals("test == setupRun",      testInvocationThread, setupRunThread);
             Assert.assertEquals("test == teardownRun",   testInvocationThread, teardownRunThread);
+        } else {
+            Assert.assertTrue("test <: setupRun",           testInvocationThread.containsAll(setupRunThread));
+            Assert.assertTrue("test <: teardownRunThread",  testInvocationThread.containsAll(teardownRunThread));
         }
     }
 
     @TearDown(Level.Iteration)
     public void tearDownIteration() {
-        teardownIterationThread = Thread.currentThread();
+        teardownIterationThread.add(Thread.currentThread());
 
         // Within iteration, expect the same thread
         Assert.assertEquals("test == setupIteration",     testInvocationThread, setupIterationThread);
@@ -99,7 +105,7 @@ public class ThreadBenchSameThreadTest {
 
     @TearDown(Level.Invocation)
     public void tearDownInvocation() {
-        teardownInvocationThread = Thread.currentThread();
+        teardownInvocationThread.add(Thread.currentThread());
     }
 
     @Benchmark
@@ -109,7 +115,7 @@ public class ThreadBenchSameThreadTest {
     @Fork(1)
     @Threads(4)
     public void test() {
-        testInvocationThread = Thread.currentThread();
+        testInvocationThread.add(Thread.currentThread());
         Fixtures.work();
     }
 

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/ThreadStateSameThreadTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/ThreadStateSameThreadTest.java
@@ -64,60 +64,44 @@ public class ThreadStateSameThreadTest {
 
         @Setup(Level.Trial)
         public void setupRun() {
-            if (setupRunThread == null) {
-                setupRunThread = Thread.currentThread();
-            }
-            Assert.assertEquals("setupRun", setupRunThread, Thread.currentThread());
+            setupRunThread = Thread.currentThread();
         }
 
         @Setup(Level.Iteration)
         public void setupIteration() {
-            if (setupIterationThread == null) {
-                setupIterationThread = Thread.currentThread();
-            }
-            Assert.assertEquals("setupIteration", setupIterationThread, Thread.currentThread());
+            setupIterationThread = Thread.currentThread();
         }
 
         @Setup(Level.Invocation)
         public void setupInvocation() {
-            if (setupInvocationThread == null) {
-                setupInvocationThread = Thread.currentThread();
-            }
-            Assert.assertEquals("setupInvocation", setupInvocationThread, Thread.currentThread());
+            setupInvocationThread = Thread.currentThread();
         }
 
         @TearDown(Level.Trial)
         public void tearDownRun() {
-            if (teardownRunThread == null) {
-                teardownRunThread = Thread.currentThread();
+            teardownRunThread = Thread.currentThread();
+
+            // Threads can change iteration to iteration
+            if (Fixtures.expectStableThreads()) {
+                Assert.assertEquals("test == setupRun",      testInvocationThread, setupRunThread);
+                Assert.assertEquals("test == teardownRun",   testInvocationThread, teardownRunThread);
             }
-            Assert.assertEquals("teardownRun", teardownRunThread, Thread.currentThread());
         }
 
         @TearDown(Level.Iteration)
         public void tearDownIteration() {
-            if (teardownIterationThread == null) {
-                teardownIterationThread = Thread.currentThread();
-            }
-            Assert.assertEquals("teardownIteration", teardownIterationThread, Thread.currentThread());
+            teardownIterationThread = Thread.currentThread();
+
+            // Within iteration, expect the same thread
+            Assert.assertEquals("test == setupIteration",     testInvocationThread, setupIterationThread);
+            Assert.assertEquals("test == teardownIteration",  testInvocationThread, teardownIterationThread);
+            Assert.assertEquals("test == setupInvocation",    testInvocationThread, setupInvocationThread);
+            Assert.assertEquals("test == teardownInvocation", testInvocationThread, teardownInvocationThread);
         }
 
         @TearDown(Level.Invocation)
         public void tearDownInvocation() {
-            if (teardownInvocationThread == null) {
-                teardownInvocationThread = Thread.currentThread();
-            }
-            Assert.assertEquals("tearDownInvocation", teardownInvocationThread, Thread.currentThread());
-        }
-
-        @TearDown(Level.Trial)
-        public void teardownZZZ() { // should perform last
-            Assert.assertEquals("test != setupRun", testInvocationThread, setupRunThread);
-            Assert.assertEquals("test != setupIteration", testInvocationThread, setupIterationThread);
-            Assert.assertEquals("test != setupInvocation", testInvocationThread, setupInvocationThread);
-            Assert.assertEquals("test != teardownRun", testInvocationThread, teardownRunThread);
-            Assert.assertEquals("test != teardownIteration", testInvocationThread, teardownIterationThread);
-            Assert.assertEquals("test != teardownInvocation", testInvocationThread, teardownInvocationThread);
+            teardownInvocationThread = Thread.currentThread();
         }
     }
 
@@ -128,10 +112,7 @@ public class ThreadStateSameThreadTest {
     @Fork(1)
     @Threads(4)
     public void test(MyState state) {
-        if (state.testInvocationThread == null) {
-            state.testInvocationThread = Thread.currentThread();
-        }
-        Assert.assertEquals("test", state.testInvocationThread, Thread.currentThread());
+        state.testInvocationThread = Thread.currentThread();
         Fixtures.work();
     }
 

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/TwoThreadCountTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/TwoThreadCountTest.java
@@ -56,7 +56,11 @@ public class TwoThreadCountTest {
 
     @TearDown(Level.Iteration)
     public void tearDown() {
-        Assert.assertEquals("amount of threads should be 2", threads.size(), 2);
+        if (Fixtures.expectStableThreads()) {
+            Assert.assertEquals(2, threads.size());
+        } else {
+            Assert.assertTrue(threads.size() >= 2);
+        }
     }
 
     @Benchmark

--- a/jmh-core/src/main/java/org/openjdk/jmh/infra/Blackhole.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/infra/Blackhole.java
@@ -27,6 +27,8 @@ package org.openjdk.jmh.infra;
 import org.openjdk.jmh.util.Utils;
 
 import java.lang.ref.WeakReference;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Random;
 
 /*
@@ -251,9 +253,15 @@ public final class Blackhole extends BlackholeL4 {
      * AND LOTS OF TIME OVER THAT. ADJUST YOUR PLANS ACCORDINGLY.
      */
 
-    private static final boolean COMPILER_BLACKHOLE = Boolean.getBoolean("compilerBlackholesEnabled");
+    private static final boolean COMPILER_BLACKHOLE;
 
     static {
+        COMPILER_BLACKHOLE = AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
+            public Boolean run() {
+                return Boolean.getBoolean("compilerBlackholesEnabled");
+            }
+        });
+
         Utils.check(Blackhole.class, "b1", "b2");
         Utils.check(Blackhole.class, "bool1", "bool2");
         Utils.check(Blackhole.class, "c1", "c2");

--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/BaseRunner.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/BaseRunner.java
@@ -257,8 +257,9 @@ abstract class BaseRunner {
             }
 
             out.iteration(benchParams, wp, i);
+            boolean isFirstIteration = (i == 1);
             boolean isLastIteration = (benchParams.getMeasurement().getCount() == 0);
-            IterationResult ir = handler.runIteration(benchParams, wp, isLastIteration);
+            IterationResult ir = handler.runIteration(benchParams, wp, isFirstIteration, isLastIteration);
             out.iterationResult(benchParams, wp, i, ir);
 
             allWarmup += ir.getMetadata().getAllOps();
@@ -277,8 +278,9 @@ abstract class BaseRunner {
             // run benchmark iteration
             out.iteration(benchParams, mp, i);
 
+            boolean isFirstIteration = (benchParams.getWarmup().getCount() == 0) && (i == 1);
             boolean isLastIteration = (i == mp.getCount());
-            IterationResult ir = handler.runIteration(benchParams, mp, isLastIteration);
+            IterationResult ir = handler.runIteration(benchParams, mp, isFirstIteration, isLastIteration);
             out.iterationResult(benchParams, mp, i, ir);
 
             allMeasurement += ir.getMetadata().getAllOps();

--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/BenchmarkException.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/BenchmarkException.java
@@ -40,7 +40,9 @@ public class BenchmarkException extends RuntimeException {
     public BenchmarkException(String msg, Collection<Throwable> errors) {
         super(msg);
         for (Throwable err : errors) {
-            addSuppressed(err);
+            if (err != null) {
+                addSuppressed(err);
+            }
         }
     }
 

--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/BenchmarkHandler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/BenchmarkHandler.java
@@ -53,7 +53,10 @@ class BenchmarkHandler {
      */
     private final ExecutorService executor;
 
+    private final CyclicBarrier workerDataBarrier;
     private final ConcurrentMap<Thread, WorkerData> workerData;
+    private final BlockingQueue<WorkerData> unusedWorkerData;
+
     private final BlockingQueue<ThreadParams> tps;
 
     private final OutputFormat out;
@@ -74,14 +77,18 @@ class BenchmarkHandler {
         profilersRev = new ArrayList<>(profilers);
         Collections.reverse(profilersRev);
 
-        tps = new ArrayBlockingQueue<>(executionParams.getThreads());
-        tps.addAll(distributeThreads(executionParams.getThreads(), executionParams.getThreadGroups()));
+        int threads = executionParams.getThreads();
 
+        tps = new ArrayBlockingQueue<>(threads);
+        tps.addAll(distributeThreads(threads, executionParams.getThreadGroups()));
+
+        workerDataBarrier = new CyclicBarrier(threads, this::captureUnusedWorkerData);
         workerData = new ConcurrentHashMap<>();
+        unusedWorkerData = new ArrayBlockingQueue<>(threads);
 
         this.out = out;
         try {
-            executor = EXECUTOR_TYPE.createExecutor(executionParams.getThreads(), executionParams.getBenchmark());
+            executor = EXECUTOR_TYPE.createExecutor(threads, executionParams.getBenchmark());
         } catch (Exception e) {
             throw new IllegalStateException(e);
         }
@@ -192,6 +199,11 @@ class BenchmarkHandler {
             ExecutorService createExecutor(int maxThreads, String prefix) {
                 return Executors.newFixedThreadPool(maxThreads, WorkerThreadFactories.platformWorkerFactory(prefix));
             }
+
+            @Override
+            boolean hasStableThreads() {
+                return true;
+            }
         },
 
         /**
@@ -220,8 +232,6 @@ class BenchmarkHandler {
         FJP_COMMON {
             @Override
             ExecutorService createExecutor(int maxThreads, String prefix) throws Exception {
-                // (Aleksey):
-                // requires some of the reflection magic to untie from JDK 8 compile-time dependencies
                 Method m = Class.forName("java.util.concurrent.ForkJoinPool").getMethod("commonPool");
                 return (ExecutorService) m.invoke(null);
             }
@@ -250,6 +260,8 @@ class BenchmarkHandler {
         boolean shutdownForbidden() {
             return false;
         }
+
+        boolean hasStableThreads() { return false; }
     }
 
     protected void startProfilers(BenchmarkParams benchmarkParams, IterationParams iterationParams) {
@@ -305,10 +317,12 @@ class BenchmarkHandler {
      *
      * @param benchmarkParams Benchmark parameters
      * @param params  Iteration parameters
-     * @param last    Should this iteration considered to be the last
+     * @param isFirstIteration   Should this iteration considered to be the first
+     * @param isLastIteration    Should this iteration considered to be the last
      * @return IterationResult
      */
-    public IterationResult runIteration(BenchmarkParams benchmarkParams, IterationParams params, boolean last) {
+    public IterationResult runIteration(BenchmarkParams benchmarkParams, IterationParams params,
+                                        boolean isFirstIteration, boolean isLastIteration) {
         int numThreads = benchmarkParams.getThreads();
         TimeValue runtime = params.getTime();
 
@@ -319,7 +333,8 @@ class BenchmarkHandler {
         List<Result> iterationResults = new ArrayList<>();
 
         InfraControl control = new InfraControl(benchmarkParams, params,
-                preSetupBarrier, preTearDownBarrier, last,
+                preSetupBarrier, preTearDownBarrier,
+                isFirstIteration, isLastIteration,
                 new Control());
 
         // preparing the worker runnables
@@ -410,8 +425,14 @@ class BenchmarkHandler {
                 allOps += btr.getAllOps();
                 measuredOps += btr.getMeasuredOps();
             } catch (ExecutionException ex) {
-                // unwrap: ExecutionException -> Throwable-wrapper -> InvocationTargetException
-                Throwable cause = ex.getCause().getCause().getCause();
+                // Unwrap at most three exceptions through benchmark-thrown exception:
+                //  ExecutionException -> Throwable-wrapper -> InvocationTargetException
+                //
+                // Infrastructural exceptions come with shorter causal chains.
+                Throwable cause = ex;
+                for (int c = 0; (c < 3) && (cause.getCause() != null); c++) {
+                    cause = cause.getCause();
+                }
 
                 // record exception, unless it is the assist exception
                 if (!(cause instanceof FailureAssistException)) {
@@ -437,12 +458,46 @@ class BenchmarkHandler {
         return result;
     }
 
-    private WorkerData newWorkerData(Thread worker) {
-        WorkerData wd = workerData.get(worker);
-        if (wd != null) {
-            return wd;
+
+    private WorkerData getWorkerData(Thread worker) {
+        // See if there is a good worker data for us already, use it.
+        WorkerData wd = workerData.remove(worker);
+
+        // Wait for all threads to roll to this synchronization point.
+        // If there is any thread without assignment, the barrier action
+        // would dump the unused worker data for claiming.
+        try {
+            workerDataBarrier.await();
+        } catch (InterruptedException | BrokenBarrierException e) {
+            throw new IllegalStateException("Worker data barrier error ", e);
         }
 
+        if (wd == null) {
+            // Odd mode, no worker task recorded for the thread. Pull the worker data
+            // from the unused queue. This can only happen with executors with unstable threads.
+            if (EXECUTOR_TYPE.hasStableThreads()) {
+                throw new IllegalStateException("Worker data assignment failed for executor with stable threads");
+            }
+
+            wd = unusedWorkerData.poll();
+            if (wd == null) {
+                throw new IllegalStateException("Cannot get another thread working data");
+            }
+        }
+
+        WorkerData exist = workerData.put(worker, wd);
+        if (exist != null) {
+            throw new IllegalStateException("Duplicate thread data");
+        }
+        return wd;
+    }
+
+    private void captureUnusedWorkerData() {
+        unusedWorkerData.addAll(workerData.values());
+        workerData.clear();
+    }
+
+    private WorkerData newWorkerData(Thread worker) {
         try {
             Object o = clazz.getConstructor().newInstance();
             ThreadParams t = tps.poll();
@@ -450,7 +505,7 @@ class BenchmarkHandler {
                 throw new IllegalStateException("Cannot get another thread params");
             }
 
-            wd = new WorkerData(o, t);
+            WorkerData wd = new WorkerData(o, t);
             WorkerData exist = workerData.put(worker, wd);
             if (exist != null) {
                 throw new IllegalStateException("Duplicate thread data");
@@ -480,7 +535,7 @@ class BenchmarkHandler {
                 runner = Thread.currentThread();
 
                 // poll the current data, or instantiate in this thread, if needed
-                WorkerData wd = newWorkerData(runner);
+                WorkerData wd = control.firstIteration ? newWorkerData(runner) : getWorkerData(runner);
 
                 return (BenchmarkTaskResult) method.invoke(wd.instance, control, wd.params);
             } catch (Throwable e) {

--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/InfraControl.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/InfraControl.java
@@ -47,6 +47,7 @@ public class InfraControl extends InfraControlL4 {
         Utils.check(InfraControl.class, "isDone", "isFailing");
         Utils.check(InfraControl.class, "volatileSpoiler");
         Utils.check(InfraControl.class, "preSetup", "preTearDown");
+        Utils.check(InfraControl.class, "firstIteration");
         Utils.check(InfraControl.class, "lastIteration");
         Utils.check(InfraControl.class, "warmupVisited", "warmdownVisited");
         Utils.check(InfraControl.class, "warmupShouldWait", "warmdownShouldWait");
@@ -56,9 +57,10 @@ public class InfraControl extends InfraControlL4 {
     }
 
     public InfraControl(BenchmarkParams benchmarkParams, IterationParams iterationParams,
-                        CountDownLatch preSetup, CountDownLatch preTearDown, boolean lastIteration,
+                        CountDownLatch preSetup, CountDownLatch preTearDown,
+                        boolean firstIteration, boolean lastIteration,
                         Control notifyControl) {
-        super(benchmarkParams, iterationParams, preSetup, preTearDown, lastIteration, notifyControl);
+        super(benchmarkParams, iterationParams, preSetup, preTearDown, firstIteration, lastIteration, notifyControl);
     }
 
     /**
@@ -161,6 +163,7 @@ abstract class InfraControlL2 extends InfraControlL1 {
 
     public final CountDownLatch preSetup;
     public final CountDownLatch preTearDown;
+    public final boolean firstIteration;
     public final boolean lastIteration;
 
     public final AtomicInteger warmupVisited, warmdownVisited;
@@ -175,7 +178,8 @@ abstract class InfraControlL2 extends InfraControlL1 {
     private final int threads;
 
     public InfraControlL2(BenchmarkParams benchmarkParams, IterationParams iterationParams,
-                          CountDownLatch preSetup, CountDownLatch preTearDown, boolean lastIteration,
+                          CountDownLatch preSetup, CountDownLatch preTearDown,
+                          boolean firstIteration, boolean lastIteration,
                           Control notifyControl) {
         warmupVisited = new AtomicInteger();
         warmdownVisited = new AtomicInteger();
@@ -193,6 +197,7 @@ abstract class InfraControlL2 extends InfraControlL1 {
 
         this.preSetup = preSetup;
         this.preTearDown = preTearDown;
+        this.firstIteration = firstIteration;
         this.lastIteration = lastIteration;
         this.benchmarkParams = benchmarkParams;
         this.iterationParams = iterationParams;
@@ -274,9 +279,10 @@ abstract class InfraControlL3 extends InfraControlL2 {
     private boolean q171, q172, q173, q174, q175, q176, q177, q178;
 
     public InfraControlL3(BenchmarkParams benchmarkParams, IterationParams iterationParams,
-                          CountDownLatch preSetup, CountDownLatch preTearDown, boolean lastIteration,
+                          CountDownLatch preSetup, CountDownLatch preTearDown,
+                          boolean firstIteration, boolean lastIteration,
                           Control notifyControl) {
-        super(benchmarkParams, iterationParams, preSetup, preTearDown, lastIteration, notifyControl);
+        super(benchmarkParams, iterationParams, preSetup, preTearDown, firstIteration, lastIteration, notifyControl);
     }
 }
 
@@ -284,9 +290,10 @@ abstract class InfraControlL4 extends InfraControlL3 {
     private int markerEnd;
 
     public InfraControlL4(BenchmarkParams benchmarkParams, IterationParams iterationParams,
-                          CountDownLatch preSetup, CountDownLatch preTearDown, boolean lastIteration,
+                          CountDownLatch preSetup, CountDownLatch preTearDown,
+                          boolean firstIteration, boolean lastIteration,
                           Control notifyControl) {
-        super(benchmarkParams, iterationParams, preSetup, preTearDown, lastIteration, notifyControl);
+        super(benchmarkParams, iterationParams, preSetup, preTearDown, firstIteration, lastIteration, notifyControl);
     }
 }
 


### PR DESCRIPTION
See the bug for the original bug report.

This PR makes sure the harness code is able to work with different styles of executors, including the custom executor that always gives us a new thread. Integration tests now run with several important executor modes to catch errors early.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903476](https://bugs.openjdk.org/browse/CODETOOLS-7903476): JMH: Threading model should not assume stable threads


### Reviewers
 * [Sergey Kuksenko](https://openjdk.org/census#skuksenko) (@kuksenko - Committer) ⚠️ Review applies to [4b971d34](https://git.openjdk.org/jmh/pull/107/files/4b971d347436b79b455e3f661db88c852dd83e8e)


### Contributors
 * Sergey Kuksenko `<skuksenko@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/107/head:pull/107` \
`$ git checkout pull/107`

Update a local copy of the PR: \
`$ git checkout pull/107` \
`$ git pull https://git.openjdk.org/jmh.git pull/107/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 107`

View PR using the GUI difftool: \
`$ git pr show -t 107`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/107.diff">https://git.openjdk.org/jmh/pull/107.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/107#issuecomment-1572700414)