### PR TITLE
7903676: JMH: Simplify GHA pipelines

### DIFF
--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -20,7 +20,7 @@ jobs:
         os: [ubuntu-22.04, windows-2022, macos-11]
       fail-fast: false
     name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 180
 
     steps:
     - uses: actions/checkout@v4
@@ -39,33 +39,41 @@ jobs:
         perf stat echo 1
       if: (runner.os == 'Linux')
 
-    - name: Run build with tests (Default)
+    - name: Build with tests (Default)
       run: mvn clean install -B --file pom.xml
+      continue-on-error: true
 
-    - name: Run build with tests (Reflection)
+    - name: Build with tests (Reflection)
       run: mvn clean install -P reflection -B --file pom.xml
+      continue-on-error: true
       if: (runner.os == 'Linux')
 
-    - name: Run build without tests (Reflection)
+    - name: Build without tests (Reflection)
       run: mvn clean install -P reflection -B --file pom.xml -DskipTests
+      continue-on-error: true
       if: (runner.os != 'Linux')
 
-    - name: Run build with tests (ASM)
+    - name: Build with tests (ASM)
       run: mvn clean install -P asm -B --file pom.xml
+      continue-on-error: true
       if: (runner.os == 'Linux')
 
-    - name: Run build without tests (ASM)
+    - name: Build without tests (ASM)
       run: mvn clean install -P asm -B --file pom.xml -DskipTests
+      continue-on-error: true
       if: (runner.os != 'Linux')
 
-    - name: Run build with tests (FJP Executor)
+    - name: Build with tests (FJP Executor)
       run: mvn clean install -P executor-fjp -B --file pom.xml
+      continue-on-error: true
       if: (runner.os == 'Linux')
 
-    - name: Run build with tests (Custom Executor)
+    - name: Build with tests (Custom Executor)
       run: mvn clean install -P executor-custom -B --file pom.xml
+      continue-on-error: true
       if: (runner.os == 'Linux')
 
-    - name: Run build with tests (Virtual Executor)
+    - name: Build with tests (Virtual Executor)
       run: mvn clean install -P executor-virtual -B --file pom.xml
+      continue-on-error: true
       if: (runner.os == 'Linux') && (matrix.java == '21')

--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -18,9 +18,8 @@ jobs:
       matrix:
         java: [8, 11, 17, 21]
         os: [ubuntu-22.04, windows-2022, macos-11]
-        profile: [default, reflection, asm, executor-virtual, executor-fjp, executor-custom]
       fail-fast: false
-    name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}, ${{ matrix.profile }}
+    name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}
     timeout-minutes: 60
 
     steps:
@@ -41,33 +40,32 @@ jobs:
       if: (runner.os == 'Linux')
 
     - name: Run build with tests (Default)
-      run: mvn clean install -P ${{ matrix.profile }} -B --file pom.xml
-      if: (matrix.profile == 'default')
+      run: mvn clean install -B --file pom.xml
 
     - name: Run build with tests (Reflection)
-      run: mvn clean install -P ${{ matrix.profile }} -B --file pom.xml
-      if: (runner.os == 'Linux') && (matrix.profile == 'reflection')
+      run: mvn clean install -P reflection -B --file pom.xml
+      if: (runner.os == 'Linux')
 
     - name: Run build without tests (Reflection)
-      run: mvn clean install -P ${{ matrix.profile }} -B --file pom.xml -DskipTests
-      if: (runner.os != 'Linux') && (matrix.profile == 'reflection')
+      run: mvn clean install -P reflection -B --file pom.xml -DskipTests
+      if: (runner.os != 'Linux')
 
     - name: Run build with tests (ASM)
-      run: mvn clean install -P ${{ matrix.profile }} -B --file pom.xml
-      if: (runner.os == 'Linux') && (matrix.profile == 'asm')
+      run: mvn clean install -P asm -B --file pom.xml
+      if: (runner.os == 'Linux')
 
     - name: Run build without tests (ASM)
-      run: mvn clean install -P ${{ matrix.profile }} -B --file pom.xml -DskipTests
-      if: (runner.os != 'Linux') && (matrix.profile == 'asm')
+      run: mvn clean install -P asm -B --file pom.xml -DskipTests
+      if: (runner.os != 'Linux')
 
     - name: Run build with tests (FJP Executor)
-      run: mvn clean install -P ${{ matrix.profile }} -B --file pom.xml
-      if: (runner.os == 'Linux') && (matrix.profile == 'executor-fjp')
+      run: mvn clean install -P executor-fjp -B --file pom.xml
+      if: (runner.os == 'Linux')
 
     - name: Run build with tests (Custom Executor)
-      run: mvn clean install -P ${{ matrix.profile }} -B --file pom.xml
-      if: (runner.os == 'Linux') && (matrix.profile == 'executor-custom')
+      run: mvn clean install -P executor-custom -B --file pom.xml
+      if: (runner.os == 'Linux')
 
     - name: Run build with tests (Virtual Executor)
-      run: mvn clean install -P ${{ matrix.profile }} -B --file pom.xml
-      if: (runner.os == 'Linux') && (matrix.java == '21') && (matrix.profile == 'executor-virtual')
+      run: mvn clean install -P executor-virtual -B --file pom.xml
+      if: (runner.os == 'Linux') && (matrix.java == '21')

--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -45,35 +45,28 @@ jobs:
 
     - name: Build with tests (Reflection)
       run: mvn clean install -P reflection -B --file pom.xml
-      continue-on-error: true
       if: (runner.os == 'Linux')
 
     - name: Build without tests (Reflection)
       run: mvn clean install -P reflection -B --file pom.xml -DskipTests
-      continue-on-error: true
       if: (runner.os != 'Linux')
 
     - name: Build with tests (ASM)
       run: mvn clean install -P asm -B --file pom.xml
-      continue-on-error: true
       if: (runner.os == 'Linux')
 
     - name: Build without tests (ASM)
       run: mvn clean install -P asm -B --file pom.xml -DskipTests
-      continue-on-error: true
       if: (runner.os != 'Linux')
 
     - name: Build with tests (FJP Executor)
       run: mvn clean install -P executor-fjp -B --file pom.xml
-      continue-on-error: true
       if: (runner.os == 'Linux')
 
     - name: Build with tests (Custom Executor)
       run: mvn clean install -P executor-custom -B --file pom.xml
-      continue-on-error: true
       if: (runner.os == 'Linux')
 
     - name: Build with tests (Virtual Executor)
       run: mvn clean install -P executor-virtual -B --file pom.xml
-      continue-on-error: true
       if: (runner.os == 'Linux') && (matrix.java == '21')

--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -41,7 +41,6 @@ jobs:
 
     - name: Build with tests (Default)
       run: mvn clean install -B --file pom.xml
-      continue-on-error: true
 
     - name: Build with tests (Reflection)
       run: mvn clean install -P reflection -B --file pom.xml


### PR DESCRIPTION
JMH currently runs many jobs with matrix taking the optional profile. This means many jobs are not actually doing any useful work. When those jobs run, we have quite a few warnings: "Error: Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved."

We can merge current pipelines a bit to simplify the whole thing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903676](https://bugs.openjdk.org/browse/CODETOOLS-7903676): JMH: Simplify GHA pipelines (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/128/head:pull/128` \
`$ git checkout pull/128`

Update a local copy of the PR: \
`$ git checkout pull/128` \
`$ git pull https://git.openjdk.org/jmh.git pull/128/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 128`

View PR using the GUI difftool: \
`$ git pr show -t 128`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/128.diff">https://git.openjdk.org/jmh/pull/128.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/128#issuecomment-1953824218)