### PR TITLE
7903498: JMH: Reset worker interrupt status after iteration

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/BenchmarkHandler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/BenchmarkHandler.java
@@ -515,6 +515,12 @@ class BenchmarkHandler {
                 // bind the executor thread
                 runner = Thread.currentThread();
 
+                // Clear the interruption status for the thread before going into the infra.
+                // Normally, the interrupts would be cleared at the end of benchmark, but
+                // there is a tiny window when harness could deliver another interrupt after
+                // we left.
+                boolean unused = Thread.interrupted();
+
                 // poll the current data, or instantiate in this thread, if needed
                 WorkerData wd = control.firstIteration ? newWorkerData(runner) : getWorkerData(runner);
 
@@ -545,13 +551,13 @@ class BenchmarkHandler {
 
                 throw new Exception(e); // wrapping Throwable
             } finally {
+                // unbind the executor thread
+                runner = null;
+
                 // Clear the interruption status for the thread after leaving the benchmark method.
                 // If any InterruptedExceptions happened, they should have been handled by now.
                 // This prepares the runner thread for another iteration.
                 boolean unused = Thread.interrupted();
-
-                // unbind the executor thread
-                runner = null;
             }
         }
 

--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/BenchmarkHandler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/BenchmarkHandler.java
@@ -395,6 +395,8 @@ class BenchmarkHandler {
 
         if (interrupts > 0) {
             out.print("(benchmark timed out, interrupted " + interrupts + " times) ");
+
+            // Roll over the workers
         }
 
         // Process the results: we get here after all worker threads have quit,
@@ -436,6 +438,8 @@ class BenchmarkHandler {
         // finished to capture the edge behaviors; or, on a failure path
         stopProfilers(benchmarkParams, params, result);
 
+        // clear thread interruption status when
+
         if (!errors.isEmpty()) {
             throw new BenchmarkException("Benchmark error during the run", errors);
         }
@@ -453,7 +457,7 @@ class BenchmarkHandler {
         // would dump the unused worker data for claiming.
         //
         // In face of interruptions, the barrier can either throw the interrupted
-        // exception if this thread caughts it and breaks the barrier,
+        // exception if this thread caught it and breaks the barrier,
         // or broken barrier exception if other threads were waiting on this
         // barrier. Bubble up both exceptions, and let the caller handle.
         workerDataBarrier.await();
@@ -550,6 +554,11 @@ class BenchmarkHandler {
 
                 throw new Exception(e); // wrapping Throwable
             } finally {
+                // Clear the interruption status for the thread after leaving the benchmark
+                // methods. If any InterruptedExceptions happened, they should have been handled
+                // by now. This prepares the runner thread for another iteration.
+                boolean unused = Thread.interrupted();
+
                 // unbind the executor thread
                 runner = null;
             }

--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/BenchmarkHandler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/BenchmarkHandler.java
@@ -395,8 +395,6 @@ class BenchmarkHandler {
 
         if (interrupts > 0) {
             out.print("(benchmark timed out, interrupted " + interrupts + " times) ");
-
-            // Roll over the workers
         }
 
         // Process the results: we get here after all worker threads have quit,
@@ -438,8 +436,6 @@ class BenchmarkHandler {
         // finished to capture the edge behaviors; or, on a failure path
         stopProfilers(benchmarkParams, params, result);
 
-        // clear thread interruption status when
-
         if (!errors.isEmpty()) {
             throw new BenchmarkException("Benchmark error during the run", errors);
         }
@@ -455,11 +451,6 @@ class BenchmarkHandler {
         // Wait for all threads to roll to this synchronization point.
         // If there is any thread without assignment, the barrier action
         // would dump the unused worker data for claiming.
-        //
-        // In face of interruptions, the barrier can either throw the interrupted
-        // exception if this thread caught it and breaks the barrier,
-        // or broken barrier exception if other threads were waiting on this
-        // barrier. Bubble up both exceptions, and let the caller handle.
         workerDataBarrier.await();
 
         if (wd == null) {
@@ -554,9 +545,9 @@ class BenchmarkHandler {
 
                 throw new Exception(e); // wrapping Throwable
             } finally {
-                // Clear the interruption status for the thread after leaving the benchmark
-                // methods. If any InterruptedExceptions happened, they should have been handled
-                // by now. This prepares the runner thread for another iteration.
+                // Clear the interruption status for the thread after leaving the benchmark method.
+                // If any InterruptedExceptions happened, they should have been handled by now.
+                // This prepares the runner thread for another iteration.
                 boolean unused = Thread.interrupted();
 
                 // unbind the executor thread


### PR DESCRIPTION
We need to handle the interrupts that are not captured by infra methods.

Additional testing: 
 - [x] Multiple iterations of GHA-like testing

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903498](https://bugs.openjdk.org/browse/CODETOOLS-7903498): JMH: Reset worker interrupt status after iteration (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/112/head:pull/112` \
`$ git checkout pull/112`

Update a local copy of the PR: \
`$ git checkout pull/112` \
`$ git pull https://git.openjdk.org/jmh.git pull/112/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 112`

View PR using the GUI difftool: \
`$ git pr show -t 112`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/112.diff">https://git.openjdk.org/jmh/pull/112.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/112#issuecomment-1597745141)