### PR TITLE
7903554: JMH: add Threads.HALF_MAX constant

### DIFF
--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/HalfMaxThreadCountTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/HalfMaxThreadCountTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/HalfMaxThreadCountTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/HalfMaxThreadCountTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jmh.it.threads;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.it.Fixtures;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.All)
+@State(Scope.Benchmark)
+public class HalfMaxThreadCountTest {
+
+    private final Set<Thread> threads = Collections.synchronizedSet(new HashSet<>());
+
+    @TearDown(Level.Iteration)
+    public void tearDown() {
+        if (Fixtures.expectStableThreads()) {
+            Assert.assertEquals(threads.size(), Runtime.getRuntime().availableProcessors() / 2);
+        } else {
+            Assert.assertTrue(threads.size() >= Runtime.getRuntime().availableProcessors() / 2);
+        }
+    }
+
+    @Benchmark
+    @Measurement(iterations = 1, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+    @Warmup(iterations = 0)
+    @Fork(1)
+    @Threads(Threads.HALF_MAX)
+    public void test1() {
+        threads.add(Thread.currentThread());
+        Fixtures.work();
+    }
+
+    @Benchmark
+    @Measurement(iterations = 1, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+    @Warmup(iterations = 0)
+    @Fork(1)
+    public void test2() {
+        threads.add(Thread.currentThread());
+        Fixtures.work();
+    }
+
+    @Test
+    public void invokeAPI_1() throws RunnerException {
+        for (int c = 0; c < Fixtures.repetitionCount(); c++) {
+            Options opt = new OptionsBuilder()
+                    .include(Fixtures.getTestMask(this.getClass()) + ".*test1")
+                    .shouldFailOnError(true)
+                    .build();
+            new Runner(opt).run();
+        }
+    }
+
+    @Test
+    public void invokeAPI_2() throws RunnerException {
+        for (int c = 0; c < Fixtures.repetitionCount(); c++) {
+            Options opt = new OptionsBuilder()
+                    .include(Fixtures.getTestMask(this.getClass()) + ".*test2")
+                    .shouldFailOnError(true)
+                    .threads(Threads.HALF_MAX)
+                    .build();
+            new Runner(opt).run();
+        }
+    }
+}

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/HalfMaxThreadCountTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/threads/HalfMaxThreadCountTest.java
@@ -47,9 +47,9 @@ public class HalfMaxThreadCountTest {
     @TearDown(Level.Iteration)
     public void tearDown() {
         if (Fixtures.expectStableThreads()) {
-            Assert.assertEquals(threads.size(), Runtime.getRuntime().availableProcessors() / 2);
+            Assert.assertEquals(threads.size(), (1 + Runtime.getRuntime().availableProcessors()) / 2);
         } else {
-            Assert.assertTrue(threads.size() >= Runtime.getRuntime().availableProcessors() / 2);
+            Assert.assertTrue(threads.size() >= (1 + Runtime.getRuntime().availableProcessors()) / 2);
         }
     }
 

--- a/jmh-core/src/main/java/org/openjdk/jmh/annotations/Threads.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/annotations/Threads.java
@@ -50,6 +50,12 @@ public @interface Threads {
     int MAX = -1;
 
     /**
+     * The magic value for MAX/2 threads.
+     * This means Runtime.getRuntime().availableProcessors()/2 threads.
+     */
+    int HALF_MAX = -2;
+
+    /**
      * @return Number of threads; use Threads.MAX to run with all available threads.
      */
     int value();

--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/Runner.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/Runner.java
@@ -390,15 +390,18 @@ public class Runner extends BaseRunner {
                 benchmark.getThreads().orElse(
                         Defaults.THREADS));
 
-        if (threads == Threads.MAX) {
+        if (threads == Threads.MAX || threads == Threads.HALF_MAX) {
             if (cpuCount == 0) {
                 out.print("# Detecting actual CPU count: ");
                 cpuCount = Utils.figureOutHotCPUs();
                 out.println(cpuCount + " detected");
             }
-            threads = cpuCount;
+            if (threads == Threads.HALF_MAX) {
+                threads = Math.max(1, cpuCount / 2);
+            } else {
+                threads = cpuCount;
+            }
         }
-
         threads = Utils.roundUp(threads, Utils.sum(threadGroups));
 
         boolean synchIterations = (benchmark.getMode() != Mode.SingleShotTime) &&

--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/Runner.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/Runner.java
@@ -397,7 +397,7 @@ public class Runner extends BaseRunner {
                 out.println(cpuCount + " detected");
             }
             if (threads == Threads.HALF_MAX) {
-                threads = Math.max(1, cpuCount / 2);
+                threads = (cpuCount + 1) / 2;
             } else {
                 threads = cpuCount;
             }

--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/options/CommandLineOptions.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/options/CommandLineOptions.java
@@ -131,7 +131,7 @@ public class CommandLineOptions implements Options {
                 .withRequiredArg().ofType(TimeValue.class).describedAs("time");
 
         OptionSpec<Integer> optThreads = parser.accepts("t", "Number of worker threads to run with. 'max' means the " +
-                "maximum number of hardware threads available on the machine, figured out by JMH itself. " +
+                "maximum number of hardware threads available on the machine, figured out by JMH itself. 'half_max' means 'max/2'" +
                 "(default: " + Defaults.THREADS + ")")
                 .withRequiredArg().withValuesConvertedBy(ThreadsValueConverter.INSTANCE).describedAs("int");
 

--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/options/CommandLineOptions.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/options/CommandLineOptions.java
@@ -131,7 +131,7 @@ public class CommandLineOptions implements Options {
                 .withRequiredArg().ofType(TimeValue.class).describedAs("time");
 
         OptionSpec<Integer> optThreads = parser.accepts("t", "Number of worker threads to run with. 'max' means the " +
-                "maximum number of hardware threads available on the machine, figured out by JMH itself. 'half_max' means 'max/2'" +
+                "maximum number of hardware threads available on the machine, figured out by JMH itself. 'halfmax' means 'max/2'" +
                 "(default: " + Defaults.THREADS + ")")
                 .withRequiredArg().withValuesConvertedBy(ThreadsValueConverter.INSTANCE).describedAs("int");
 

--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/options/OptionsBuilder.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/options/OptionsBuilder.java
@@ -272,7 +272,7 @@ public class OptionsBuilder implements Options, ChainedOptionsBuilder {
 
     @Override
     public ChainedOptionsBuilder threads(int count) {
-        if (count != Threads.MAX) {
+        if (count != Threads.MAX && count != Threads.HALF_MAX) {
             checkGreaterOrEqual(count, 1, "Threads");
         }
         this.threads = Optional.of(count);

--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/options/ThreadsValueConverter.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/options/ThreadsValueConverter.java
@@ -37,7 +37,7 @@ public class ThreadsValueConverter implements ValueConverter<Integer> {
     public Integer convert(String value) {
         if (value.equalsIgnoreCase("max")) {
             return Threads.MAX;
-        } else if (value.equalsIgnoreCase("half_max")) {
+        } else if (value.equalsIgnoreCase("halfmax")) {
             return Threads.HALF_MAX;
         }
         return IntegerValueConverter.POSITIVE.convert(value);

--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/options/ThreadsValueConverter.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/options/ThreadsValueConverter.java
@@ -37,6 +37,8 @@ public class ThreadsValueConverter implements ValueConverter<Integer> {
     public Integer convert(String value) {
         if (value.equalsIgnoreCase("max")) {
             return Threads.MAX;
+        } else if (value.equalsIgnoreCase("half_max")) {
+            return Threads.HALF_MAX;
         }
         return IntegerValueConverter.POSITIVE.convert(value);
     }

--- a/jmh-core/src/test/java/org/openjdk/jmh/runner/options/TestOptions.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/runner/options/TestOptions.java
@@ -240,7 +240,7 @@ public class TestOptions {
 
     @Test
     public void testThreads_HalfMax() throws Exception {
-        CommandLineOptions cmdLine = new CommandLineOptions("-t", "half_max");
+        CommandLineOptions cmdLine = new CommandLineOptions("-t", "halfmax");
         Options builder = new OptionsBuilder().threads(Threads.HALF_MAX).build();
         Assert.assertEquals(builder.getThreads(), cmdLine.getThreads());
     }

--- a/jmh-core/src/test/java/org/openjdk/jmh/runner/options/TestOptions.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/runner/options/TestOptions.java
@@ -239,6 +239,13 @@ public class TestOptions {
     }
 
     @Test
+    public void testThreads_HalfMax() throws Exception {
+        CommandLineOptions cmdLine = new CommandLineOptions("-t", "half_max");
+        Options builder = new OptionsBuilder().threads(Threads.HALF_MAX).build();
+        Assert.assertEquals(builder.getThreads(), cmdLine.getThreads());
+    }
+
+    @Test
     public void testThreads_Zero() {
         try {
             new CommandLineOptions("-t", "0");


### PR DESCRIPTION
add Threads.HALF_MAX constant equals to "Runtime.getRuntime().availableProcessors()/2"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903554](https://bugs.openjdk.org/browse/CODETOOLS-7903554): JMH: add Threads.HALF_MAX constant (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/118/head:pull/118` \
`$ git checkout pull/118`

Update a local copy of the PR: \
`$ git checkout pull/118` \
`$ git pull https://git.openjdk.org/jmh.git pull/118/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 118`

View PR using the GUI difftool: \
`$ git pr show -t 118`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/118.diff">https://git.openjdk.org/jmh/pull/118.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/118#issuecomment-1711034596)