### PR TITLE
7903677: JMH: Workaround xperfasm failure in GHA

### DIFF
--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/AbstractAsmProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/AbstractAsmProfilerTest.java
@@ -67,4 +67,8 @@ public abstract class AbstractAsmProfilerTest {
         }
     }
 
+    public static boolean someEventsCaptured(String out) {
+        return !out.contains("The perf event count is suspiciously low (0).");
+    }
+
 }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/WinPerfAsmProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/WinPerfAsmProfilerTest.java
@@ -57,7 +57,7 @@ public class WinPerfAsmProfilerTest extends AbstractAsmProfilerTest {
 
         Map<String, Result> sr = rr.getSecondaryResults();
         String out = ProfilerTestUtils.checkedGet(sr, "asm").extendedInfo();
-        if (!checkDisassembly(out)) {
+        if (!checkDisassembly(out) && someEventsCaptured(out)) {
             throw new IllegalStateException("Profile does not contain the required frame: " + out);
         }
     }


### PR DESCRIPTION
GHA Windows runners do not work with xperf out of the box, so the WinPerfAsmTests fail. We need to work them around.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903677](https://bugs.openjdk.org/browse/CODETOOLS-7903677): JMH: Workaround xperfasm failure in GHA (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/129/head:pull/129` \
`$ git checkout pull/129`

Update a local copy of the PR: \
`$ git checkout pull/129` \
`$ git pull https://git.openjdk.org/jmh.git pull/129/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 129`

View PR using the GUI difftool: \
`$ git pr show -t 129`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/129.diff">https://git.openjdk.org/jmh/pull/129.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/129#issuecomment-1954413920)