### PR TITLE
7903572: JMH: mempool should capture Direct/Mapped memory pools as well

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/MemPoolProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/MemPoolProfiler.java
@@ -74,15 +74,11 @@ public class MemPoolProfiler implements InternalProfiler {
         results.addAll(
                 ManagementFactory.getPlatformMXBeans(BufferPoolMXBean.class)
                         .stream()
-                        .flatMap(bean -> Stream.of(
-                                new ScalarResult(String.format("mempool.%s.totalCapacity", bean.getName()),
-                                        bean.getTotalCapacity() / BYTES_PER_KIB,
-                                        "KiB",
-                                        AggregationPolicy.MAX),
-                                new ScalarResult(String.format("mempool.%s.memoryUsed", bean.getName()),
+                        .map(bean ->
+                                new ScalarResult(String.format("mempool.%s.used", bean.getName()),
                                         bean.getMemoryUsed() / BYTES_PER_KIB,
                                         "KiB",
-                                        AggregationPolicy.MAX)))
+                                        AggregationPolicy.MAX))
                         .collect(Collectors.toList()));
         return results;
     }

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/MemPoolProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/MemPoolProfiler.java
@@ -67,14 +67,13 @@ public class MemPoolProfiler implements InternalProfiler {
         }
 
         for (BufferPoolMXBean bean : ManagementFactory.getPlatformMXBeans(BufferPoolMXBean.class)) {
-            final long used = bean.getMemoryUsed();
+            long used = bean.getMemoryUsed();
             sum += used;
-            results.add(new ScalarResult(String.format("mempool.%s.used", bean.getName()), used / BYTES_PER_KIB, "KiB", AggregationPolicy.MAX));
+            results.add(new ScalarResult("mempool." + bean.getName() + ".used", used / BYTES_PER_KIB, "KiB", AggregationPolicy.MAX));
         }
 
         results.add(new ScalarResult("mempool.total.codeheap.used", sumCodeHeap / BYTES_PER_KIB, "KiB", AggregationPolicy.MAX));
         results.add(new ScalarResult("mempool.total.used", sum / BYTES_PER_KIB, "KiB", AggregationPolicy.MAX));
-
         return results;
     }
 }


### PR DESCRIPTION
In this PR I am adding the support for Direct/Mapped Memory pools in the `MemPoolProfiler`.
In my case, it was needed because I suppose a memory leak in the third-party library that unmaps `MappedByteBuffer`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903572](https://bugs.openjdk.org/browse/CODETOOLS-7903572): JMH: mempool should capture Direct/Mapped memory pools as well (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/124/head:pull/124` \
`$ git checkout pull/124`

Update a local copy of the PR: \
`$ git checkout pull/124` \
`$ git pull https://git.openjdk.org/jmh.git pull/124/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 124`

View PR using the GUI difftool: \
`$ git pr show -t 124`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/124.diff">https://git.openjdk.org/jmh/pull/124.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/124#issuecomment-1773044691)