### PR TITLE
7903511: JMH: Add score stability performance tests

### DIFF
--- a/jmh-core-benchmarks/src/main/java/org/openjdk/jmh/benchmarks/BurstStabilityBench.java
+++ b/jmh-core-benchmarks/src/main/java/org/openjdk/jmh/benchmarks/BurstStabilityBench.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jmh.benchmarks;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.SingleShotTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 50)
+@Measurement(iterations = 50)
+@Threads(1)
+@State(Scope.Thread)
+public class BurstStabilityBench {
+
+    @Param("10")
+    private int delay;
+
+    @Setup(Level.Iteration)
+    public void sleep() throws InterruptedException {
+        TimeUnit.MILLISECONDS.sleep(delay);
+    }
+
+    @Benchmark
+    public void test() {
+        Blackhole.consumeCPU(1_000_000);
+    }
+
+}

--- a/jmh-core-benchmarks/src/main/java/org/openjdk/jmh/benchmarks/LongStabilityBench.java
+++ b/jmh-core-benchmarks/src/main/java/org/openjdk/jmh/benchmarks/LongStabilityBench.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,21 +29,11 @@ import org.openjdk.jmh.infra.Blackhole;
 
 import java.util.concurrent.TimeUnit;
 
-@BenchmarkMode(Mode.SingleShotTime)
-@OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Warmup(iterations = 50)
-@Measurement(iterations = 50)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
 @Threads(1)
 @State(Scope.Thread)
-public class ScoreStabilityBench {
-
-    @Param("10")
-    private int delay;
-
-    @Setup(Level.Iteration)
-    public void sleep() throws InterruptedException {
-        TimeUnit.MILLISECONDS.sleep(delay);
-    }
+public class LongStabilityBench {
 
     @Benchmark
     public void test() {

--- a/jmh-core-benchmarks/src/main/java/org/openjdk/jmh/validation/Main.java
+++ b/jmh-core-benchmarks/src/main/java/org/openjdk/jmh/validation/Main.java
@@ -158,8 +158,26 @@ public class Main {
                 case timing:
                     new TimingMeasurementsTest().runWith(pw, opts);
                     break;
-                case stability:
-                    new ScoreStabilityTest().runWith(pw, opts);
+                case long_stability:
+                    switch (mode) {
+                        case flash:
+                            new LongStabilityTest(3).runWith(pw, opts);
+                            break;
+                        case quick:
+                            new LongStabilityTest(5).runWith(pw, opts);
+                            break;
+                        case normal:
+                            new LongStabilityTest(18).runWith(pw, opts);
+                            break;
+                        case longer:
+                            new LongStabilityTest(60).runWith(pw, opts);
+                            break;
+                        default:
+                            throw new IllegalStateException();
+                    }
+                    break;
+                case burst_stability:
+                    new BurstStabilityTest().runWith(pw, opts);
                     break;
                 case compiler_hints:
                     new CompilerHintsTest().runWith(pw, opts);
@@ -242,7 +260,8 @@ public class Main {
         timing,
         compiler_hints,
         thermal,
-        stability,
+        long_stability,
+        burst_stability,
         thread_scale,
         helpers,
         blackhole_cpu,

--- a/jmh-core-benchmarks/src/main/java/org/openjdk/jmh/validation/tests/BurstStabilityTest.java
+++ b/jmh-core-benchmarks/src/main/java/org/openjdk/jmh/validation/tests/BurstStabilityTest.java
@@ -25,7 +25,7 @@
 package org.openjdk.jmh.validation.tests;
 
 import org.openjdk.jmh.annotations.Mode;
-import org.openjdk.jmh.benchmarks.ScoreStabilityBench;
+import org.openjdk.jmh.benchmarks.BurstStabilityBench;
 import org.openjdk.jmh.results.Result;
 import org.openjdk.jmh.results.RunResult;
 import org.openjdk.jmh.runner.Runner;
@@ -37,10 +37,10 @@ import org.openjdk.jmh.validation.ValidationTest;
 
 import java.io.PrintWriter;
 
-public class ScoreStabilityTest extends ValidationTest {
+public class BurstStabilityTest extends ValidationTest {
     @Override
     public void runWith(PrintWriter pw, Options parent) throws RunnerException {
-        pw.println("--------- SCORE STABILITY TEST");
+        pw.println("--------- BURST STABILITY TEST");
         pw.println();
 
         org.openjdk.jmh.util.Utils.reflow(pw,
@@ -74,7 +74,7 @@ public class ScoreStabilityTest extends ValidationTest {
                 Options opts = new OptionsBuilder()
                         .parent(parent)
                         .mode(m)
-                        .include(ScoreStabilityBench.class.getCanonicalName())
+                        .include(BurstStabilityBench.class.getCanonicalName())
                         .verbosity(VerboseMode.SILENT)
                         .param("delay", String.valueOf(delay))
                         .build();

--- a/jmh-core-benchmarks/src/main/java/org/openjdk/jmh/validation/tests/LongStabilityTest.java
+++ b/jmh-core-benchmarks/src/main/java/org/openjdk/jmh/validation/tests/LongStabilityTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jmh.validation.tests;
+
+import org.openjdk.jmh.benchmarks.LongStabilityBench;
+import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+import org.openjdk.jmh.runner.options.VerboseMode;
+import org.openjdk.jmh.validation.ValidationTest;
+
+import java.io.PrintWriter;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class LongStabilityTest extends ValidationTest {
+    private final int tries;
+
+    public LongStabilityTest(int tries) {
+        this.tries = tries;
+    }
+
+    @Override
+    public void runWith(PrintWriter pw, Options parent) throws RunnerException {
+        pw.println("--------- LONG STABILITY TEST");
+        pw.println();
+
+        org.openjdk.jmh.util.Utils.reflow(pw,
+                "This test verifies the performance for a single test by running it several times with some " +
+                        "delays between the runs. The performance should be the same across all runs. " +
+                        "If there is a significant difference between the runs, this is usually " +
+                        "indicative of noisy environment, e.g. a busy virtualized node, or background processes " +
+                        "interfering with the run, making the benchmarks unreliable.",
+                80, 2);
+        pw.println();
+
+        for (int t = 0; t < tries; t++) {
+            int ms = (t == 0) ? 0 : ThreadLocalRandom.current().nextInt(5_000, 30_000);
+
+            pw.printf("  Sleeping for %6d ms...", ms);
+            pw.flush();
+            try {
+                Thread.sleep(ms);
+            } catch (InterruptedException e) {
+                // Do nothing.
+            }
+
+            pw.print("  Run: ");
+            pw.flush();
+
+            Options opts = new OptionsBuilder()
+                    .parent(parent)
+                    .include(LongStabilityBench.class.getCanonicalName())
+                    .warmupIterations(5)
+                    .warmupTime(TimeValue.seconds(1))
+                    .measurementIterations(5)
+                    .measurementTime(TimeValue.seconds(1))
+                    .forks(1)
+                    .verbosity(VerboseMode.SILENT)
+                    .build();
+
+            RunResult result = new Runner(opts).runSingle();
+            Result r = result.getPrimaryResult();
+            pw.printf(" %16s", String.format("%.2f \u00b1 %.2f %s%n", r.getScore(), r.getScoreError(), r.getScoreUnit()));
+            pw.flush();
+        }
+    }
+}


### PR DESCRIPTION
For machines in the clouds, it is important to quantify whether their long-term performance deviates. This is important for any benchmarking to make sense.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903511](https://bugs.openjdk.org/browse/CODETOOLS-7903511): JMH: Add score stability performance tests (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/116/head:pull/116` \
`$ git checkout pull/116`

Update a local copy of the PR: \
`$ git checkout pull/116` \
`$ git pull https://git.openjdk.org/jmh.git pull/116/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 116`

View PR using the GUI difftool: \
`$ git pr show -t 116`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/116.diff">https://git.openjdk.org/jmh/pull/116.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/116#issuecomment-1652241425)