### PR TITLE
7903740: JMH: Perf event validation not working with skid options

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfAsmProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfAsmProfiler.java
@@ -47,7 +47,7 @@ public class LinuxPerfAsmProfiler extends AbstractPerfAsmProfiler {
     public LinuxPerfAsmProfiler(String initLine) throws ProfilerException {
         super(initLine, "cycles");
 
-        String[] senseCmd = { PerfSupport.PERF_EXEC, "record", "--event", Utils.join(requestedEventNames, ","), "--log-fd", "2", "echo", "1" };
+        String[] senseCmd = { PerfSupport.PERF_EXEC, "record", "--event", Utils.join(requestedEventNames, ","), "echo", "1" };
 
         Collection<String> failMsg = Utils.tryWith(senseCmd);
         if (!failMsg.isEmpty()) {

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfAsmProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfAsmProfiler.java
@@ -46,7 +46,7 @@ public class LinuxPerfAsmProfiler extends AbstractPerfAsmProfiler {
     public LinuxPerfAsmProfiler(String initLine) throws ProfilerException {
         super(initLine, "cycles");
 
-        String[] senseCmd = { PerfSupport.PERF_EXEC, "record", "--event", Utils.join(requestedEventNames, ","), "-o", "-", "true"};
+        String[] senseCmd = { PerfSupport.PERF_EXEC, "record", "-q", "--event", Utils.join(requestedEventNames, ","), "-o", "-", "true"};
 
         Collection<String> failMsg = Utils.tryWith(senseCmd);
         if (!failMsg.isEmpty()) {

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfAsmProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfAsmProfiler.java
@@ -53,13 +53,6 @@ public class LinuxPerfAsmProfiler extends AbstractPerfAsmProfiler {
             throw new ProfilerException(failMsg.toString());
         }
 
-//        Collection<String> passMsg = Utils.runWith(senseCmd);
-//        for (String m : passMsg) {
-//            if (m.contains("[ perf record: Captured and wrote 0.000 MB (null) ]")) {
-//                throw new ProfilerException("Unsupported events: " + requestedEventNames);
-//            }
-//        }
-
         for (String ev : requestedEventNames) {
             String reportCmd = String.format("perf report -i perf-record-validate.data --stdio | grep %s | wc -l", ev);
             String[] tunnelCmd = { "/bin/sh", "-c", reportCmd };

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfAsmProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfAsmProfiler.java
@@ -36,6 +36,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class LinuxPerfAsmProfiler extends AbstractPerfAsmProfiler {
 
@@ -46,7 +47,13 @@ public class LinuxPerfAsmProfiler extends AbstractPerfAsmProfiler {
     public LinuxPerfAsmProfiler(String initLine) throws ProfilerException {
         super(initLine, "cycles");
 
-        String[] senseCmd = { PerfSupport.PERF_EXEC, "stat", "--event", Utils.join(requestedEventNames, ","), "--log-fd", "2", "echo", "1" };
+        List<String> senseEventNames = requestedEventNames.stream()
+            .map(s -> s.split(":"))
+            .filter(s -> s.length > 0)
+            .map(s -> s[0])
+            .collect(Collectors.toList());
+
+        String[] senseCmd = { PerfSupport.PERF_EXEC, "stat", "--event", Utils.join(senseEventNames, ","), "--log-fd", "2", "echo", "1" };
 
         Collection<String> failMsg = Utils.tryWith(senseCmd);
         if (!failMsg.isEmpty()) {

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfAsmProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfAsmProfiler.java
@@ -47,13 +47,7 @@ public class LinuxPerfAsmProfiler extends AbstractPerfAsmProfiler {
     public LinuxPerfAsmProfiler(String initLine) throws ProfilerException {
         super(initLine, "cycles");
 
-        List<String> senseEventNames = requestedEventNames.stream()
-            .map(s -> s.split(":"))
-            .filter(s -> s.length > 0)
-            .map(s -> s[0])
-            .collect(Collectors.toList());
-
-        String[] senseCmd = { PerfSupport.PERF_EXEC, "stat", "--event", Utils.join(senseEventNames, ","), "--log-fd", "2", "echo", "1" };
+        String[] senseCmd = { PerfSupport.PERF_EXEC, "record", "--event", Utils.join(requestedEventNames, ","), "--log-fd", "2", "echo", "1" };
 
         Collection<String> failMsg = Utils.tryWith(senseCmd);
         if (!failMsg.isEmpty()) {

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfAsmProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfAsmProfiler.java
@@ -61,7 +61,7 @@ public class LinuxPerfAsmProfiler extends AbstractPerfAsmProfiler {
 //        }
 
         for (String ev : requestedEventNames) {
-            String reportCmd = String.format("perf report -q -i perf-record-validate.data --stdio | grep %s | wc -l", ev);
+            String reportCmd = String.format("perf report -i perf-record-validate.data --stdio | grep %s | wc -l", ev);
             String[] tunnelCmd = { "/bin/sh", "-c", reportCmd };
             Collection<String> output = Utils.runWith(tunnelCmd);
             if (output.isEmpty()) {

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfAsmProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfAsmProfiler.java
@@ -46,7 +46,7 @@ public class LinuxPerfAsmProfiler extends AbstractPerfAsmProfiler {
     public LinuxPerfAsmProfiler(String initLine) throws ProfilerException {
         super(initLine, "cycles");
 
-        String[] senseCmd = { PerfSupport.PERF_EXEC, "record", "--event", Utils.join(requestedEventNames, ","), "echo", "1" };
+        String[] senseCmd = { PerfSupport.PERF_EXEC, "record", "--event", Utils.join(requestedEventNames, ","), "--output", "perf-record-validate.data", "echo", "1" };
 
         Collection<String> failMsg = Utils.tryWith(senseCmd);
         if (!failMsg.isEmpty()) {

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfAsmProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfAsmProfiler.java
@@ -53,23 +53,36 @@ public class LinuxPerfAsmProfiler extends AbstractPerfAsmProfiler {
             throw new ProfilerException(failMsg.toString());
         }
 
-        for (String ev : requestedEventNames) {
-            String reportCmd = String.format("perf report -q --stdio | grep %s | wc -l", ev);
-            String[] tunnelCmd = { "/bin/sh", "-c", reportCmd };
-            Collection<String> output = Utils.runWith(tunnelCmd);
-            if (output.isEmpty()) {
-                throw new ProfilerException("No events recorded for " + ev);
-            }
-
-            try {
-                final int count = Integer.parseInt(output.iterator().next());
-                if (count == 0) {
-                    throw new ProfilerException("Unsupported event: " + ev);
-                }
-            } catch (NumberFormatException e) {
-                throw new ProfilerException("Perf event count not a number for event " + ev + ": " + output);
+        Collection<String> passMsg = Utils.runWith(senseCmd);
+        for (String m : passMsg) {
+            if (m.contains("[ perf record: Captured and wrote 0.000 MB (null) ]")) {
+                throw new ProfilerException("Unsupported events: " + requestedEventNames);
             }
         }
+
+//        for (String ev : requestedEventNames) {
+//            if (PerfSupport.containsUnsupported(passMsg, ev)) {
+//                throw new ProfilerException("Unsupported event: " + ev);
+//            }
+//        }
+
+//        for (String ev : requestedEventNames) {
+//            String reportCmd = String.format("perf report -q --stdio | grep %s | wc -l", ev);
+//            String[] tunnelCmd = { "/bin/sh", "-c", reportCmd };
+//            Collection<String> output = Utils.runWith(tunnelCmd);
+//            if (output.isEmpty()) {
+//                throw new ProfilerException("No events recorded for " + ev);
+//            }
+//
+//            try {
+//                final int count = Integer.parseInt(output.iterator().next());
+//                if (count == 0) {
+//                    throw new ProfilerException("Unsupported event: " + ev);
+//                }
+//            } catch (NumberFormatException e) {
+//                throw new ProfilerException("Perf event count not a number for event " + ev + ": " + output);
+//            }
+//        }
 
         try {
             sampleFrequency = set.valueOf(optFrequency);

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfAsmProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfAsmProfiler.java
@@ -53,10 +53,28 @@ public class LinuxPerfAsmProfiler extends AbstractPerfAsmProfiler {
             throw new ProfilerException(failMsg.toString());
         }
 
-        Collection<String> passMsg = Utils.runWith(senseCmd);
-        for (String m : passMsg) {
-            if (m.contains("[ perf record: Captured and wrote 0.000 MB (null) ]")) {
-                throw new ProfilerException("Unsupported events: " + requestedEventNames);
+//        Collection<String> passMsg = Utils.runWith(senseCmd);
+//        for (String m : passMsg) {
+//            if (m.contains("[ perf record: Captured and wrote 0.000 MB (null) ]")) {
+//                throw new ProfilerException("Unsupported events: " + requestedEventNames);
+//            }
+//        }
+
+        for (String ev : requestedEventNames) {
+            String reportCmd = String.format("perf report -q -i perf-record-validate.data --stdio | grep %s | wc -l", ev);
+            String[] tunnelCmd = { "/bin/sh", "-c", reportCmd };
+            Collection<String> output = Utils.runWith(tunnelCmd);
+            if (output.isEmpty()) {
+                throw new ProfilerException("No events recorded for " + ev);
+            }
+
+            try {
+                final int count = Integer.parseInt(output.iterator().next());
+                if (count == 0) {
+                    throw new ProfilerException("Unsupported event: " + ev);
+                }
+            } catch (NumberFormatException e) {
+                throw new ProfilerException("Perf event count not a number for event " + ev + ": " + output);
             }
         }
 

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfAsmProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfAsmProfiler.java
@@ -69,7 +69,7 @@ public class LinuxPerfAsmProfiler extends AbstractPerfAsmProfiler {
             }
 
             try {
-                final int count = Integer.parseInt(output.iterator().next());
+                final int count = Integer.parseInt(output.iterator().next().trim());
                 if (count == 0) {
                     throw new ProfilerException("Unsupported event: " + ev);
                 }

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfAsmProfiler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/LinuxPerfAsmProfiler.java
@@ -60,30 +60,6 @@ public class LinuxPerfAsmProfiler extends AbstractPerfAsmProfiler {
             }
         }
 
-//        for (String ev : requestedEventNames) {
-//            if (PerfSupport.containsUnsupported(passMsg, ev)) {
-//                throw new ProfilerException("Unsupported event: " + ev);
-//            }
-//        }
-
-//        for (String ev : requestedEventNames) {
-//            String reportCmd = String.format("perf report -q --stdio | grep %s | wc -l", ev);
-//            String[] tunnelCmd = { "/bin/sh", "-c", reportCmd };
-//            Collection<String> output = Utils.runWith(tunnelCmd);
-//            if (output.isEmpty()) {
-//                throw new ProfilerException("No events recorded for " + ev);
-//            }
-//
-//            try {
-//                final int count = Integer.parseInt(output.iterator().next());
-//                if (count == 0) {
-//                    throw new ProfilerException("Unsupported event: " + ev);
-//                }
-//            } catch (NumberFormatException e) {
-//                throw new ProfilerException("Perf event count not a number for event " + ev + ": " + output);
-//            }
-//        }
-
         try {
             sampleFrequency = set.valueOf(optFrequency);
         } catch (OptionException e) {


### PR DESCRIPTION
Fixes https://bugs.openjdk.org/browse/CODETOOLS-7903740

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903740](https://bugs.openjdk.org/browse/CODETOOLS-7903740): JMH: Perf event validation not working with skid options (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/132/head:pull/132` \
`$ git checkout pull/132`

Update a local copy of the PR: \
`$ git checkout pull/132` \
`$ git pull https://git.openjdk.org/jmh.git pull/132/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 132`

View PR using the GUI difftool: \
`$ git pr show -t 132`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/132.diff">https://git.openjdk.org/jmh/pull/132.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/132#issuecomment-2142727262)