### PR TITLE
CODETOOLS-7903487: JMH: Make sure JMH profilers work on all tested configurations

### DIFF
--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -32,7 +32,7 @@ jobs:
         cache: maven
     - name: Set up perf (Linux)
       run: |
-        sudo apt-get install linux-tools-common linux-tools-generic linux-tools-`uname -r` 
+        sudo apt-get install -y linux-tools-common linux-tools-generic linux-tools-`uname -r` 
         perf stat echo 1
       if: (runner.os == 'Linux')
     - name: Run build with tests

--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -30,6 +30,11 @@ jobs:
         distribution: zulu
         java-version: ${{ matrix.java }}
         cache: maven
+    - name: Set up perf (Linux)
+      run: |
+        sudo apt-get install linux-tools-common linux-tools-generic linux-tools-`uname -r` 
+        perf stat echo 1
+      if: (runner.os == 'Linux')
     - name: Run build with tests
       run: mvn clean install -P ${{ matrix.profile }} -B --file pom.xml
       if: (runner.os == 'Linux') || (matrix.profile == 'default')

--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -33,7 +33,8 @@ jobs:
     - name: Set up perf (Linux)
       run: |
         sudo apt-get update
-        sudo apt-get install -y linux-tools-common linux-tools-generic linux-tools-`uname -r` 
+        sudo apt-get install -y linux-tools-common linux-tools-generic linux-tools-`uname -r`
+        echo -1 | sudo tee /proc/sys/kernel/perf_event_paranoid
         perf stat echo 1
       if: (runner.os == 'Linux')
     - name: Run build with tests

--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -32,6 +32,7 @@ jobs:
         cache: maven
     - name: Set up perf (Linux)
       run: |
+        sudo apt-get update
         sudo apt-get install -y linux-tools-common linux-tools-generic linux-tools-`uname -r` 
         perf stat echo 1
       if: (runner.os == 'Linux')

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/Fixtures.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/Fixtures.java
@@ -71,4 +71,7 @@ public class Fixtures {
         return PROFILE.equals("default");
     }
 
+    public static boolean isVirtualExecutor() {
+        return PROFILE.contains("executor-virtual");
+    }
 }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/AbstractAsmProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/AbstractAsmProfilerTest.java
@@ -24,19 +24,8 @@
  */
 package org.openjdk.jmh.it.profilers;
 
-import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
-import org.openjdk.jmh.it.Fixtures;
-import org.openjdk.jmh.profile.DTraceAsmProfiler;
-import org.openjdk.jmh.profile.ProfilerException;
-import org.openjdk.jmh.results.Result;
-import org.openjdk.jmh.results.RunResult;
-import org.openjdk.jmh.runner.Runner;
-import org.openjdk.jmh.runner.RunnerException;
-import org.openjdk.jmh.runner.options.Options;
-import org.openjdk.jmh.runner.options.OptionsBuilder;
 
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 @Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/AbstractAsmProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/AbstractAsmProfilerTest.java
@@ -25,6 +25,7 @@
 package org.openjdk.jmh.it.profilers;
 
 import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.util.JDKVersion;
 
 import java.util.concurrent.TimeUnit;
 
@@ -49,6 +50,21 @@ public abstract class AbstractAsmProfilerTest {
         // Call something that definitely results in calling a native stub.
         // This should work on environments where hsdis is not available.
         System.arraycopy(src, 0, dst, 0, SIZE);
+    }
+
+    public static boolean checkDisassembly(String out) {
+        if (JDKVersion.parseMajor(System.getProperty("java.version")) >= 17) {
+            // Should always print, since abstract assembler is available
+            return out.contains("StubRoutines::");
+        } else {
+            if (out.contains("StubRoutines::")) {
+                // hsdis is enabled, good
+                return true;
+            } else {
+                // hsdis is not enabled, okay
+                return out.contains("<no assembly is recorded, native region>");
+            }
+        }
     }
 
 }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/ClassloadProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/ClassloadProfilerTest.java
@@ -91,7 +91,7 @@ public class ClassloadProfilerTest {
         RunResult rr = new Runner(opts).runSingle();
 
         Map<String, Result> sr = rr.getSecondaryResults();
-        double classLoad = sr.get("·class.load.norm").getScore();
+        double classLoad = ProfilerTestUtils.checkedGet(sr, "·class.load.norm").getScore();
 
         // Allow 5% slack
         if (Math.abs(1 - classLoad) > 0.05) {

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/ClassloadProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/ClassloadProfilerTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jmh.it.profilers;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.it.Fixtures;
+import org.openjdk.jmh.profile.ClassloaderProfiler;
+import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+public class ClassloadProfilerTest {
+
+    // Simplest Dummy class
+    static final byte[] CLASS = new byte[] {
+            (byte) 0xca, (byte) 0xfe, (byte) 0xba, (byte) 0xbe,
+            0x00, 0x00, 0x00, 0x34,
+            0x00, 0x0a, 0x0a, 0x00, 0x02, 0x00, 0x03, 0x07,
+            0x00, 0x04, 0x0c, 0x00, 0x05, 0x00, 0x06, 0x01,
+            0x00, 0x10, 0x6a, 0x61, 0x76, 0x61, 0x2f, 0x6c,
+            0x61, 0x6e, 0x67, 0x2f, 0x4f, 0x62, 0x6a, 0x65,
+            0x63, 0x74, 0x01, 0x00, 0x06, 0x3c, 0x69, 0x6e,
+            0x69, 0x74, 0x3e, 0x01, 0x00, 0x03, 0x28, 0x29,
+            0x56, 0x07, 0x00, 0x08, 0x01, 0x00, 0x05, 0x44,
+            0x75, 0x6d, 0x6d, 0x79, 0x01, 0x00, 0x04, 0x43,
+            0x6f, 0x64, 0x65, 0x00, 0x21, 0x00, 0x07, 0x00,
+            0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
+            0x01, 0x00, 0x05, 0x00, 0x06, 0x00, 0x01, 0x00,
+            0x09, 0x00, 0x00, 0x00, 0x11, 0x00, 0x01, 0x00,
+            0x01, 0x00, 0x00, 0x00, 0x05, 0x2a, (byte) 0xb7, 0x00,
+            0x01, (byte) 0xb1, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+    };
+
+    static class MyClassLoader extends ClassLoader {
+        public Class<?> loadClass(String name) throws ClassNotFoundException {
+            if (name.equals("Dummy")) {
+                return defineClass(name, CLASS, 0, CLASS.length, null);
+            } else {
+                return super.loadClass(name);
+            }
+        }
+    }
+
+    @Benchmark
+    public Class<?> allocClass() throws Exception {
+        Fixtures.work();
+        ClassLoader loader = new MyClassLoader();
+        return Class.forName("Dummy", true, loader);
+    }
+
+    @Test
+    public void test() throws RunnerException {
+        Options opts = new OptionsBuilder()
+                .include(Fixtures.getTestMask(this.getClass()))
+                .addProfiler(ClassloaderProfiler.class)
+                .build();
+
+        RunResult rr = new Runner(opts).runSingle();
+
+        Map<String, Result> sr = rr.getSecondaryResults();
+        double classLoad = sr.get("·class.load.norm").getScore();
+
+        // Allow 5% slack
+        if (Math.abs(1 - classLoad) > 0.05) {
+            Assert.fail("Class loading rate is incorrect. Reported by profiler: " + classLoad);
+        }
+    }
+
+}

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/ClassloadProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/ClassloadProfilerTest.java
@@ -75,7 +75,7 @@ public class ClassloadProfilerTest {
     }
 
     @Benchmark
-    public Class<?> allocClass() throws Exception {
+    public Class<?> work() throws Exception {
         Fixtures.work();
         ClassLoader loader = new MyClassLoader();
         return Class.forName("Dummy", true, loader);

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/CompilerProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/CompilerProfilerTest.java
@@ -58,8 +58,8 @@ public class CompilerProfilerTest {
         RunResult rr = new Runner(opts).runSingle();
 
         Map<String, Result> sr = rr.getSecondaryResults();
-        double timeTotal = sr.get("·compiler.time.total").getScore();
-        double timeProfiled = sr.get("·compiler.time.profiled").getScore();
+        double timeTotal = ProfilerTestUtils.checkedGet(sr, "·compiler.time.total").getScore();
+        double timeProfiled = ProfilerTestUtils.checkedGet(sr, "·compiler.time.profiled").getScore();
 
         if (timeProfiled > timeTotal) {
             throw new IllegalStateException("Profiled time is larger than total time. " +

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/CompilerProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/CompilerProfilerTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jmh.it.profilers;
+
+import org.junit.Test;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.it.Fixtures;
+import org.openjdk.jmh.profile.CompilerProfiler;
+import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+public class CompilerProfilerTest {
+
+    @Benchmark
+    public void empty() {
+        Fixtures.work();
+    }
+
+    @Test
+    public void test() throws RunnerException {
+        Options opts = new OptionsBuilder()
+                .include(Fixtures.getTestMask(this.getClass()))
+                .addProfiler(CompilerProfiler.class)
+                .build();
+
+        RunResult rr = new Runner(opts).runSingle();
+
+        Map<String, Result> sr = rr.getSecondaryResults();
+        double timeTotal = sr.get("·compiler.time.total").getScore();
+        double timeProfiled = sr.get("·compiler.time.profiled").getScore();
+
+        if (timeProfiled > timeTotal) {
+            throw new IllegalStateException("Profiled time is larger than total time. " +
+                    "Total: " + timeTotal + ", Profiled: " + timeProfiled);
+        }
+
+        if (timeProfiled <= 0) {
+            throw new IllegalStateException("Should have profiled time: " + timeProfiled);
+        }
+
+        if (timeTotal <= 0) {
+            throw new IllegalStateException("Should have total time: " + timeTotal);
+        }
+    }
+
+}

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/CompilerProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/CompilerProfilerTest.java
@@ -44,7 +44,7 @@ import java.util.concurrent.TimeUnit;
 public class CompilerProfilerTest {
 
     @Benchmark
-    public void empty() {
+    public void work() {
         Fixtures.work();
     }
 

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/DTraceAsmProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/DTraceAsmProfilerTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jmh.it.profilers;
+
+import org.junit.Test;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.it.Fixtures;
+import org.openjdk.jmh.profile.DTraceAsmProfiler;
+import org.openjdk.jmh.profile.ProfilerException;
+import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+public class DTraceAsmProfilerTest {
+
+    @Benchmark
+    public void empty() {
+        somethingInTheMiddle();
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public void somethingInTheMiddle() {
+        Fixtures.work();
+    }
+
+    @Test
+    public void test() throws RunnerException {
+        try {
+            new DTraceAsmProfiler("");
+        } catch (ProfilerException e) {
+            // Not supported
+            return;
+        }
+
+        Options opts = new OptionsBuilder()
+                .include(Fixtures.getTestMask(this.getClass()))
+                .addProfiler(DTraceAsmProfiler.class)
+                .build();
+
+        RunResult rr = new Runner(opts).runSingle();
+
+        Map<String, Result> sr = rr.getSecondaryResults();
+        String out = sr.get("asm").extendedInfo();
+        if (!out.contains("somethingInTheMiddle")) {
+            throw new IllegalStateException("Profile does not contain the required frame");
+        }
+    }
+
+}

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/DTraceAsmProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/DTraceAsmProfilerTest.java
@@ -26,6 +26,7 @@ package org.openjdk.jmh.it.profilers;
 
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.it.Fixtures;
 import org.openjdk.jmh.profile.DTraceAsmProfiler;
 import org.openjdk.jmh.profile.ProfilerException;
@@ -45,13 +46,13 @@ import java.util.concurrent.TimeUnit;
 public class DTraceAsmProfilerTest {
 
     @Benchmark
-    public void empty() {
+    public void work() {
         somethingInTheMiddle();
     }
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void somethingInTheMiddle() {
-        Fixtures.work();
+        Blackhole.consumeCPU(1);
     }
 
     @Test
@@ -71,7 +72,7 @@ public class DTraceAsmProfilerTest {
         RunResult rr = new Runner(opts).runSingle();
 
         Map<String, Result> sr = rr.getSecondaryResults();
-        String out = sr.get("asm").extendedInfo();
+        String out = sr.get("·asm").extendedInfo();
         if (!out.contains("somethingInTheMiddle")) {
             throw new IllegalStateException("Profile does not contain the required frame");
         }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/DTraceAsmProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/DTraceAsmProfilerTest.java
@@ -58,7 +58,7 @@ public class DTraceAsmProfilerTest extends AbstractAsmProfilerTest {
         Map<String, Result> sr = rr.getSecondaryResults();
         String out = ProfilerTestUtils.checkedGet(sr, "·asm").extendedInfo();
         if (!out.contains("StubRoutines::")) {
-            throw new IllegalStateException("Profile does not contain the required frame");
+            throw new IllegalStateException("Profile does not contain the required frame: " + out);
         }
     }
 

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/DTraceAsmProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/DTraceAsmProfilerTest.java
@@ -72,7 +72,7 @@ public class DTraceAsmProfilerTest {
         RunResult rr = new Runner(opts).runSingle();
 
         Map<String, Result> sr = rr.getSecondaryResults();
-        String out = sr.get("·asm").extendedInfo();
+        String out = ProfilerTestUtils.checkedGet(sr, "·asm").extendedInfo();
         if (!out.contains("somethingInTheMiddle")) {
             throw new IllegalStateException("Profile does not contain the required frame");
         }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/DTraceAsmProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/DTraceAsmProfilerTest.java
@@ -60,7 +60,7 @@ public class DTraceAsmProfilerTest {
         try {
             new DTraceAsmProfiler("");
         } catch (ProfilerException e) {
-            // Not supported
+            System.out.println("Profiler is not supported or cannot be enabled, skipping test");
             return;
         }
 

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/DTraceAsmProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/DTraceAsmProfilerTest.java
@@ -57,7 +57,7 @@ public class DTraceAsmProfilerTest extends AbstractAsmProfilerTest {
 
         Map<String, Result> sr = rr.getSecondaryResults();
         String out = ProfilerTestUtils.checkedGet(sr, "·asm").extendedInfo();
-        if (!out.contains("StubRoutines::")) {
+        if (!checkDisassembly(out)) {
             throw new IllegalStateException("Profile does not contain the required frame: " + out);
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/GCProfilerAllocRateTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/GCProfilerAllocRateTest.java
@@ -78,8 +78,8 @@ public class GCProfilerAllocRateTest {
         double opsPerSec = rr.getPrimaryResult().getScore();
 
         Map<String, Result> sr = rr.getSecondaryResults();
-        double allocRateMB = sr.get("·gc.alloc.rate").getScore();
-        double allocRateNormB = sr.get("·gc.alloc.rate.norm").getScore();
+        double allocRateMB = ProfilerTestUtils.checkedGet(sr, "·gc.alloc.rate").getScore();
+        double allocRateNormB = ProfilerTestUtils.checkedGet(sr, "·gc.alloc.rate.norm").getScore();
         double allocRatePrimaryMB = opsPerSec * allocRateNormB / 1024 / 1024;
 
         // Allow 20% slack

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/GCProfilerSeparateThreadTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/GCProfilerSeparateThreadTest.java
@@ -67,7 +67,7 @@ public class GCProfilerSeparateThreadTest {
         RunResult rr = new Runner(opts).runSingle();
 
         Map<String, Result> sr = rr.getSecondaryResults();
-        double allocRateNormB = sr.get("·gc.alloc.rate.norm").getScore();
+        double allocRateNormB = ProfilerTestUtils.checkedGet(sr, "·gc.alloc.rate.norm").getScore();
 
         String msg = "Reported by profiler: " + allocRateNormB + ", target: " + SIZE;
 

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/JavaFlightRecorderProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/JavaFlightRecorderProfilerTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jmh.it.profilers;
+
+import org.junit.Test;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.it.Fixtures;
+import org.openjdk.jmh.profile.CompilerProfiler;
+import org.openjdk.jmh.profile.JavaFlightRecorderProfiler;
+import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+public class JavaFlightRecorderProfilerTest {
+
+    @Benchmark
+    public void empty() {
+        Fixtures.work();
+    }
+
+    @Test
+    public void test() throws RunnerException {
+        Options opts = new OptionsBuilder()
+                .include(Fixtures.getTestMask(this.getClass()))
+                .addProfiler(JavaFlightRecorderProfiler.class)
+                .build();
+
+        new Runner(opts).runSingle();
+    }
+
+}

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/JavaFlightRecorderProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/JavaFlightRecorderProfilerTest.java
@@ -45,7 +45,7 @@ import java.util.concurrent.TimeUnit;
 public class JavaFlightRecorderProfilerTest {
 
     @Benchmark
-    public void empty() {
+    public void work() {
         Fixtures.work();
     }
 

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfAsmProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfAsmProfilerTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jmh.it.profilers;
+
+import org.junit.Test;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.it.Fixtures;
+import org.openjdk.jmh.profile.LinuxPerfAsmProfiler;
+import org.openjdk.jmh.profile.ProfilerException;
+import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+public class LinuxPerfAsmProfilerTest {
+
+    @Benchmark
+    public void empty() {
+        somethingInTheMiddle();
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public void somethingInTheMiddle() {
+        Fixtures.work();
+    }
+
+    @Test
+    public void test() throws RunnerException {
+        try {
+            new LinuxPerfAsmProfiler("");
+        } catch (ProfilerException e) {
+            // Not supported
+            return;
+        }
+
+        Options opts = new OptionsBuilder()
+                .include(Fixtures.getTestMask(this.getClass()))
+                .addProfiler(LinuxPerfAsmProfiler.class)
+                .build();
+
+        RunResult rr = new Runner(opts).runSingle();
+
+        Map<String, Result> sr = rr.getSecondaryResults();
+        String out = sr.get("asm").extendedInfo();
+        if (!out.contains("somethingInTheMiddle")) {
+            throw new IllegalStateException("Profile does not contain the required frame");
+        }
+    }
+
+}

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfAsmProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfAsmProfilerTest.java
@@ -60,7 +60,7 @@ public class LinuxPerfAsmProfilerTest {
         try {
             new LinuxPerfAsmProfiler("");
         } catch (ProfilerException e) {
-            // Not supported
+            System.out.println("Profiler is not supported or cannot be enabled, skipping test");
             return;
         }
 

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfAsmProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfAsmProfilerTest.java
@@ -25,8 +25,6 @@
 package org.openjdk.jmh.it.profilers;
 
 import org.junit.Test;
-import org.openjdk.jmh.annotations.*;
-import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.it.Fixtures;
 import org.openjdk.jmh.profile.LinuxPerfAsmProfiler;
 import org.openjdk.jmh.profile.ProfilerException;
@@ -38,22 +36,8 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
-@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
-@Fork(1)
-public class LinuxPerfAsmProfilerTest {
-
-    @Benchmark
-    public void work() {
-        somethingInTheMiddle();
-    }
-
-    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public void somethingInTheMiddle() {
-        Blackhole.consumeCPU(1);
-    }
+public class LinuxPerfAsmProfilerTest extends AbstractAsmProfilerTest {
 
     @Test
     public void test() throws RunnerException {
@@ -73,7 +57,7 @@ public class LinuxPerfAsmProfilerTest {
 
         Map<String, Result> sr = rr.getSecondaryResults();
         String out = ProfilerTestUtils.checkedGet(sr, "·asm").extendedInfo();
-        if (!out.contains("somethingInTheMiddle")) {
+        if (!out.contains("StubRoutines::")) {
             throw new IllegalStateException("Profile does not contain the required frame");
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfAsmProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfAsmProfilerTest.java
@@ -58,7 +58,7 @@ public class LinuxPerfAsmProfilerTest extends AbstractAsmProfilerTest {
         Map<String, Result> sr = rr.getSecondaryResults();
         String out = ProfilerTestUtils.checkedGet(sr, "·asm").extendedInfo();
         if (!out.contains("StubRoutines::")) {
-            throw new IllegalStateException("Profile does not contain the required frame");
+            throw new IllegalStateException("Profile does not contain the required frame: " + out);
         }
     }
 

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfAsmProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfAsmProfilerTest.java
@@ -57,7 +57,7 @@ public class LinuxPerfAsmProfilerTest extends AbstractAsmProfilerTest {
 
         Map<String, Result> sr = rr.getSecondaryResults();
         String out = ProfilerTestUtils.checkedGet(sr, "·asm").extendedInfo();
-        if (!out.contains("StubRoutines::")) {
+        if (!checkDisassembly(out)) {
             throw new IllegalStateException("Profile does not contain the required frame: " + out);
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfAsmProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfAsmProfilerTest.java
@@ -26,6 +26,7 @@ package org.openjdk.jmh.it.profilers;
 
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.it.Fixtures;
 import org.openjdk.jmh.profile.LinuxPerfAsmProfiler;
 import org.openjdk.jmh.profile.ProfilerException;
@@ -45,13 +46,13 @@ import java.util.concurrent.TimeUnit;
 public class LinuxPerfAsmProfilerTest {
 
     @Benchmark
-    public void empty() {
+    public void work() {
         somethingInTheMiddle();
     }
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void somethingInTheMiddle() {
-        Fixtures.work();
+        Blackhole.consumeCPU(1);
     }
 
     @Test
@@ -71,7 +72,7 @@ public class LinuxPerfAsmProfilerTest {
         RunResult rr = new Runner(opts).runSingle();
 
         Map<String, Result> sr = rr.getSecondaryResults();
-        String out = sr.get("asm").extendedInfo();
+        String out = sr.get("·asm").extendedInfo();
         if (!out.contains("somethingInTheMiddle")) {
             throw new IllegalStateException("Profile does not contain the required frame");
         }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfAsmProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfAsmProfilerTest.java
@@ -72,7 +72,7 @@ public class LinuxPerfAsmProfilerTest {
         RunResult rr = new Runner(opts).runSingle();
 
         Map<String, Result> sr = rr.getSecondaryResults();
-        String out = sr.get("·asm").extendedInfo();
+        String out = ProfilerTestUtils.checkedGet(sr, "·asm").extendedInfo();
         if (!out.contains("somethingInTheMiddle")) {
             throw new IllegalStateException("Profile does not contain the required frame");
         }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfC2CProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfC2CProfilerTest.java
@@ -46,7 +46,7 @@ import java.util.concurrent.TimeUnit;
 public class LinuxPerfC2CProfilerTest {
 
     @Benchmark
-    public void empty() {
+    public void work() {
         somethingInTheMiddle();
     }
 

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfC2CProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfC2CProfilerTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jmh.it.profilers;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.it.Fixtures;
+import org.openjdk.jmh.profile.LinuxPerfC2CProfiler;
+import org.openjdk.jmh.profile.ProfilerException;
+import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+public class LinuxPerfC2CProfilerTest {
+
+    @Benchmark
+    public void empty() {
+        somethingInTheMiddle();
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public void somethingInTheMiddle() {
+        Fixtures.work();
+    }
+
+    @Test
+    public void test() throws RunnerException {
+        try {
+            new LinuxPerfC2CProfiler();
+        } catch (ProfilerException e) {
+            // Not supported
+            return;
+        }
+
+        Options opts = new OptionsBuilder()
+                .include(Fixtures.getTestMask(this.getClass()))
+                .addProfiler(LinuxPerfC2CProfiler.class)
+                .build();
+
+        RunResult rr = new Runner(opts).runSingle();
+
+        Map<String, Result> sr = rr.getSecondaryResults();
+        String text = sr.get("·perfc2c").extendedInfo();
+
+        Assert.assertNotNull(text);
+    }
+
+}

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfC2CProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfC2CProfilerTest.java
@@ -72,7 +72,7 @@ public class LinuxPerfC2CProfilerTest {
         RunResult rr = new Runner(opts).runSingle();
 
         Map<String, Result> sr = rr.getSecondaryResults();
-        String text = sr.get("·perfc2c").extendedInfo();
+        String text = ProfilerTestUtils.checkedGet(sr, "·perfc2c").extendedInfo();
 
         Assert.assertNotNull(text);
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfC2CProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfC2CProfilerTest.java
@@ -60,7 +60,7 @@ public class LinuxPerfC2CProfilerTest {
         try {
             new LinuxPerfC2CProfiler();
         } catch (ProfilerException e) {
-            // Not supported
+            System.out.println("Profiler is not supported or cannot be enabled, skipping test");
             return;
         }
 

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfNormProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfNormProfilerTest.java
@@ -61,7 +61,7 @@ public class LinuxPerfNormProfilerTest {
         try {
             new LinuxPerfNormProfiler("");
         } catch (ProfilerException e) {
-            // Not supported
+            System.out.println("Profiler is not supported or cannot be enabled, skipping test");
             return;
         }
 

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfNormProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfNormProfilerTest.java
@@ -27,6 +27,7 @@ package org.openjdk.jmh.it.profilers;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.it.Fixtures;
 import org.openjdk.jmh.profile.LinuxPerfNormProfiler;
 import org.openjdk.jmh.profile.ProfilerException;
@@ -46,13 +47,13 @@ import java.util.concurrent.TimeUnit;
 public class LinuxPerfNormProfilerTest {
 
     @Benchmark
-    public void empty() {
+    public void work() {
         somethingInTheMiddle();
     }
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void somethingInTheMiddle() {
-        Fixtures.work();
+        Blackhole.consumeCPU(1);
     }
 
     @Test

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfNormProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfNormProfilerTest.java
@@ -73,11 +73,11 @@ public class LinuxPerfNormProfilerTest {
         RunResult rr = new Runner(opts).runSingle();
 
         Map<String, Result> sr = rr.getSecondaryResults();
-        double ipc = sr.get("IPC").getScore();
-        double cpi = sr.get("CPI").getScore();
-        double instructions = sr.get("instructions").getScore();
-        double cycles = sr.get("cycles").getScore();
-        double branches = sr.get("branches").getScore();
+        double ipc = ProfilerTestUtils.checkedGet(sr, "IPC").getScore();
+        double cpi = ProfilerTestUtils.checkedGet(sr, "CPI").getScore();
+        double instructions = ProfilerTestUtils.checkedGet(sr, "instructions").getScore();
+        double cycles = ProfilerTestUtils.checkedGet(sr, "cycles").getScore();
+        double branches = ProfilerTestUtils.checkedGet(sr, "branches").getScore();
 
         Assert.assertNotEquals(0, ipc);
         Assert.assertNotEquals(0, cpi);

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfNormProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfNormProfilerTest.java
@@ -73,11 +73,11 @@ public class LinuxPerfNormProfilerTest {
         RunResult rr = new Runner(opts).runSingle();
 
         Map<String, Result> sr = rr.getSecondaryResults();
-        double ipc = sr.get("·IPC").getScore();
-        double cpi = sr.get("·CPI").getScore();
-        double instructions = sr.get("·instructions").getScore();
-        double cycles = sr.get("·cycles").getScore();
-        double branches = sr.get("·branches").getScore();
+        double ipc = sr.get("IPC").getScore();
+        double cpi = sr.get("CPI").getScore();
+        double instructions = sr.get("instructions").getScore();
+        double cycles = sr.get("cycles").getScore();
+        double branches = sr.get("branches").getScore();
 
         Assert.assertNotEquals(0, ipc);
         Assert.assertNotEquals(0, cpi);
@@ -85,8 +85,8 @@ public class LinuxPerfNormProfilerTest {
         Assert.assertNotEquals(0, cycles);
         Assert.assertNotEquals(0, branches);
 
-        if (instructions > branches) {
-            throw new IllegalStateException(String.format("Instructions (%.2f) larger than branches (%.3f)", instructions, branches));
+        if (branches > instructions) {
+            throw new IllegalStateException(String.format("Branches (%.2f) larger than instructions (%.3f)", branches, instructions));
         }
     }
 

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfNormProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfNormProfilerTest.java
@@ -73,14 +73,10 @@ public class LinuxPerfNormProfilerTest {
         RunResult rr = new Runner(opts).runSingle();
 
         Map<String, Result> sr = rr.getSecondaryResults();
-        double ipc = ProfilerTestUtils.checkedGet(sr, "IPC").getScore();
-        double cpi = ProfilerTestUtils.checkedGet(sr, "CPI").getScore();
         double instructions = ProfilerTestUtils.checkedGet(sr, "instructions").getScore();
         double cycles = ProfilerTestUtils.checkedGet(sr, "cycles").getScore();
         double branches = ProfilerTestUtils.checkedGet(sr, "branches").getScore();
 
-        Assert.assertNotEquals(0, ipc);
-        Assert.assertNotEquals(0, cpi);
         Assert.assertNotEquals(0, instructions);
         Assert.assertNotEquals(0, cycles);
         Assert.assertNotEquals(0, branches);
@@ -88,6 +84,12 @@ public class LinuxPerfNormProfilerTest {
         if (branches > instructions) {
             throw new IllegalStateException(String.format("Branches (%.2f) larger than instructions (%.3f)", branches, instructions));
         }
+
+        double ipc = ProfilerTestUtils.checkedGet(sr, "IPC").getScore();
+        double cpi = ProfilerTestUtils.checkedGet(sr, "CPI").getScore();
+
+        Assert.assertNotEquals(0, ipc);
+        Assert.assertNotEquals(0, cpi);
     }
 
 }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfNormProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfNormProfilerTest.java
@@ -73,9 +73,9 @@ public class LinuxPerfNormProfilerTest {
         RunResult rr = new Runner(opts).runSingle();
 
         Map<String, Result> sr = rr.getSecondaryResults();
-        double instructions = ProfilerTestUtils.checkedGet(sr, "instructions").getScore();
-        double cycles = ProfilerTestUtils.checkedGet(sr, "cycles").getScore();
-        double branches = ProfilerTestUtils.checkedGet(sr, "branches").getScore();
+        double instructions = ProfilerTestUtils.checkedGet(sr, "instructions", "instructions:u").getScore();
+        double cycles = ProfilerTestUtils.checkedGet(sr, "cycles", "cycles:u").getScore();
+        double branches = ProfilerTestUtils.checkedGet(sr, "branches", "branches:u").getScore();
 
         Assert.assertNotEquals(0, instructions);
         Assert.assertNotEquals(0, cycles);

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfNormProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfNormProfilerTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jmh.it.profilers;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.it.Fixtures;
+import org.openjdk.jmh.profile.LinuxPerfNormProfiler;
+import org.openjdk.jmh.profile.ProfilerException;
+import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+public class LinuxPerfNormProfilerTest {
+
+    @Benchmark
+    public void empty() {
+        somethingInTheMiddle();
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public void somethingInTheMiddle() {
+        Fixtures.work();
+    }
+
+    @Test
+    public void test() throws RunnerException {
+        try {
+            new LinuxPerfNormProfiler("");
+        } catch (ProfilerException e) {
+            // Not supported
+            return;
+        }
+
+        Options opts = new OptionsBuilder()
+                .include(Fixtures.getTestMask(this.getClass()))
+                .addProfiler(LinuxPerfNormProfiler.class)
+                .build();
+
+        RunResult rr = new Runner(opts).runSingle();
+
+        Map<String, Result> sr = rr.getSecondaryResults();
+        double ipc = sr.get("·IPC").getScore();
+        double cpi = sr.get("·CPI").getScore();
+        double instructions = sr.get("·instructions").getScore();
+        double cycles = sr.get("·cycles").getScore();
+        double branches = sr.get("·branches").getScore();
+
+        Assert.assertNotEquals(0, ipc);
+        Assert.assertNotEquals(0, cpi);
+        Assert.assertNotEquals(0, instructions);
+        Assert.assertNotEquals(0, cycles);
+        Assert.assertNotEquals(0, branches);
+
+        if (instructions > branches) {
+            throw new IllegalStateException(String.format("Instructions (%.2f) larger than branches (%.3f)", instructions, branches));
+        }
+    }
+
+}

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfProfilerTest.java
@@ -62,7 +62,7 @@ public class LinuxPerfProfilerTest {
         try {
             new LinuxPerfProfiler("");
         } catch (ProfilerException e) {
-            // Not supported
+            System.out.println("Profiler is not supported or cannot be enabled, skipping test");
             return;
         }
 

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfProfilerTest.java
@@ -27,6 +27,7 @@ package org.openjdk.jmh.it.profilers;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.it.Fixtures;
 import org.openjdk.jmh.profile.LinuxPerfAsmProfiler;
 import org.openjdk.jmh.profile.LinuxPerfProfiler;
@@ -47,13 +48,13 @@ import java.util.concurrent.TimeUnit;
 public class LinuxPerfProfilerTest {
 
     @Benchmark
-    public void empty() {
+    public void work() {
         somethingInTheMiddle();
     }
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void somethingInTheMiddle() {
-        Fixtures.work();
+        Blackhole.consumeCPU(1);
     }
 
     @Test

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfProfilerTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jmh.it.profilers;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.it.Fixtures;
+import org.openjdk.jmh.profile.LinuxPerfAsmProfiler;
+import org.openjdk.jmh.profile.LinuxPerfProfiler;
+import org.openjdk.jmh.profile.ProfilerException;
+import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+public class LinuxPerfProfilerTest {
+
+    @Benchmark
+    public void empty() {
+        somethingInTheMiddle();
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public void somethingInTheMiddle() {
+        Fixtures.work();
+    }
+
+    @Test
+    public void test() throws RunnerException {
+        try {
+            new LinuxPerfProfiler("");
+        } catch (ProfilerException e) {
+            // Not supported
+            return;
+        }
+
+        Options opts = new OptionsBuilder()
+                .include(Fixtures.getTestMask(this.getClass()))
+                .addProfiler(LinuxPerfProfiler.class)
+                .build();
+
+        RunResult rr = new Runner(opts).runSingle();
+
+        Map<String, Result> sr = rr.getSecondaryResults();
+        double ipc = sr.get("·ipc").getScore();
+        double cpi = sr.get("·cpi").getScore();
+        String msg = sr.get("·perf").extendedInfo();
+
+        Assert.assertNotEquals(0, ipc);
+        Assert.assertNotEquals(0, cpi);
+
+        Assert.assertTrue(msg.contains("cycles"));
+        Assert.assertTrue(msg.contains("instructions"));
+        Assert.assertTrue(msg.contains("branches"));
+    }
+
+}

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfProfilerTest.java
@@ -74,12 +74,14 @@ public class LinuxPerfProfilerTest {
         RunResult rr = new Runner(opts).runSingle();
 
         Map<String, Result> sr = rr.getSecondaryResults();
-        double ipc = ProfilerTestUtils.checkedGet(sr, "·ipc").getScore();
-        double cpi = ProfilerTestUtils.checkedGet(sr, "·cpi").getScore();
         String msg = ProfilerTestUtils.checkedGet(sr, "·perf").extendedInfo();
 
-        Assert.assertNotEquals(0, ipc);
-        Assert.assertNotEquals(0, cpi);
+        if (sr.containsKey("·ipc")) {
+            double ipc = ProfilerTestUtils.checkedGet(sr, "·ipc").getScore();
+            double cpi = ProfilerTestUtils.checkedGet(sr, "·cpi").getScore();
+            Assert.assertNotEquals(0, ipc);
+            Assert.assertNotEquals(0, cpi);
+        }
 
         Assert.assertTrue(msg.contains("cycles"));
         Assert.assertTrue(msg.contains("instructions"));

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfProfilerTest.java
@@ -74,9 +74,9 @@ public class LinuxPerfProfilerTest {
         RunResult rr = new Runner(opts).runSingle();
 
         Map<String, Result> sr = rr.getSecondaryResults();
-        double ipc = sr.get("·ipc").getScore();
-        double cpi = sr.get("·cpi").getScore();
-        String msg = sr.get("·perf").extendedInfo();
+        double ipc = ProfilerTestUtils.checkedGet(sr, "·ipc").getScore();
+        double cpi = ProfilerTestUtils.checkedGet(sr, "·cpi").getScore();
+        String msg = ProfilerTestUtils.checkedGet(sr, "·perf").extendedInfo();
 
         Assert.assertNotEquals(0, ipc);
         Assert.assertNotEquals(0, cpi);

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/MemPoolProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/MemPoolProfilerTest.java
@@ -45,7 +45,7 @@ import java.util.concurrent.TimeUnit;
 public class MemPoolProfilerTest {
 
     @Benchmark
-    public void empty() {
+    public void work() {
         Fixtures.work();
     }
 

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/MemPoolProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/MemPoolProfilerTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jmh.it.profilers;
+
+import org.junit.Test;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.it.Fixtures;
+import org.openjdk.jmh.profile.CompilerProfiler;
+import org.openjdk.jmh.profile.MemPoolProfiler;
+import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+public class MemPoolProfilerTest {
+
+    @Benchmark
+    public void empty() {
+        Fixtures.work();
+    }
+
+    @Test
+    public void test() throws RunnerException {
+        Options opts = new OptionsBuilder()
+                .include(Fixtures.getTestMask(this.getClass()))
+                .addProfiler(MemPoolProfiler.class)
+                .build();
+
+        RunResult rr = new Runner(opts).runSingle();
+
+        Map<String, Result> sr = rr.getSecondaryResults();
+
+        double usedMetaspace = sr.get("·mempool.Metaspace.used").getScore();
+        double usedTotal = sr.get("·mempool.total.used").getScore();
+        double usedTotalCodeheap = sr.get("·mempool.total.codeheap.used").getScore();
+
+        if (usedMetaspace == 0) {
+            throw new IllegalStateException("Metaspace used is zero");
+        }
+
+        if (usedTotal == 0) {
+            throw new IllegalStateException("Total used is zero");
+        }
+
+        if (usedTotalCodeheap == 0) {
+            throw new IllegalStateException("Total codeheap used is zero");
+        }
+
+        if (usedMetaspace > usedTotal) {
+            throw new IllegalStateException("Metaspace size is larger than total size. " +
+                    "Total: " + usedTotal + ", Metaspace: " + usedMetaspace);
+        }
+
+        if (usedTotalCodeheap > usedTotal) {
+            throw new IllegalStateException("Codeheap size is larger than total size. " +
+                    "Total: " + usedTotal + ", Codeheap: " + usedTotalCodeheap);
+        }
+    }
+
+}

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/MemPoolProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/MemPoolProfilerTest.java
@@ -60,9 +60,9 @@ public class MemPoolProfilerTest {
 
         Map<String, Result> sr = rr.getSecondaryResults();
 
-        double usedMetaspace = sr.get("·mempool.Metaspace.used").getScore();
-        double usedTotal = sr.get("·mempool.total.used").getScore();
-        double usedTotalCodeheap = sr.get("·mempool.total.codeheap.used").getScore();
+        double usedMetaspace = ProfilerTestUtils.checkedGet(sr, "·mempool.Metaspace.used").getScore();
+        double usedTotal = ProfilerTestUtils.checkedGet(sr, "·mempool.total.used").getScore();
+        double usedTotalCodeheap = ProfilerTestUtils.checkedGet(sr, "·mempool.total.codeheap.used").getScore();
 
         if (usedMetaspace == 0) {
             throw new IllegalStateException("Metaspace used is zero");

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/ProfilerTestUtils.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/ProfilerTestUtils.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2014, 2015, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jmh.it.profilers;
+
+import org.openjdk.jmh.results.Result;
+
+import java.util.Map;
+
+public class ProfilerTestUtils {
+
+    public static Result checkedGet(Map<String, Result> sr, String name) {
+        Result r = sr.get(name);
+        if (r != null) {
+            return r;
+        } else {
+            StringBuilder sb = new StringBuilder();
+            for (String k : sr.keySet()) {
+                sb.append(k);
+                sb.append(" = ");
+                sb.append(sr.get(k));
+                sb.append(System.lineSeparator());
+            }
+            throw new IllegalStateException("Cannot find the result \"" + name + "\". Available entries: " + sb);
+        }
+    }
+
+
+}

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/ProfilerTestUtils.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/ProfilerTestUtils.java
@@ -26,24 +26,27 @@ package org.openjdk.jmh.it.profilers;
 
 import org.openjdk.jmh.results.Result;
 
+import java.util.Arrays;
 import java.util.Map;
 
 public class ProfilerTestUtils {
 
-    public static Result checkedGet(Map<String, Result> sr, String name) {
-        Result r = sr.get(name);
-        if (r != null) {
-            return r;
-        } else {
-            StringBuilder sb = new StringBuilder();
-            for (String k : sr.keySet()) {
-                sb.append(k);
-                sb.append(" = ");
-                sb.append(sr.get(k));
-                sb.append(System.lineSeparator());
+    public static Result checkedGet(Map<String, Result> sr, String... names) {
+        for (String name : names) {
+            Result r = sr.get(name);
+            if (r != null) {
+                return r;
             }
-            throw new IllegalStateException("Cannot find the result \"" + name + "\". Available entries: " + sb);
         }
+
+        StringBuilder sb = new StringBuilder();
+        for (String k : sr.keySet()) {
+            sb.append(k);
+            sb.append(" = ");
+            sb.append(sr.get(k));
+            sb.append(System.lineSeparator());
+        }
+        throw new IllegalStateException("Cannot find the result for " + Arrays.toString(names) + "\". Available entries: " + sb);
     }
 
 

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/SafepointsProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/SafepointsProfilerTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jmh.it.profilers;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.it.Fixtures;
+import org.openjdk.jmh.profile.MemPoolProfiler;
+import org.openjdk.jmh.profile.SafepointsProfiler;
+import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1, jvmArgsAppend = {"-Xms1g", "-Xmx1g"})
+public class SafepointsProfilerTest {
+
+    @Benchmark
+    public int[] allocate() {
+        return new int[1_000_000];
+    }
+
+    @Test
+    public void test() throws RunnerException {
+        Options opts = new OptionsBuilder()
+                .include(Fixtures.getTestMask(this.getClass()))
+                .addProfiler(SafepointsProfiler.class)
+                .build();
+
+        RunResult rr = new Runner(opts).runSingle();
+
+        Map<String, Result> sr = rr.getSecondaryResults();
+
+        double interval = sr.get("·safepoints.interval").getScore();
+        double pauseTotal = sr.get("·safepoints.pause").getScore();
+        double ttspTotal = sr.get("·safepoints.ttsp").getScore();
+
+        double pauseCount = sr.get("·safepoints.pause.count").getScore();
+        double ttspCount = sr.get("·safepoints.ttsp.count").getScore();
+
+        Assert.assertNotEquals(pauseTotal, 0);
+        Assert.assertNotEquals(ttspTotal, 0);
+
+        Assert.assertNotEquals(pauseCount, 0);
+        Assert.assertNotEquals(ttspCount, 0);
+        Assert.assertEquals(ttspCount, pauseCount, 0);
+
+        if (interval < 3000) {
+            throw new IllegalStateException("Interval time is too low. " +
+                    " Interval: " + interval);
+        }
+
+        if (ttspTotal > interval) {
+            throw new IllegalStateException("TTSP time is larger than interval time. " +
+                    "TTSP: " + ttspTotal + ", Interval: " + interval);
+        }
+
+        if (pauseTotal > interval) {
+            throw new IllegalStateException("Pause time is larger than interval time. " +
+                    "Pause: " + pauseTotal + ", Interval: " + interval);
+        }
+
+        if (ttspTotal > pauseTotal) {
+            throw new IllegalStateException("TTSP time is larger than pause time. " +
+                    "TTSP: " + ttspTotal + ", Pause: " + pauseTotal);
+        }
+
+        double lastPause = 0;
+        double lastTTSP = 0;
+        for (String suff : new String[] {"0.00", "0.50", "0.90", "0.95", "0.99", "0.999", "0.9999", "1.00"}) {
+            double curPause = sr.get("·safepoints.pause.p" + suff).getScore();
+            double curTTSP = sr.get("·safepoints.ttsp.p" + suff).getScore();
+            if (curPause < lastPause) {
+                throw new IllegalStateException("pause.p" + suff + " is not monotonic");
+            }
+            if (curTTSP < lastTTSP) {
+                throw new IllegalStateException("ttsp.p" + suff + " is not monotonic");
+            }
+            lastPause = curPause;
+            lastTTSP = curTTSP;
+        }
+
+    }
+
+}

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/SafepointsProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/SafepointsProfilerTest.java
@@ -61,12 +61,12 @@ public class SafepointsProfilerTest {
 
         Map<String, Result> sr = rr.getSecondaryResults();
 
-        double interval = sr.get("·safepoints.interval").getScore();
-        double pauseTotal = sr.get("·safepoints.pause").getScore();
-        double ttspTotal = sr.get("·safepoints.ttsp").getScore();
+        double interval = ProfilerTestUtils.checkedGet(sr, "·safepoints.interval").getScore();
+        double pauseTotal = ProfilerTestUtils.checkedGet(sr, "·safepoints.pause").getScore();
+        double ttspTotal = ProfilerTestUtils.checkedGet(sr, "·safepoints.ttsp").getScore();
 
-        double pauseCount = sr.get("·safepoints.pause.count").getScore();
-        double ttspCount = sr.get("·safepoints.ttsp.count").getScore();
+        double pauseCount = ProfilerTestUtils.checkedGet(sr, "·safepoints.pause.count").getScore();
+        double ttspCount = ProfilerTestUtils.checkedGet(sr, "·safepoints.ttsp.count").getScore();
 
         Assert.assertNotEquals(pauseTotal, 0);
         Assert.assertNotEquals(ttspTotal, 0);
@@ -98,8 +98,8 @@ public class SafepointsProfilerTest {
         double lastPause = 0;
         double lastTTSP = 0;
         for (String suff : new String[] {"0.00", "0.50", "0.90", "0.95", "0.99", "0.999", "0.9999", "1.00"}) {
-            double curPause = sr.get("·safepoints.pause.p" + suff).getScore();
-            double curTTSP = sr.get("·safepoints.ttsp.p" + suff).getScore();
+            double curPause = ProfilerTestUtils.checkedGet(sr, "·safepoints.pause.p" + suff).getScore();
+            double curTTSP = ProfilerTestUtils.checkedGet(sr, "·safepoints.ttsp.p" + suff).getScore();
             if (curPause < lastPause) {
                 throw new IllegalStateException("pause.p" + suff + " is not monotonic");
             }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/StackProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/StackProfilerTest.java
@@ -64,7 +64,7 @@ public class StackProfilerTest {
         RunResult rr = new Runner(opts).runSingle();
 
         Map<String, Result> sr = rr.getSecondaryResults();
-        String out = ProfilerTestUtils.checkedGet(sr, "·out").extendedInfo();
+        String out = ProfilerTestUtils.checkedGet(sr, "·stack").extendedInfo();
         if (!out.contains(StackProfilerTest.class.getCanonicalName() + ".somethingInTheMiddle")) {
             throw new IllegalStateException("Profile does not contain the required frame: " + out);
         }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/StackProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/StackProfilerTest.java
@@ -64,7 +64,7 @@ public class StackProfilerTest {
         RunResult rr = new Runner(opts).runSingle();
 
         Map<String, Result> sr = rr.getSecondaryResults();
-        String stack = sr.get("·stack").extendedInfo();
+        String stack = ProfilerTestUtils.checkedGet(sr, "·stack").extendedInfo();
         if (!stack.contains(StackProfilerTest.class.getCanonicalName() + ".somethingInTheMiddle")) {
             throw new IllegalStateException("Stack profiler does not contain the required frame");
         }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/StackProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/StackProfilerTest.java
@@ -45,7 +45,7 @@ import java.util.concurrent.TimeUnit;
 public class StackProfilerTest {
 
     @Benchmark
-    public void empty() {
+    public void work() {
         somethingInTheMiddle();
     }
 

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/StackProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/StackProfilerTest.java
@@ -56,6 +56,11 @@ public class StackProfilerTest {
 
     @Test
     public void test() throws RunnerException {
+        if (Fixtures.isVirtualExecutor()) {
+            System.out.println("Stack profiler is not reliable with virtual threads");
+            return;
+        }
+
         Options opts = new OptionsBuilder()
                 .include(Fixtures.getTestMask(this.getClass()))
                 .addProfiler(StackProfiler.class, "lines=10")

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/StackProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/StackProfilerTest.java
@@ -64,9 +64,9 @@ public class StackProfilerTest {
         RunResult rr = new Runner(opts).runSingle();
 
         Map<String, Result> sr = rr.getSecondaryResults();
-        String stack = ProfilerTestUtils.checkedGet(sr, "·stack").extendedInfo();
-        if (!stack.contains(StackProfilerTest.class.getCanonicalName() + ".somethingInTheMiddle")) {
-            throw new IllegalStateException("Stack profiler does not contain the required frame");
+        String out = ProfilerTestUtils.checkedGet(sr, "·out").extendedInfo();
+        if (!out.contains(StackProfilerTest.class.getCanonicalName() + ".somethingInTheMiddle")) {
+            throw new IllegalStateException("Profile does not contain the required frame: " + out);
         }
     }
 

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/StackProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/StackProfilerTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jmh.it.profilers;
+
+import org.junit.Test;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.it.Fixtures;
+import org.openjdk.jmh.profile.JavaFlightRecorderProfiler;
+import org.openjdk.jmh.profile.StackProfiler;
+import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+public class StackProfilerTest {
+
+    @Benchmark
+    public void empty() {
+        somethingInTheMiddle();
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public void somethingInTheMiddle() {
+        Fixtures.work();
+    }
+
+    @Test
+    public void test() throws RunnerException {
+        Options opts = new OptionsBuilder()
+                .include(Fixtures.getTestMask(this.getClass()))
+                .addProfiler(StackProfiler.class, "lines=10")
+                .build();
+
+        RunResult rr = new Runner(opts).runSingle();
+
+        Map<String, Result> sr = rr.getSecondaryResults();
+        String stack = sr.get("·stack").extendedInfo();
+        if (!stack.contains(StackProfilerTest.class.getCanonicalName() + ".somethingInTheMiddle")) {
+            throw new IllegalStateException("Stack profiler does not contain the required frame");
+        }
+    }
+
+}

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/WinPerfAsmProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/WinPerfAsmProfilerTest.java
@@ -61,7 +61,7 @@ public class WinPerfAsmProfilerTest {
         try {
             new WinPerfAsmProfiler("");
         } catch (ProfilerException e) {
-            // Not supported
+            System.out.println("Profiler is not supported or cannot be enabled, skipping test");
             return;
         }
 

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/WinPerfAsmProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/WinPerfAsmProfilerTest.java
@@ -57,7 +57,7 @@ public class WinPerfAsmProfilerTest extends AbstractAsmProfilerTest {
 
         Map<String, Result> sr = rr.getSecondaryResults();
         String out = ProfilerTestUtils.checkedGet(sr, "·asm").extendedInfo();
-        if (!out.contains("StubRoutines::")) {
+        if (!checkDisassembly(out)) {
             throw new IllegalStateException("Profile does not contain the required frame: " + out);
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/WinPerfAsmProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/WinPerfAsmProfilerTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jmh.it.profilers;
+
+import org.junit.Test;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.it.Fixtures;
+import org.openjdk.jmh.profile.LinuxPerfAsmProfiler;
+import org.openjdk.jmh.profile.ProfilerException;
+import org.openjdk.jmh.profile.WinPerfAsmProfiler;
+import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+public class WinPerfAsmProfilerTest {
+
+    @Benchmark
+    public void empty() {
+        somethingInTheMiddle();
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public void somethingInTheMiddle() {
+        Fixtures.work();
+    }
+
+    @Test
+    public void test() throws RunnerException {
+        try {
+            new WinPerfAsmProfiler("");
+        } catch (ProfilerException e) {
+            // Not supported
+            return;
+        }
+
+        Options opts = new OptionsBuilder()
+                .include(Fixtures.getTestMask(this.getClass()))
+                .addProfiler(WinPerfAsmProfiler.class)
+                .build();
+
+        RunResult rr = new Runner(opts).runSingle();
+
+        Map<String, Result> sr = rr.getSecondaryResults();
+        String out = sr.get("asm").extendedInfo();
+        if (!out.contains("somethingInTheMiddle")) {
+            throw new IllegalStateException("Profile does not contain the required frame");
+        }
+    }
+
+}

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/WinPerfAsmProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/WinPerfAsmProfilerTest.java
@@ -25,10 +25,7 @@
 package org.openjdk.jmh.it.profilers;
 
 import org.junit.Test;
-import org.openjdk.jmh.annotations.*;
-import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.it.Fixtures;
-import org.openjdk.jmh.profile.LinuxPerfAsmProfiler;
 import org.openjdk.jmh.profile.ProfilerException;
 import org.openjdk.jmh.profile.WinPerfAsmProfiler;
 import org.openjdk.jmh.results.Result;
@@ -39,22 +36,8 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
-@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
-@Fork(1)
-public class WinPerfAsmProfilerTest {
-
-    @Benchmark
-    public void work() {
-        somethingInTheMiddle();
-    }
-
-    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public void somethingInTheMiddle() {
-        Blackhole.consumeCPU(1);
-    }
+public class WinPerfAsmProfilerTest extends AbstractAsmProfilerTest {
 
     @Test
     public void test() throws RunnerException {
@@ -74,7 +57,7 @@ public class WinPerfAsmProfilerTest {
 
         Map<String, Result> sr = rr.getSecondaryResults();
         String out = ProfilerTestUtils.checkedGet(sr, "·asm").extendedInfo();
-        if (!out.contains("somethingInTheMiddle")) {
+        if (!out.contains("StubRoutines::")) {
             throw new IllegalStateException("Profile does not contain the required frame");
         }
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/WinPerfAsmProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/WinPerfAsmProfilerTest.java
@@ -73,7 +73,7 @@ public class WinPerfAsmProfilerTest {
         RunResult rr = new Runner(opts).runSingle();
 
         Map<String, Result> sr = rr.getSecondaryResults();
-        String out = sr.get("·asm").extendedInfo();
+        String out = ProfilerTestUtils.checkedGet(sr, "·asm").extendedInfo();
         if (!out.contains("somethingInTheMiddle")) {
             throw new IllegalStateException("Profile does not contain the required frame");
         }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/WinPerfAsmProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/WinPerfAsmProfilerTest.java
@@ -26,6 +26,7 @@ package org.openjdk.jmh.it.profilers;
 
 import org.junit.Test;
 import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.it.Fixtures;
 import org.openjdk.jmh.profile.LinuxPerfAsmProfiler;
 import org.openjdk.jmh.profile.ProfilerException;
@@ -46,13 +47,13 @@ import java.util.concurrent.TimeUnit;
 public class WinPerfAsmProfilerTest {
 
     @Benchmark
-    public void empty() {
+    public void work() {
         somethingInTheMiddle();
     }
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void somethingInTheMiddle() {
-        Fixtures.work();
+        Blackhole.consumeCPU(1);
     }
 
     @Test
@@ -72,7 +73,7 @@ public class WinPerfAsmProfilerTest {
         RunResult rr = new Runner(opts).runSingle();
 
         Map<String, Result> sr = rr.getSecondaryResults();
-        String out = sr.get("asm").extendedInfo();
+        String out = sr.get("·asm").extendedInfo();
         if (!out.contains("somethingInTheMiddle")) {
             throw new IllegalStateException("Profile does not contain the required frame");
         }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/WinPerfAsmProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/WinPerfAsmProfilerTest.java
@@ -58,7 +58,7 @@ public class WinPerfAsmProfilerTest extends AbstractAsmProfilerTest {
         Map<String, Result> sr = rr.getSecondaryResults();
         String out = ProfilerTestUtils.checkedGet(sr, "·asm").extendedInfo();
         if (!out.contains("StubRoutines::")) {
-            throw new IllegalStateException("Profile does not contain the required frame");
+            throw new IllegalStateException("Profile does not contain the required frame: " + out);
         }
     }
 

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/DTraceAsmProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/DTraceAsmProfiler.java
@@ -94,7 +94,7 @@ public class DTraceAsmProfiler extends AbstractPerfAsmProfiler {
             throw new IllegalStateException("Cannot determine dtrace process PID");
         }
 
-        Collection<String> messages = Utils.tryWith("sudo", "kill", "-TERM", Long.toString(dtracePid));
+        Collection<String> messages = Utils.tryWith("sudo", "-n", "kill", "-TERM", Long.toString(dtracePid));
         if (!messages.isEmpty()) {
             throw new IllegalStateException(messages.toString());
         }

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfAsmProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfAsmProfiler.java
@@ -46,7 +46,7 @@ public class LinuxPerfAsmProfiler extends AbstractPerfAsmProfiler {
     public LinuxPerfAsmProfiler(String initLine) throws ProfilerException {
         super(initLine, "cycles");
 
-        Collection<String> failMsg = Utils.tryWith(PerfSupport.PERF_EXEC, "stat", "--log-fd", "2", "echo", "1");
+        Collection<String> failMsg = Utils.tryWith(PerfSupport.PERF_EXEC, "stat", "--event", Utils.join(requestedEventNames, ","), "--log-fd", "2", "echo", "1");
         if (!failMsg.isEmpty()) {
             throw new ProfilerException(failMsg.toString());
         }

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfAsmProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfAsmProfiler.java
@@ -46,14 +46,18 @@ public class LinuxPerfAsmProfiler extends AbstractPerfAsmProfiler {
     public LinuxPerfAsmProfiler(String initLine) throws ProfilerException {
         super(initLine, "cycles");
 
-        Collection<String> failMsg = Utils.tryWith(PerfSupport.PERF_EXEC, "stat", "--event", Utils.join(requestedEventNames, ","), "--log-fd", "2", "echo", "1");
+        String[] senseCmd = { PerfSupport.PERF_EXEC, "stat", "--event", Utils.join(requestedEventNames, ","), "--log-fd", "2", "echo", "1" };
+
+        Collection<String> failMsg = Utils.tryWith(senseCmd);
         if (!failMsg.isEmpty()) {
             throw new ProfilerException(failMsg.toString());
         }
 
-        Collection<String> passMsg = Utils.tryWith(PerfSupport.PERF_EXEC, "stat", "--event", Utils.join(requestedEventNames, ","), "--log-fd", "2", "echo", "1");
-        if (PerfSupport.containsUnsupported(passMsg, "")) {
-            throw new ProfilerException("Unsupported events: " + passMsg);
+        Collection<String> passMsg = Utils.tryWith(senseCmd);
+        for (String ev : requestedEventNames) {
+            if (PerfSupport.containsUnsupported(passMsg, ev)) {
+                throw new ProfilerException("Unsupported event: " + ev);
+            }
         }
 
         try {

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfAsmProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfAsmProfiler.java
@@ -53,7 +53,7 @@ public class LinuxPerfAsmProfiler extends AbstractPerfAsmProfiler {
             throw new ProfilerException(failMsg.toString());
         }
 
-        Collection<String> passMsg = Utils.tryWith(senseCmd);
+        Collection<String> passMsg = Utils.runWith(senseCmd);
         for (String ev : requestedEventNames) {
             if (PerfSupport.containsUnsupported(passMsg, ev)) {
                 throw new ProfilerException("Unsupported event: " + ev);

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfAsmProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfAsmProfiler.java
@@ -51,6 +51,11 @@ public class LinuxPerfAsmProfiler extends AbstractPerfAsmProfiler {
             throw new ProfilerException(failMsg.toString());
         }
 
+        Collection<String> passMsg = Utils.tryWith(PerfSupport.PERF_EXEC, "stat", "--event", Utils.join(requestedEventNames, ","), "--log-fd", "2", "echo", "1");
+        if (PerfSupport.containsUnsupported(passMsg, "")) {
+            throw new ProfilerException("Unsupported events: " + passMsg);
+        }
+
         try {
             sampleFrequency = set.valueOf(optFrequency);
         } catch (OptionException e) {

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfC2CProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfC2CProfiler.java
@@ -44,6 +44,11 @@ public final class LinuxPerfC2CProfiler implements ExternalProfiler {
     protected final TempFile perfBinData;
 
     public LinuxPerfC2CProfiler() throws ProfilerException {
+        Collection<String> failMsg = Utils.tryWith(PerfSupport.PERF_EXEC, "c2c", "record", "echo", "1");
+        if (!failMsg.isEmpty()) {
+            throw new ProfilerException(failMsg.toString());
+        }
+
         try {
             perfBinData = FileUtils.weakTempFile("perf-c2c-bin");
         } catch (IOException e) {

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfNormProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfNormProfiler.java
@@ -118,19 +118,22 @@ public class LinuxPerfNormProfiler implements ExternalProfiler {
         Collection<String> incremental = Utils.tryWith(PerfSupport.PERF_EXEC, "stat", "--log-fd", "2", "--field-separator", ",", "--interval-print", String.valueOf(incrementInterval), "echo", "1");
         isIncrementable = incremental.isEmpty();
 
+        Collection<String> candidateEvents = new ArrayList<>();
         if (userEvents != null) {
             for (String ev : userEvents) {
                 if (ev.trim().isEmpty()) continue;
-                supportedEvents.add(ev);
+                candidateEvents.add(ev);
             }
         }
 
         if (supportedEvents.isEmpty()) {
-            for (String ev : interestingEvents) {
-                Collection<String> res = Utils.tryWith(PerfSupport.PERF_EXEC, "stat", "--log-fd", "2", "--field-separator", ",", "--event", ev, "echo", "1");
-                if (res.isEmpty()) {
-                    supportedEvents.add(ev);
-                }
+            candidateEvents.addAll(Arrays.asList(interestingEvents));
+        }
+
+        for (String ev : candidateEvents) {
+            Collection<String> res = Utils.tryWith(PerfSupport.PERF_EXEC, "stat", "--log-fd", "2", "--field-separator", ",", "--event", ev, "echo", "1");
+            if (res.isEmpty()) {
+                supportedEvents.add(ev);
             }
         }
 

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfNormProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfNormProfiler.java
@@ -133,6 +133,10 @@ public class LinuxPerfNormProfiler implements ExternalProfiler {
                 }
             }
         }
+
+        if (!useDefaultStats && supportedEvents.isEmpty()) {
+            throw new ProfilerException("No supported events.");
+        }
     }
 
     @Override

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfNormProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfNormProfiler.java
@@ -342,8 +342,14 @@ public class LinuxPerfNormProfiler implements ExternalProfiler {
 
                 // Also figure out IPC/CPI, if enough counters available:
                 {
-                    long cycles = events.count("cycles");
-                    long instructions = events.count("instructions");
+                    long c1 = events.count("cycles");
+                    long c2 = events.count("cycles:u");
+
+                    long i1 = events.count("instructions");
+                    long i2 = events.count("instructions:u");
+
+                    long cycles = (c1 != 0) ? c1 : c2;
+                    long instructions = (i1 != 0) ? i1 : i2;
                     if (cycles != 0 && instructions != 0) {
                         results.add(new PerfResult("CPI", "clks/insn", 1.0 * cycles / instructions));
                         results.add(new PerfResult("IPC", "insns/clk", 1.0 * instructions / cycles));

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfNormProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfNormProfiler.java
@@ -133,7 +133,10 @@ public class LinuxPerfNormProfiler implements ExternalProfiler {
         for (String ev : candidateEvents) {
             Collection<String> res = Utils.tryWith(PerfSupport.PERF_EXEC, "stat", "--log-fd", "2", "--field-separator", ",", "--event", ev, "echo", "1");
             if (res.isEmpty()) {
-                supportedEvents.add(ev);
+                Collection<String> out = Utils.runWith(PerfSupport.PERF_EXEC, "stat", "--log-fd", "2", "--field-separator", ",", "--event", ev, "echo", "1");
+                if (!PerfSupport.containsUnsupported(out, ev)) {
+                    supportedEvents.add(ev);
+                }
             }
         }
 

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfNormProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfNormProfiler.java
@@ -131,9 +131,10 @@ public class LinuxPerfNormProfiler implements ExternalProfiler {
         }
 
         for (String ev : candidateEvents) {
-            Collection<String> res = Utils.tryWith(PerfSupport.PERF_EXEC, "stat", "--log-fd", "2", "--field-separator", ",", "--event", ev, "echo", "1");
+            String[] senseCmd = { PerfSupport.PERF_EXEC, "stat", "--log-fd", "2", "--field-separator", ",", "--event", ev, "echo", "1" };
+            Collection<String> res = Utils.tryWith(senseCmd);
             if (res.isEmpty()) {
-                Collection<String> out = Utils.runWith(PerfSupport.PERF_EXEC, "stat", "--log-fd", "2", "--field-separator", ",", "--event", ev, "echo", "1");
+                Collection<String> out = Utils.runWith(senseCmd);
                 if (!PerfSupport.containsUnsupported(out, ev)) {
                     supportedEvents.add(ev);
                 }

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/MemPoolProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/MemPoolProfiler.java
@@ -57,7 +57,7 @@ public class MemPoolProfiler implements InternalProfiler {
         long sum = 0L;
         for (MemoryPoolMXBean bean : ManagementFactory.getMemoryPoolMXBeans()) {
             long used = bean.getPeakUsage().getUsed();
-            if (bean.getName().contains("CodeHeap")) {
+            if (bean.getName().contains("CodeHeap") || bean.getName().contains("Code Cache")) {
                 sumCodeHeap += used;
             }
             sum += used;

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/PerfSupport.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/PerfSupport.java
@@ -24,6 +24,8 @@
  */
 package org.openjdk.jmh.profile;
 
+import java.util.Collection;
+
 class PerfSupport {
 
     static final String PERF_EXEC;
@@ -31,6 +33,15 @@ class PerfSupport {
     static {
         String perf = System.getenv("JMH_PERF");
         PERF_EXEC = (perf == null) ? "perf" : perf;
+    }
+
+    public static boolean containsUnsupported(Collection<String> msgs, String event) {
+        for (String m : msgs) {
+            if (m.contains(event) && m.contains("<not supported>")) {
+                return true;
+            }
+        }
+        return false;
     }
 
 }

--- a/jmh-core/src/main/java/org/openjdk/jmh/util/Utils.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/util/Utils.java
@@ -528,6 +528,10 @@ public class Utils {
         }
     }
 
+    public static Collection<String> runWith(String... cmds) {
+        return runWith(Arrays.asList(cmds));
+    }
+
     public static Collection<String> runWith(List<String> cmd) {
         Collection<String> messages = new ArrayList<>();
         try {


### PR DESCRIPTION
JMH profilers is the important feature, and they should be verified with at least smoke tests to capture their breakage, e.g. when JDK changes something.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903487](https://bugs.openjdk.org/browse/CODETOOLS-7903487): JMH: Make sure JMH profilers work on all tested configurations (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/109/head:pull/109` \
`$ git checkout pull/109`

Update a local copy of the PR: \
`$ git checkout pull/109` \
`$ git pull https://git.openjdk.org/jmh.git pull/109/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 109`

View PR using the GUI difftool: \
`$ git pr show -t 109`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/109.diff">https://git.openjdk.org/jmh/pull/109.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/109#issuecomment-1574207715)