### PR TITLE
7903896: JMH: Trim down String literals in generated code

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/generators/core/BenchmarkGenerator.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/generators/core/BenchmarkGenerator.java
@@ -460,6 +460,9 @@ public class BenchmarkGenerator {
 
         // generate padding
         Paddings.padding(writer, "p");
+        writer.println();
+        writer.println(ident(1) + "static final String BLACKHOLE_CHALLENGE = \"Should not be calling this.\";");
+        writer.println();
 
         writer.println(ident(1) + "int startRndMask;");
         writer.println(ident(1) + "BenchmarkParams benchmarkParams;");
@@ -640,7 +643,7 @@ public class BenchmarkGenerator {
             writer.println(ident(3) + "return results;");
             writer.println(ident(2) + "} else");
         }
-        writer.println(ident(3) + "throw new IllegalStateException(\"Harness failed to distribute threads among groups properly\");");
+        writer.println(ident(3) + "throw new IllegalStateException();");
         writer.println(ident(1) + "}");
 
         writer.println();
@@ -774,7 +777,7 @@ public class BenchmarkGenerator {
             writer.println(ident(3) + "return results;");
             writer.println(ident(2) + "} else");
         }
-        writer.println(ident(3) + "throw new IllegalStateException(\"Harness failed to distribute threads among groups properly\");");
+        writer.println(ident(3) + "throw new IllegalStateException();");
         writer.println(ident(1) + "}");
 
         writer.println();
@@ -822,12 +825,12 @@ public class BenchmarkGenerator {
         writer.println(ident(2) + "this.threadParams    = threadParams;");
         writer.println(ident(2) + "this.notifyControl   = control.notifyControl;");
         writer.println(ident(2) + "if (this.blackhole == null) {");
-        writer.println(ident(3) + "this.blackhole = new Blackhole(\"Today's password is swordfish. I understand instantiating Blackholes directly is dangerous.\");");
+        writer.println(ident(3) + "this.blackhole = new Blackhole(BLACKHOLE_CHALLENGE);");
         writer.println(ident(2) + "}");
     }
 
     private void methodEpilog(PrintWriter writer) {
-        writer.println(ident(3) + "this.blackhole.evaporate(\"Yes, I am Stephen Hawking, and know a thing or two about black holes.\");");
+        writer.println(ident(3) + "this.blackhole.evaporate(BLACKHOLE_CHALLENGE);");
     }
 
     private String prefix(String argList) {
@@ -933,7 +936,7 @@ public class BenchmarkGenerator {
             writer.println(ident(3) + "return results;");
             writer.println(ident(2) + "} else");
         }
-        writer.println(ident(3) + "throw new IllegalStateException(\"Harness failed to distribute threads among groups properly\");");
+        writer.println(ident(3) + "throw new IllegalStateException();");
         writer.println(ident(1) + "}");
 
         writer.println();
@@ -1042,7 +1045,7 @@ public class BenchmarkGenerator {
             writer.println(ident(3) + "return results;");
             writer.println(ident(2) + "} else");
         }
-        writer.println(ident(3) + "throw new IllegalStateException(\"Harness failed to distribute threads among groups properly\");");
+        writer.println(ident(3) + "throw new IllegalStateException();");
         writer.println(ident(1) + "}");
 
         writer.println();

--- a/jmh-core/src/main/java/org/openjdk/jmh/infra/Blackhole.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/infra/Blackhole.java
@@ -293,7 +293,7 @@ public final class Blackhole extends BlackholeL4 {
          * directly though.
          */
 
-        if (!challengeResponse.equals("Today's password is swordfish. I understand instantiating Blackholes directly is dangerous.")) {
+        if (!challengeResponse.equals("Should not be calling this.")) {
             throw new IllegalStateException("Blackholes should not be instantiated directly.");
         }
     }
@@ -307,8 +307,8 @@ public final class Blackhole extends BlackholeL4 {
      * @param challengeResponse arbitrary string
      */
     public void evaporate(String challengeResponse) {
-        if (!challengeResponse.equals("Yes, I am Stephen Hawking, and know a thing or two about black holes.")) {
-            throw new IllegalStateException("Who are you?");
+        if (!challengeResponse.equals("Should not be calling this.")) {
+            throw new IllegalStateException("Evaporate should not be called directly.");
         }
         obj1 = null;
     }

--- a/jmh-core/src/test/java/org/openjdk/jmh/BlackholeTest.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/BlackholeTest.java
@@ -54,7 +54,7 @@ public class BlackholeTest {
         }
 
         try {
-            new Blackhole("Today's password is swordfish. I understand instantiating Blackholes directly is dangerous.");
+            new Blackhole("Should not be calling this.");
         } catch (Throwable e) {
             Assert.fail("Failed unexpectedly");
         }


### PR DESCRIPTION
It is apparent in the heap dump I got when investigating [JDK-8345302](https://bugs.openjdk.org/browse/JDK-8345302) that javac compilation of JDK benchmarks corpus takes significant memory holding String literals referenced in JMH generated code. About 0.6% of them are the ones from Blackhole challenges and internal exceptions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903896](https://bugs.openjdk.org/browse/CODETOOLS-7903896): JMH: Trim down String literals in generated code (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/139/head:pull/139` \
`$ git checkout pull/139`

Update a local copy of the PR: \
`$ git checkout pull/139` \
`$ git pull https://git.openjdk.org/jmh.git pull/139/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 139`

View PR using the GUI difftool: \
`$ git pr show -t 139`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/139.diff">https://git.openjdk.org/jmh/pull/139.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/139#issuecomment-2521255838)
</details>
