### PR TITLE
7903504: JMH: Fix new Sonar warnings

### DIFF
--- a/jmh-core-benchmarks/src/main/java/org/openjdk/jmh/validation/AffinitySupport.java
+++ b/jmh-core-benchmarks/src/main/java/org/openjdk/jmh/validation/AffinitySupport.java
@@ -87,7 +87,9 @@ public class AffinitySupport {
 
             // Need to rename the file to the proper name, otherwise JNA would not discover it
             File proper = new File(bootLibraryPath + '/' + System.mapLibraryName("jnidispatch"));
-            file.renameTo(proper);
+            if (!file.renameTo(proper)) {
+                throw new IllegalStateException("Failed to rename " + file + " to " + proper);
+            }
 
             return Arrays.asList(
                     "-Djna.nounpack=true",    // Should not unpack itself, but use predefined path

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfNormProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfNormProfilerTest.java
@@ -77,9 +77,9 @@ public class LinuxPerfNormProfilerTest {
         double cycles = ProfilerTestUtils.checkedGet(sr, "cycles", "cycles:u").getScore();
         double branches = ProfilerTestUtils.checkedGet(sr, "branches", "branches:u").getScore();
 
-        Assert.assertNotEquals(0, instructions);
-        Assert.assertNotEquals(0, cycles);
-        Assert.assertNotEquals(0, branches);
+        Assert.assertNotEquals(0D, instructions, 0D);
+        Assert.assertNotEquals(0D, cycles, 0D);
+        Assert.assertNotEquals(0D, branches, 0D);
 
         if (branches > instructions) {
             throw new IllegalStateException(String.format("Branches (%.2f) larger than instructions (%.3f)", branches, instructions));
@@ -88,8 +88,8 @@ public class LinuxPerfNormProfilerTest {
         double ipc = ProfilerTestUtils.checkedGet(sr, "IPC").getScore();
         double cpi = ProfilerTestUtils.checkedGet(sr, "CPI").getScore();
 
-        Assert.assertNotEquals(0, ipc);
-        Assert.assertNotEquals(0, cpi);
+        Assert.assertNotEquals(0D, ipc, 0D);
+        Assert.assertNotEquals(0D, cpi, 0D);
     }
 
 }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfProfilerTest.java
@@ -79,8 +79,8 @@ public class LinuxPerfProfilerTest {
         if (sr.containsKey("·ipc")) {
             double ipc = ProfilerTestUtils.checkedGet(sr, "·ipc").getScore();
             double cpi = ProfilerTestUtils.checkedGet(sr, "·cpi").getScore();
-            Assert.assertNotEquals(0, ipc);
-            Assert.assertNotEquals(0, cpi);
+            Assert.assertNotEquals(0D, ipc, 0D);
+            Assert.assertNotEquals(0D, cpi, 0D);
         }
 
         Assert.assertTrue(msg.contains("cycles"));

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/SafepointsProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/SafepointsProfilerTest.java
@@ -68,12 +68,12 @@ public class SafepointsProfilerTest {
         double pauseCount = ProfilerTestUtils.checkedGet(sr, "·safepoints.pause.count").getScore();
         double ttspCount = ProfilerTestUtils.checkedGet(sr, "·safepoints.ttsp.count").getScore();
 
-        Assert.assertNotEquals(pauseTotal, 0);
-        Assert.assertNotEquals(ttspTotal, 0);
+        Assert.assertNotEquals(0D, pauseTotal, 0D);
+        Assert.assertNotEquals(0D, ttspTotal, 0D);
 
-        Assert.assertNotEquals(pauseCount, 0);
-        Assert.assertNotEquals(ttspCount, 0);
-        Assert.assertEquals(ttspCount, pauseCount, 0);
+        Assert.assertNotEquals(0D, pauseCount, 0D);
+        Assert.assertNotEquals(0D, ttspCount, 0D);
+        Assert.assertEquals(ttspCount, pauseCount, 0D);
 
         if (interval < 3000) {
             throw new IllegalStateException("Interval time is too low. " +


### PR DESCRIPTION
SonarCloud reports a few warnings in new code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903504](https://bugs.openjdk.org/browse/CODETOOLS-7903504): JMH: Fix new Sonar warnings (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/113/head:pull/113` \
`$ git checkout pull/113`

Update a local copy of the PR: \
`$ git checkout pull/113` \
`$ git pull https://git.openjdk.org/jmh.git pull/113/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 113`

View PR using the GUI difftool: \
`$ git pr show -t 113`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/113.diff">https://git.openjdk.org/jmh/pull/113.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/113#issuecomment-1623592641)