### PR TITLE
7903897: JMH: Disable DTrace profiler tests

### DIFF
--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/DTraceAsmProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/DTraceAsmProfilerTest.java
@@ -24,6 +24,7 @@
  */
 package org.openjdk.jmh.it.profilers;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.openjdk.jmh.it.Fixtures;
 import org.openjdk.jmh.profile.DTraceAsmProfiler;
@@ -37,6 +38,9 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import java.util.Map;
 
+// DTraceAsm profiler is aging, and would be replaced by XCTraceAsm profiler.
+// This test is not very reliable and therefore disabled.
+@Ignore
 public class DTraceAsmProfilerTest extends AbstractAsmProfilerTest {
 
     @Test


### PR DESCRIPTION
DTrace profiler does not work reliably on GHA, and it would probably be replaced by XCTrace profiler completely. So we can just disable the test to get cleaner runs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903897](https://bugs.openjdk.org/browse/CODETOOLS-7903897): JMH: Disable DTrace profiler tests (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/138/head:pull/138` \
`$ git checkout pull/138`

Update a local copy of the PR: \
`$ git checkout pull/138` \
`$ git pull https://git.openjdk.org/jmh.git pull/138/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 138`

View PR using the GUI difftool: \
`$ git pr show -t 138`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/138.diff">https://git.openjdk.org/jmh/pull/138.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/138#issuecomment-2521108727)
</details>
