### PR TITLE
CODETOOLS-7903567: JMH: Improve README guidance for archetype bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ to work through the [JMH Samples](https://github.com/openjdk/jmh/tree/master/jmh
 
 ### Preferred Usage: Command Line
 
-**Step 1. Setting up the benchmarking project.** The following command will generate the new JMH-driven project in new test folder. Note that current and target folder should not already contain any Maven project for this to work reliably.
+**Step 1. Setting up the benchmarking project.** The following command will generate the new JMH-driven project in new `test` folder. Note that current and target folder should not already contain any Maven project for this to work reliably.
 
     $ mvn archetype:generate \
       -DinteractiveMode=false \

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ to work through the [JMH Samples](https://github.com/openjdk/jmh/tree/master/jmh
 ### Preferred Usage: Command Line
 
 **Step 1. Setting up the benchmarking project.** The following command will generate the new JMH-driven
-project in `test` folder:
+project in `test` folder (do not try to run the command within an already existing maven project):
 
     $ mvn archetype:generate \
       -DinteractiveMode=false \

--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ to work through the [JMH Samples](https://github.com/openjdk/jmh/tree/master/jmh
 
 ### Preferred Usage: Command Line
 
-**Step 1. Setting up the benchmarking project.** The following command will generate the new JMH-driven
-project in `test` folder (do not try to run the command within an already existing maven project):
+**Step 1. Setting up the benchmarking project.** The following command will generate the new JMH-driven project in new test folder. Note that current and target folder should not already contain any Maven project for this to work reliably.
 
     $ mvn archetype:generate \
       -DinteractiveMode=false \


### PR DESCRIPTION
Attempting to execute the "mvn archetype:generate" command specified in Step 1 of Preferred Usage in the README will result in a maven execution error if you interpret it like I did! In my case I naively interpreted the following text to mean that I could create a sub project within the test folder of my already existing java project. "test" is the default test folder!

_

> "Step 1. Setting up the benchmarking project. The following command will generate the new JMH-driven project in test folder:"

_

This resulted in 10-15 minutes of trying to figure out if I needed to install something new to use mvn archetype - as I have not used it before.

This change might make it easier for users to get set up with JMH project templates.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903567](https://bugs.openjdk.org/browse/CODETOOLS-7903567): JMH: Improve README guidance for archetype bootstrap (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)
 * @mamadaliev (no known openjdk.org user name / role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/123/head:pull/123` \
`$ git checkout pull/123`

Update a local copy of the PR: \
`$ git checkout pull/123` \
`$ git pull https://git.openjdk.org/jmh.git pull/123/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 123`

View PR using the GUI difftool: \
`$ git pr show -t 123`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/123.diff">https://git.openjdk.org/jmh/pull/123.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/123#issuecomment-1772986560)