### PR TITLE
CODETOOLS-7903559: JMH: Update testing pipelines for JDK 21 release

### DIFF
--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java: [8, 11, 17, 21, 22-ea]
+        java: [8, 11, 17, 21]
         os: [ubuntu-22.04, windows-2022, macos-11]
         profile: [default, reflection, asm, executor-virtual, executor-fjp, executor-custom]
       fail-fast: false
@@ -70,4 +70,4 @@ jobs:
 
     - name: Run build with tests (Virtual Executor)
       run: mvn clean install -P ${{ matrix.profile }} -B --file pom.xml
-      if: (runner.os == 'Linux') && (matrix.java == '21-ea') && (matrix.profile == 'executor-virtual')
+      if: (runner.os == 'Linux') && (matrix.java == '21') && (matrix.profile == 'executor-virtual')

--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java: [8, 11, 17, 20, 21-ea]
+        java: [8, 11, 17, 21, 22-ea]
         os: [ubuntu-22.04, windows-2022, macos-11]
         profile: [default, reflection, asm, executor-virtual, executor-fjp, executor-custom]
       fail-fast: false

--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v3
       with:
-        distribution: temurin
+        distribution: corretto
         java-version: ${{ matrix.java }}
         cache: maven
         check-latest: true


### PR DESCRIPTION
JDK 21 is released, we should start testing with it, and also with JDK 22-ea.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903559](https://bugs.openjdk.org/browse/CODETOOLS-7903559): JMH: Update testing pipelines for JDK 21 release (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/120/head:pull/120` \
`$ git checkout pull/120`

Update a local copy of the PR: \
`$ git checkout pull/120` \
`$ git pull https://git.openjdk.org/jmh.git pull/120/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 120`

View PR using the GUI difftool: \
`$ git pr show -t 120`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/120.diff">https://git.openjdk.org/jmh/pull/120.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/120#issuecomment-1729424544)