### PR TITLE
7903797: JMH: Workaround dtraceasm failure in GHA

### DIFF
--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/DTraceAsmProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/DTraceAsmProfilerTest.java
@@ -57,7 +57,7 @@ public class DTraceAsmProfilerTest extends AbstractAsmProfilerTest {
 
         Map<String, Result> sr = rr.getSecondaryResults();
         String out = ProfilerTestUtils.checkedGet(sr, "asm").extendedInfo();
-        if (!checkDisassembly(out)) {
+        if (!checkDisassembly(out) && someEventsCaptured(out)) {
             throw new IllegalStateException("Profile does not contain the required frame: " + out);
         }
     }


### PR DESCRIPTION
Like with [CODETOOLS-7903677](https://bugs.openjdk.org/browse/CODETOOLS-7903677), we want to workaround MacOS problems with dtraceasm.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903797](https://bugs.openjdk.org/browse/CODETOOLS-7903797): JMH: Workaround dtraceasm failure in GHA (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/135/head:pull/135` \
`$ git checkout pull/135`

Update a local copy of the PR: \
`$ git checkout pull/135` \
`$ git pull https://git.openjdk.org/jmh.git pull/135/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 135`

View PR using the GUI difftool: \
`$ git pr show -t 135`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/135.diff">https://git.openjdk.org/jmh/pull/135.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/135#issuecomment-2302173954)