### PR TITLE
7903796: JMH: Switch to latest GHA runners 

### DIFF
--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         java: [8, 11, 17, 21]
-        os: [ubuntu-22.04, windows-2022, macos-11]
+        os: [ubuntu-latest, windows-latest, macos-latest]
       fail-fast: false
     name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}
     timeout-minutes: 180


### PR DESCRIPTION
JMH currently runs macos-11 for the runners, which are scarce. Developers likely do not have access to macos-11 VMs for debugging too. Since we just want to check that JMH works on some OS flavors, we might as well switch to latest runners.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903796](https://bugs.openjdk.org/browse/CODETOOLS-7903796): JMH: Switch to latest GHA runners (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/134/head:pull/134` \
`$ git checkout pull/134`

Update a local copy of the PR: \
`$ git checkout pull/134` \
`$ git pull https://git.openjdk.org/jmh.git pull/134/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 134`

View PR using the GUI difftool: \
`$ git pr show -t 134`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/134.diff">https://git.openjdk.org/jmh/pull/134.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/134#issuecomment-2301826117)