### PR TITLE
CODETOOLS-7903560: JMH: async profiler reports only the last fork result

### DIFF
--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -38,6 +38,11 @@ jobs:
         echo -1 | sudo tee /proc/sys/kernel/perf_event_paranoid
         perf stat echo 1
       if: (runner.os == 'Linux')
+    - name: Set up async-profiler (Linux)
+      run: |
+        curl -L https://github.com/async-profiler/async-profiler/releases/download/v3.0/async-profiler-3.0-linux-x64.tar.gz | tar xzf -
+        echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/async-profiler-3.0-linux-x64/lib/" >> $GITHUB_ENV
+      if: (runner.os == 'Linux')
 
     - name: Build with tests (Default)
       run: mvn clean install -B --file pom.xml

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/AsyncProfilerForkTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/AsyncProfilerForkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,7 +68,7 @@ public class AsyncProfilerForkTest extends AbstractHotspotProfilerTest {
         Map<String, Result> sr = run("text");
 
         Collection<? extends File> files = ((AsyncProfiler.FileResult) sr.get("async-summary")).getFiles();
-        Assert.assertEquals(2, files.size());
+        Assert.assertEquals(3, files.size());
         for (File file : files) {
             Assert.assertTrue(file.length() > 10);
         }
@@ -82,7 +82,7 @@ public class AsyncProfilerForkTest extends AbstractHotspotProfilerTest {
         Map<String, Result> sr = run("collapsed");
 
         Collection<? extends File> files = ((AsyncProfiler.FileResult) sr.get("async-collapsed")).getFiles();
-        Assert.assertEquals(2, files.size());
+        Assert.assertEquals(3, files.size());
         for (File file : files) {
             Assert.assertTrue(file.length() > 10);
         }
@@ -93,7 +93,7 @@ public class AsyncProfilerForkTest extends AbstractHotspotProfilerTest {
         Map<String, Result> sr = run("flamegraph");
 
         Collection<? extends File> files = ((AsyncProfiler.FileResult) sr.get("async-flamegraph")).getFiles();
-        Assert.assertEquals(4, files.size());
+        Assert.assertEquals(5, files.size());
         for (File file : files) {
             Assert.assertTrue(file.length() > 10);
         }
@@ -103,7 +103,7 @@ public class AsyncProfilerForkTest extends AbstractHotspotProfilerTest {
     public void jfr() throws RunnerException {
         Map<String, Result> sr = run("jfr");
         Collection<? extends File> files = ((AsyncProfiler.FileResult) sr.get("async-jfr")).getFiles();
-        Assert.assertEquals(2, files.size());
+        Assert.assertEquals(3, files.size());
         for (File file : files) {
             Assert.assertTrue(file.length() > 10);
         }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/AsyncProfilerForkTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/AsyncProfilerForkTest.java
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2014, 2015, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
 package org.openjdk.jmh.it.profilers;
 
 import org.junit.Assert;

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/AsyncProfilerForkTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/AsyncProfilerForkTest.java
@@ -1,0 +1,87 @@
+package org.openjdk.jmh.it.profilers;
+
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.it.Fixtures;
+import org.openjdk.jmh.profile.AsyncProfiler;
+import org.openjdk.jmh.profile.ProfilerException;
+import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.results.TextResult;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.Map;
+
+@Fork(2)
+public class AsyncProfilerForkTest extends AbstractHotspotProfilerTest {
+
+    private Map<String, Result> run(String mode) throws RunnerException {
+        try {
+            new AsyncProfiler("");
+        } catch (ProfilerException e) {
+            Assume.assumeNoException("Could not load async-profiler", e);
+        }
+
+        Options opts = new OptionsBuilder()
+                .include(Fixtures.getTestMask(this.getClass()))
+                .addProfiler(AsyncProfiler.class, "output=" + mode)
+                .build();
+
+        RunResult rr = new Runner(opts).runSingle();
+
+        return rr.getSecondaryResults();
+    }
+
+    @Test
+    public void text() throws RunnerException {
+        Map<String, Result> sr = run("text");
+
+        Collection<? extends File> files = ((AsyncProfiler.FileResult) sr.get("async-summary")).getFiles();
+        Assert.assertEquals(2, files.size());
+        for (File file : files) {
+            Assert.assertTrue(file.length() > 10);
+        }
+
+        TextResult text = (TextResult) sr.get("async-text");
+        Assert.assertTrue(text.extendedInfo().length() > 10);
+    }
+
+    @Test
+    public void collapsed() throws RunnerException {
+        Map<String, Result> sr = run("collapsed");
+
+        Collection<? extends File> files = ((AsyncProfiler.FileResult) sr.get("async-collapsed")).getFiles();
+        Assert.assertEquals(2, files.size());
+        for (File file : files) {
+            Assert.assertTrue(file.length() > 10);
+        }
+    }
+
+    @Test
+    public void flamegraph() throws RunnerException {
+        Map<String, Result> sr = run("flamegraph");
+
+        Collection<? extends File> files = ((AsyncProfiler.FileResult) sr.get("async-flamegraph")).getFiles();
+        Assert.assertEquals(4, files.size());
+        for (File file : files) {
+            Assert.assertTrue(file.length() > 10);
+        }
+    }
+
+    @Test
+    public void jfr() throws RunnerException {
+        Map<String, Result> sr = run("jfr");
+        Collection<? extends File> files = ((AsyncProfiler.FileResult) sr.get("async-jfr")).getFiles();
+        Assert.assertEquals(2, files.size());
+        for (File file : files) {
+            Assert.assertTrue(file.length() > 10);
+        }
+    }
+}

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/AsyncProfilerForkTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/AsyncProfilerForkTest.java
@@ -93,7 +93,7 @@ public class AsyncProfilerForkTest extends AbstractHotspotProfilerTest {
         Map<String, Result> sr = run("flamegraph");
 
         Collection<? extends File> files = ((AsyncProfiler.FileResult) sr.get("async-flamegraph")).getFiles();
-        Assert.assertEquals(5, files.size());
+        Assert.assertEquals(6, files.size());
         for (File file : files) {
             Assert.assertTrue(file.length() > 10);
         }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/AsyncProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/AsyncProfilerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/AsyncProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/AsyncProfilerTest.java
@@ -1,0 +1,82 @@
+package org.openjdk.jmh.it.profilers;
+
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+import org.openjdk.jmh.it.Fixtures;
+import org.openjdk.jmh.profile.AsyncProfiler;
+import org.openjdk.jmh.profile.ProfilerException;
+import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.results.TextResult;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.Map;
+
+public class AsyncProfilerTest extends AbstractHotspotProfilerTest {
+
+    private Map<String, Result> run(String mode) throws RunnerException {
+        try {
+            new AsyncProfiler("");
+        } catch (ProfilerException e) {
+            Assume.assumeNoException("Could not load async-profiler", e);
+        }
+
+        Options opts = new OptionsBuilder()
+                .include(Fixtures.getTestMask(this.getClass()))
+                .addProfiler(AsyncProfiler.class, "output=" + mode)
+                .build();
+
+        RunResult rr = new Runner(opts).runSingle();
+
+        return rr.getSecondaryResults();
+    }
+
+    @Test
+    public void text() throws RunnerException {
+        Map<String, Result> sr = run("text");
+
+        Collection<? extends File> files = ((AsyncProfiler.FileResult) sr.get("async-summary")).getFiles();
+        Assert.assertEquals(1, files.size());
+        File single = files.iterator().next();
+        Assert.assertTrue(single.length() > 10);
+
+        TextResult text = (TextResult) sr.get("async-text");
+        Assert.assertTrue(text.extendedInfo().length() > 10);
+    }
+
+    @Test
+    public void collapsed() throws RunnerException {
+        Map<String, Result> sr = run("collapsed");
+
+        Collection<? extends File> files = ((AsyncProfiler.FileResult) sr.get("async-collapsed")).getFiles();
+        Assert.assertEquals(1, files.size());
+        File single = files.iterator().next();
+        Assert.assertTrue(single.length() > 10);
+    }
+
+    @Test
+    public void flamegraph() throws RunnerException {
+        Map<String, Result> sr = run("flamegraph");
+
+        Collection<? extends File> files = ((AsyncProfiler.FileResult) sr.get("async-flamegraph")).getFiles();
+        Assert.assertEquals(2, files.size());
+        for (File file : files) {
+            Assert.assertTrue(file.length() > 10);
+        }
+    }
+
+    @Test
+    public void jfr() throws RunnerException {
+        Map<String, Result> sr = run("jfr");
+        Collection<? extends File> files = ((AsyncProfiler.FileResult) sr.get("async-jfr")).getFiles();
+        Assert.assertEquals(1, files.size());
+        File single = files.iterator().next();
+        Assert.assertTrue(single.length() > 10);
+    }
+}

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/AsyncProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/AsyncProfilerTest.java
@@ -66,7 +66,7 @@ public class AsyncProfilerTest extends AbstractHotspotProfilerTest {
         Map<String, Result> sr = run("text");
 
         Collection<? extends File> files = ((AsyncProfiler.FileResult) sr.get("async-summary")).getFiles();
-        Assert.assertEquals(1, files.size());
+        Assert.assertEquals(2, files.size());
         File single = files.iterator().next();
         Assert.assertTrue(single.length() > 10);
 
@@ -79,7 +79,7 @@ public class AsyncProfilerTest extends AbstractHotspotProfilerTest {
         Map<String, Result> sr = run("collapsed");
 
         Collection<? extends File> files = ((AsyncProfiler.FileResult) sr.get("async-collapsed")).getFiles();
-        Assert.assertEquals(1, files.size());
+        Assert.assertEquals(2, files.size());
         File single = files.iterator().next();
         Assert.assertTrue(single.length() > 10);
     }
@@ -89,7 +89,7 @@ public class AsyncProfilerTest extends AbstractHotspotProfilerTest {
         Map<String, Result> sr = run("flamegraph");
 
         Collection<? extends File> files = ((AsyncProfiler.FileResult) sr.get("async-flamegraph")).getFiles();
-        Assert.assertEquals(2, files.size());
+        Assert.assertEquals(4, files.size());
         for (File file : files) {
             Assert.assertTrue(file.length() > 10);
         }
@@ -99,7 +99,7 @@ public class AsyncProfilerTest extends AbstractHotspotProfilerTest {
     public void jfr() throws RunnerException {
         Map<String, Result> sr = run("jfr");
         Collection<? extends File> files = ((AsyncProfiler.FileResult) sr.get("async-jfr")).getFiles();
-        Assert.assertEquals(1, files.size());
+        Assert.assertEquals(2, files.size());
         File single = files.iterator().next();
         Assert.assertTrue(single.length() > 10);
     }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/AsyncProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/AsyncProfilerTest.java
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2014, 2015, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
 package org.openjdk.jmh.it.profilers;
 
 import org.junit.Assert;

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/AsyncProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/AsyncProfiler.java
@@ -54,6 +54,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 
 /**
@@ -556,7 +557,7 @@ public final class AsyncProfiler implements ExternalProfiler, InternalProfiler {
             FileResult result = (FileResult) br.getSecondaryResults().remove(label);
             if (result != null) {
                 moved.add(new FileResult(result.getLabel(), result.files.stream()
-                        .map(f -> addDiscriminator(f, pid))
+                        .flatMap(f -> Stream.of(f, addDiscriminator(f, pid)))
                         .collect(Collectors.toList())));
             }
         }

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/AsyncProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/AsyncProfiler.java
@@ -42,6 +42,9 @@ import org.openjdk.jmh.util.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -564,7 +567,11 @@ public final class AsyncProfiler implements ExternalProfiler, InternalProfiler {
         String originalName = original.getPath();
         int extIndex = originalName.lastIndexOf('.');
         File newFile = new File(originalName.substring(0, extIndex) + "." + pid + originalName.substring(extIndex));
-        original.renameTo(newFile);
+        try {
+            Files.copy(original.toPath(), newFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
         return newFile;
     }
 

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/AsyncProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/AsyncProfiler.java
@@ -30,18 +30,27 @@ import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
 import org.openjdk.jmh.infra.BenchmarkParams;
 import org.openjdk.jmh.infra.IterationParams;
+import org.openjdk.jmh.results.AggregationPolicy;
+import org.openjdk.jmh.results.Aggregator;
 import org.openjdk.jmh.results.BenchmarkResult;
 import org.openjdk.jmh.results.IterationResult;
 import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.results.ResultRole;
 import org.openjdk.jmh.results.TextResult;
 import org.openjdk.jmh.runner.IterationType;
 import org.openjdk.jmh.util.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 
 /**
@@ -68,7 +77,6 @@ public final class AsyncProfiler implements ExternalProfiler, InternalProfiler {
     private boolean warmupStarted;
     private boolean measurementStarted;
     private int measurementIterationCount;
-    private final LinkedHashSet<File> generated = new LinkedHashSet<>();
 
     public AsyncProfiler(String initLine) throws ProfilerException {
         OptionParser parser = new OptionParser();
@@ -331,7 +339,7 @@ public final class AsyncProfiler implements ExternalProfiler, InternalProfiler {
 
     private void start() {
         if (output.contains(OutputType.jfr)) {
-            execute("start," + profilerConfig + ",file=" + outputFile("jfr-%s.jfr").getAbsolutePath());
+            execute("start," + profilerConfig + ",file=" + jfrOutputFile().getAbsolutePath());
         } else {
             execute("start," + profilerConfig);
         }
@@ -343,7 +351,7 @@ public final class AsyncProfiler implements ExternalProfiler, InternalProfiler {
         if (iterationParams.getType() == IterationType.MEASUREMENT) {
             measurementIterationCount += 1;
             if (measurementIterationCount == iterationParams.getCount()) {
-                return Collections.singletonList(stopAndDump());
+                return stopAndDump();
             }
         }
 
@@ -360,11 +368,10 @@ public final class AsyncProfiler implements ExternalProfiler, InternalProfiler {
         }
     }
 
-    private TextResult stopAndDump() {
+    private List<Result<?>> stopAndDump() {
         execute("stop");
 
-        StringWriter sw = new StringWriter();
-        PrintWriter pw = new PrintWriter(sw);
+        List<Result<?>> results = new ArrayList<>();
         for (OutputType outputType : output) {
             switch (outputType) {
                 case text:
@@ -375,54 +382,60 @@ public final class AsyncProfiler implements ExternalProfiler, InternalProfiler {
                         dump(out, "flat=" + flat + ",traces=" + traces);
                     }
                     try {
+                        StringBuilder text = new StringBuilder();
                         for (String line : FileUtils.readAllLines(out)) {
-                            pw.println(line);
+                            text.append(line).append(System.lineSeparator());
                         }
+                        results.add(new TextResult(text.toString(), "async-text"));
                     } catch (IOException e) {
                         throw new RuntimeException(e);
                     }
+                    results.add(new FileResult("async-summary", Collections.singletonList(out)));
                     break;
                 case collapsed:
-                    dump(outputFile("collapsed-%s.csv"), "collapsed");
+                    File collapsedFile = outputFile("collapsed-%s.csv");
+                    dump(collapsedFile, "collapsed");
+                    results.add(new FileResult("async-collapsed", Collections.singletonList(collapsedFile)));
                     break;
                 case flamegraph:
                     // The last SVG-enabled version is 1.x
                     String ext = isVersion1x ? "svg" : "html";
                     if (direction == Direction.both || direction == Direction.forward) {
-                        dump(outputFile("flame-%s-forward." + ext), "flamegraph");
+                        File flameForward = outputFile("flame-%s-forward." + ext);
+                        dump(flameForward, "flamegraph");
+                        results.add(new FileResult("async-flamegraph", Collections.singletonList(flameForward)));
                     }
                     if (direction == Direction.both || direction == Direction.reverse) {
-                        dump(outputFile("flame-%s-reverse." + ext), "flamegraph,reverse");
+                        File flameReverse = outputFile("flame-%s-reverse." + ext);
+                        dump(flameReverse, "flamegraph,reverse");
+                        results.add(new FileResult("async-flamegraph", Collections.singletonList(flameReverse)));
                     }
                     break;
                 case tree:
-                    dump(outputFile("tree-%s.html"), "tree");
+                    File treeFile = outputFile("tree-%s.html");
+                    dump(treeFile, "tree");
+                    results.add(new FileResult("async-tree", Collections.singletonList(treeFile)));
                     break;
                 case jfr:
                     // JFR is already dumped into file by async-profiler.
+                    results.add(new FileResult("async-jfr", Collections.singletonList(jfrOutputFile())));
                     break;
             }
         }
 
-        pw.println("Async profiler results:");
-        for (File file : generated) {
-            pw.print("  ");
-            pw.println(file.getPath());
-        }
-        pw.flush();
-        pw.close();
-
-        return new TextResult(sw.toString(), "async");
+        return results;
     }
 
     private void dump(File target, String command) {
         execute(command + "," + profilerConfig + ",file=" + target.getAbsolutePath());
     }
 
+    private File jfrOutputFile() {
+        return outputFile("jfr-%s.jfr");
+    }
+
     private File outputFile(String fileNameFormat) {
-        File output = new File(trialOutDir, String.format(fileNameFormat, outputFilePrefix));
-        generated.add(output);
-        return output;
+        return new File(trialOutDir, String.format(fileNameFormat, outputFilePrefix));
     }
 
     private String execute(String command) {
@@ -535,7 +548,24 @@ public final class AsyncProfiler implements ExternalProfiler, InternalProfiler {
 
     @Override
     public Collection<? extends Result> afterTrial(BenchmarkResult br, long pid, File stdOut, File stdErr) {
-        return Collections.emptyList();
+        List<FileResult> moved = new ArrayList<>();
+        for (String label : Arrays.asList("async-summary", "async-collapsed", "async-flamegraph", "async-tree", "async-jfr")) {
+            FileResult result = (FileResult) br.getSecondaryResults().remove(label);
+            if (result != null) {
+                moved.add(new FileResult(result.getLabel(), result.files.stream()
+                        .map(f -> addDiscriminator(f, pid))
+                        .collect(Collectors.toList())));
+            }
+        }
+        return moved;
+    }
+
+    private File addDiscriminator(File original, long pid) {
+        String originalName = original.getPath();
+        int extIndex = originalName.lastIndexOf('.');
+        File newFile = new File(originalName.substring(0, extIndex) + "." + pid + originalName.substring(extIndex));
+        original.renameTo(newFile);
+        return newFile;
     }
 
     @Override
@@ -621,5 +651,52 @@ public final class AsyncProfiler implements ExternalProfiler, InternalProfiler {
         private native long getSamples();
 
         private native void filterThread0(Thread thread, boolean enable);
+    }
+
+    public final static class FileResult extends Result<FileResult> {
+        private final List<File> files;
+
+        FileResult(String label, List<File> files) {
+            super(ResultRole.SECONDARY, label, of(Double.NaN), "---", AggregationPolicy.AVG);
+            this.files = files;
+        }
+
+        @Override
+        protected Aggregator<FileResult> getThreadAggregator() {
+            return new FileAggregator();
+        }
+
+        @Override
+        protected Aggregator<FileResult> getIterationAggregator() {
+            return new FileAggregator();
+        }
+
+        public Collection<? extends File> getFiles() {
+            return files;
+        }
+
+        @Override
+        public String toString() {
+            return "Files: " + files;
+        }
+
+        @Override
+        public String extendedInfo() {
+            StringBuilder builder = new StringBuilder("Async profiler results:").append(System.lineSeparator());
+            for (File file : files) {
+                builder.append("  ").append(file.getPath()).append(System.lineSeparator());
+            }
+            return builder.toString();
+        }
+
+        private static class FileAggregator implements Aggregator<FileResult> {
+            @Override
+            public FileResult aggregate(Collection<FileResult> results) {
+                return new FileResult(results.iterator().next().getLabel(), results.stream()
+                        .flatMap(r -> r.files.stream())
+                        .distinct()
+                        .collect(Collectors.toList()));
+            }
+        }
     }
 }


### PR DESCRIPTION
Without this change, async-profiler would write the same result in each fork, overwriting the previous result.

This patch introduces a new "FileResult" class that collects the output paths of each benchmark. In `afterTrial`, the output files are moved to a new path that includes the pid (fork number would be an alternative but it's not as easily available).

At the moment, results of different runs are not coalesced. But with these changes, it would be easy to coalesce at least the results of the "collapsed" output mode. I plan to do this in another PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903560](https://bugs.openjdk.org/browse/CODETOOLS-7903560): JMH: async profiler reports only the last fork result (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/121/head:pull/121` \
`$ git checkout pull/121`

Update a local copy of the PR: \
`$ git checkout pull/121` \
`$ git pull https://git.openjdk.org/jmh.git pull/121/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 121`

View PR using the GUI difftool: \
`$ git pr show -t 121`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/121.diff">https://git.openjdk.org/jmh/pull/121.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/121#issuecomment-1737240142)