### PR TITLE
7903895: JMH: Optimize hierarchical padding subclasses

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/generators/core/StateObjectHandler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/generators/core/StateObjectHandler.java
@@ -962,9 +962,6 @@ class StateObjectHandler {
                 PrintWriter pw = new PrintWriter(dst.newClass(so.packageName + "." + so.type + "_B1", so.userType));
 
                 pw.println("package " + so.packageName + ";");
-
-                pw.println("import " + so.userType + ";");
-
                 pw.println("public class " + so.type + "_B1 extends " + so.userType + " {");
                 Paddings.padding(pw, "b1_");
                 pw.println("}");
@@ -976,9 +973,7 @@ class StateObjectHandler {
                 PrintWriter pw = new PrintWriter(dst.newClass(so.packageName + "." + so.type + "_B2", so.userType));
 
                 pw.println("package " + so.packageName + ";");
-
                 pw.println("import " + AtomicIntegerFieldUpdater.class.getCanonicalName() + ";");
-
                 pw.println("public class " + so.type + "_B2 extends " + so.type + "_B1 {");
 
                 for (Level level : Level.values()) {
@@ -1011,22 +1006,11 @@ class StateObjectHandler {
             }
 
             {
-                PrintWriter pw = new PrintWriter(dst.newClass(so.packageName + "." + so.type + "_B3", so.userType));
-
-                pw.println("package " + so.packageName + ";");
-                pw.println("public class " + so.type + "_B3 extends " + so.type + "_B2 {");
-                Paddings.padding(pw, "b3_");
-                pw.println("}");
-                pw.println("");
-
-                pw.close();
-            }
-
-            {
                 PrintWriter pw = new PrintWriter(dst.newClass(so.packageName + "." + so.type, so.userType));
 
                 pw.println("package " + so.packageName + ";");
-                pw.println("public class " + so.type + " extends " + so.type + "_B3 {");
+                pw.println("public class " + so.type + " extends " + so.type + "_B2 {");
+                Paddings.padding(pw, "b3_");
                 pw.println("}");
                 pw.println("");
 


### PR DESCRIPTION
As [JDK-8345302](https://bugs.openjdk.org/browse/JDK-8345302) shows, generating too much code can choke javac with a small heap size. We need to investigate whether we can cut down on generated code without loss of functionality or performance. One of such opportunities is optimizing the jmhType hierarchy that we use to perform reliable padding.

We do not need one of the subclasses, since it is empty. We also do not need an explicit import for `userType`, since it is already fully qualified in `extends` clause.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903895](https://bugs.openjdk.org/browse/CODETOOLS-7903895): JMH: Optimize hierarchical padding subclasses (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/137/head:pull/137` \
`$ git checkout pull/137`

Update a local copy of the PR: \
`$ git checkout pull/137` \
`$ git pull https://git.openjdk.org/jmh.git pull/137/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 137`

View PR using the GUI difftool: \
`$ git pr show -t 137`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/137.diff">https://git.openjdk.org/jmh/pull/137.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/137#issuecomment-2521066335)
</details>
