### PR TITLE
7903898: JMH: Unsafe deprecation warnings are printed in JDK 24

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/infra/BenchmarkParams.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/infra/BenchmarkParams.java
@@ -50,21 +50,8 @@ import java.util.concurrent.TimeUnit;
  *     info about the benchmark</li>
  * </ol>
  */
-public class BenchmarkParams extends BenchmarkParamsL4 {
+public class BenchmarkParams extends BenchmarkParamsL3 {
     private static final long serialVersionUID = -1068219503090299117L;
-
-    /**
-     * Do the class hierarchy trick to evade false sharing, and check if it's working in runtime.
-     * @see org.openjdk.jmh.infra.Blackhole description for the rationale
-     */
-    static {
-        Utils.check(BenchmarkParams.class, "benchmark", "generatedTarget", "synchIterations");
-        Utils.check(BenchmarkParams.class, "threads", "threadGroups", "forks", "warmupForks");
-        Utils.check(BenchmarkParams.class, "warmup", "measurement");
-        Utils.check(BenchmarkParams.class, "mode", "params");
-        Utils.check(BenchmarkParams.class, "timeUnit", "opsPerInvocation");
-        Utils.check(BenchmarkParams.class, "jvm", "jvmArgs");
-    }
 
     public BenchmarkParams(String benchmark, String generatedTarget, boolean synchIterations,
                            int threads, int[] threadGroups, Collection<String> threadGroupLabels,
@@ -75,31 +62,6 @@ public class BenchmarkParams extends BenchmarkParamsL4 {
                            String jvm, Collection<String> jvmArgs,
                            String jdkVersion, String vmName, String vmVersion, String jmhVersion,
                            TimeValue timeout) {
-        super(benchmark, generatedTarget, synchIterations,
-                threads, threadGroups, threadGroupLabels,
-                forks, warmupForks,
-                warmup, measurement,
-                mode, params,
-                timeUnit, opsPerInvocation,
-                jvm, jvmArgs,
-                jdkVersion, vmName, vmVersion, jmhVersion,
-                timeout);
-    }
-}
-
-abstract class BenchmarkParamsL4 extends BenchmarkParamsL3 {
-    private static final long serialVersionUID = -2409216922027695385L;
-
-    private int markerEnd;
-    public BenchmarkParamsL4(String benchmark, String generatedTarget, boolean synchIterations,
-                             int threads, int[] threadGroups, Collection<String> threadGroupLabels,
-                             int forks, int warmupForks,
-                             IterationParams warmup, IterationParams measurement,
-                             Mode mode, WorkloadParams params,
-                             TimeUnit timeUnit, int opsPerInvocation,
-                             String jvm, Collection<String> jvmArgs,
-                             String jdkVersion, String vmName, String vmVersion, String jmhVersion,
-                             TimeValue timeout) {
         super(benchmark, generatedTarget, synchIterations,
                 threads, threadGroups, threadGroupLabels,
                 forks, warmupForks,
@@ -153,7 +115,7 @@ abstract class BenchmarkParamsL3 extends BenchmarkParamsL2 {
     }
 }
 
-abstract class BenchmarkParamsL1 extends BenchmarkParamsL0 {
+abstract class BenchmarkParamsL1 {
     private boolean p001, p002, p003, p004, p005, p006, p007, p008;
     private boolean p011, p012, p013, p014, p015, p016, p017, p018;
     private boolean p021, p022, p023, p024, p025, p026, p027, p028;
@@ -172,11 +134,7 @@ abstract class BenchmarkParamsL1 extends BenchmarkParamsL0 {
     private boolean p171, p172, p173, p174, p175, p176, p177, p178;
 }
 
-abstract class BenchmarkParamsL0 {
-    private int markerBegin;
-}
-
-abstract class BenchmarkParamsL2 extends BenchmarkParamsL1 implements Serializable, Comparable<BenchmarkParams> {
+abstract class BenchmarkParamsL2 implements Serializable, Comparable<BenchmarkParams> {
     private static final long serialVersionUID = -1068219503090299117L;
 
     protected final String benchmark;

--- a/jmh-core/src/main/java/org/openjdk/jmh/infra/Blackhole.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/infra/Blackhole.java
@@ -35,11 +35,7 @@ import java.util.Random;
     See the rationale for BlackholeL1..BlackholeL4 classes below.
  */
 
-abstract class BlackholeL0 {
-    private int markerBegin;
-}
-
-abstract class BlackholeL1 extends BlackholeL0 {
+abstract class BlackholeL1 {
     private boolean p001, p002, p003, p004, p005, p006, p007, p008;
     private boolean p011, p012, p013, p014, p015, p016, p017, p018;
     private boolean p021, p022, p023, p024, p025, p026, p027, p028;
@@ -141,10 +137,6 @@ abstract class BlackholeL3 extends BlackholeL2 {
     private boolean q171, q172, q173, q174, q175, q176, q177, q178;
 }
 
-abstract class BlackholeL4 extends BlackholeL3 {
-    private int markerEnd;
-}
-
 /**
  * Black Hole.
  *
@@ -152,7 +144,7 @@ abstract class BlackholeL4 extends BlackholeL3 {
  * value is actually used afterwards. This can save from the dead-code elimination
  * of the computations resulting in the given values.</p>
  */
-public final class Blackhole extends BlackholeL4 {
+public final class Blackhole extends BlackholeL3 {
 
     /*
      * IMPLEMENTATION NOTES:
@@ -261,16 +253,6 @@ public final class Blackhole extends BlackholeL4 {
                 return Boolean.getBoolean("compilerBlackholesEnabled");
             }
         });
-
-        Utils.check(Blackhole.class, "b1", "b2");
-        Utils.check(Blackhole.class, "bool1", "bool2");
-        Utils.check(Blackhole.class, "c1", "c2");
-        Utils.check(Blackhole.class, "s1", "s2");
-        Utils.check(Blackhole.class, "i1", "i2");
-        Utils.check(Blackhole.class, "l1", "l2");
-        Utils.check(Blackhole.class, "f1", "f2");
-        Utils.check(Blackhole.class, "d1", "d2");
-        Utils.check(Blackhole.class, "obj1");
     }
 
     public Blackhole(String challengeResponse) {

--- a/jmh-core/src/main/java/org/openjdk/jmh/infra/Control.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/infra/Control.java
@@ -30,23 +30,10 @@ import org.openjdk.jmh.util.Utils;
  * Control object, used to communicate significant information from JMH to the benchmark.
  * WARNING: The API for this class is considered unstable, and can be changed without notice.
  */
-public final class Control extends ControlL4 {
-
-    /**
-     * Do the class hierarchy trick to evade false sharing, and check if it's working in runtime.
-     * @see org.openjdk.jmh.infra.Blackhole description for the rationale
-     */
-    static {
-        Utils.check(Control.class, "startMeasurement", "stopMeasurement");
-    }
-
+public final class Control extends ControlL3 {
 }
 
-abstract class ControlL0 {
-    private int markerBegin;
-}
-
-abstract class ControlL1 extends ControlL0 {
+abstract class ControlL1 {
     private boolean p001, p002, p003, p004, p005, p006, p007, p008;
     private boolean p011, p012, p013, p014, p015, p016, p017, p018;
     private boolean p021, p022, p023, p024, p025, p026, p027, p028;
@@ -97,8 +84,3 @@ abstract class ControlL3 extends ControlL2 {
     private boolean q161, q162, q163, q164, q165, q166, q167, q168;
     private boolean q171, q172, q173, q174, q175, q176, q177, q178;
 }
-
-abstract class ControlL4 extends ControlL3 {
-    private int markerEnd;
-}
-

--- a/jmh-core/src/main/java/org/openjdk/jmh/infra/IterationParams.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/infra/IterationParams.java
@@ -45,27 +45,13 @@ import java.util.Objects;
  *     info about the benchmark</li>
  * </ol>
  */
-public final class IterationParams extends IterationParamsL4 {
+public final class IterationParams extends IterationParamsL3 {
     private static final long serialVersionUID = -8111111319033802892L;
-
-    static {
-        Utils.check(IterationParams.class, "type", "count", "timeValue", "batchSize");
-    }
 
     public IterationParams(IterationType type, int count, TimeValue time, int batchSize) {
         super(type, count, time, batchSize);
     }
 }
-
-abstract class IterationParamsL4 extends IterationParamsL3 {
-    private static final long serialVersionUID = 9079354621906758255L;
-
-    private int markerEnd;
-    public IterationParamsL4(IterationType type, int count, TimeValue time, int batchSize) {
-        super(type, count, time, batchSize);
-    }
-}
-
 abstract class IterationParamsL3 extends IterationParamsL2 {
     private static final long serialVersionUID = 3907464940104879178L;
 

--- a/jmh-core/src/main/java/org/openjdk/jmh/infra/ThreadParams.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/infra/ThreadParams.java
@@ -33,19 +33,11 @@ import org.openjdk.jmh.util.Utils;
  * not limited to the number of threads, thread indicies, group information, etc. Some
  * of that info duplicates what is available in {@link org.openjdk.jmh.infra.BenchmarkParams}.</p>
  */
-public final class ThreadParams extends ThreadParamsL4 {
+public final class ThreadParams extends ThreadParamsL3 {
     public ThreadParams(int threadIdx, int threadCount, int groupIdx, int groupCount, int subgroupIdx, int subgroupCount,
                         int groupThreadIdx, int groupThreadCount, int subgroupThreadIdx, int subgroupThreadCount) {
         super(threadIdx, threadCount, groupIdx, groupCount, subgroupIdx, subgroupCount,
                 groupThreadIdx, groupThreadCount, subgroupThreadIdx, subgroupThreadCount);
-    }
-
-    static {
-        Utils.check(ThreadParams.class, "threadIdx", "threadCount");
-        Utils.check(ThreadParams.class, "groupIdx", "groupCount");
-        Utils.check(ThreadParams.class, "subgroupIdx", "subgroupCount");
-        Utils.check(ThreadParams.class, "groupThreadIdx", "groupThreadCount");
-        Utils.check(ThreadParams.class, "subgroupThreadIdx", "subgroupThreadCount");
     }
 
     /**
@@ -200,11 +192,7 @@ public final class ThreadParams extends ThreadParamsL4 {
 
 }
 
-abstract class ThreadParamsL0 {
-    private int markerBegin;
-}
-
-abstract class ThreadParamsL1 extends ThreadParamsL0 {
+abstract class ThreadParamsL1 {
     private boolean p001, p002, p003, p004, p005, p006, p007, p008;
     private boolean p011, p012, p013, p014, p015, p016, p017, p018;
     private boolean p021, p022, p023, p024, p025, p026, p027, p028;
@@ -264,16 +252,6 @@ abstract class ThreadParamsL3 extends ThreadParamsL2 {
     private boolean q171, q172, q173, q174, q175, q176, q177, q178;
 
     public ThreadParamsL3(int threadIdx, int threadCount, int groupIdx, int groupCount, int subgroupIdx, int subgroupCount,
-                          int groupThreadIdx, int groupThreadCount, int subgroupThreadIdx, int subgroupThreadCount) {
-        super(threadIdx, threadCount, groupIdx, groupCount, subgroupIdx, subgroupCount,
-                groupThreadIdx, groupThreadCount, subgroupThreadIdx, subgroupThreadCount);
-    }
-}
-
-abstract class ThreadParamsL4 extends ThreadParamsL3 {
-    private int markerEnd;
-
-    public ThreadParamsL4(int threadIdx, int threadCount, int groupIdx, int groupCount, int subgroupIdx, int subgroupCount,
                           int groupThreadIdx, int groupThreadCount, int subgroupThreadIdx, int subgroupThreadCount) {
         super(threadIdx, threadCount, groupIdx, groupCount, subgroupIdx, subgroupCount,
                 groupThreadIdx, groupThreadCount, subgroupThreadIdx, subgroupThreadCount);

--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/InfraControl.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/InfraControl.java
@@ -37,25 +37,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * The InfraControl logic class.
  * This is the rendezvous class for benchmark handler and JMH.
  */
-public class InfraControl extends InfraControlL4 {
-
-    /**
-     * Do the class hierarchy trick to evade false sharing, and check if it's working in runtime.
-     * @see org.openjdk.jmh.infra.Blackhole description for the rationale
-     */
-    static {
-        Utils.check(InfraControl.class, "isDone", "isFailing");
-        Utils.check(InfraControl.class, "volatileSpoiler");
-        Utils.check(InfraControl.class, "preSetup", "preTearDown");
-        Utils.check(InfraControl.class, "firstIteration");
-        Utils.check(InfraControl.class, "lastIteration");
-        Utils.check(InfraControl.class, "shouldYield");
-        Utils.check(InfraControl.class, "warmupVisited", "warmdownVisited");
-        Utils.check(InfraControl.class, "warmupShouldWait", "warmdownShouldWait");
-        Utils.check(InfraControl.class, "warmupDone", "warmdownDone");
-        Utils.check(InfraControl.class, "benchmarkParams", "iterationParams");
-        Utils.check(InfraControl.class, "shouldSynchIterations", "threads");
-    }
+public class InfraControl extends InfraControlL3 {
 
     public InfraControl(BenchmarkParams benchmarkParams, IterationParams iterationParams,
                         CountDownLatch preSetup, CountDownLatch preTearDown,
@@ -125,11 +107,7 @@ public class InfraControl extends InfraControlL4 {
 
 }
 
-abstract class InfraControlL0 {
-    private int markerBegin;
-}
-
-abstract class InfraControlL1 extends InfraControlL0 {
+abstract class InfraControlL1 {
     private boolean p001, p002, p003, p004, p005, p006, p007, p008;
     private boolean p011, p012, p013, p014, p015, p016, p017, p018;
     private boolean p021, p022, p023, p024, p025, p026, p027, p028;
@@ -292,16 +270,3 @@ abstract class InfraControlL3 extends InfraControlL2 {
         super(benchmarkParams, iterationParams, preSetup, preTearDown, firstIteration, lastIteration, shouldYield, notifyControl);
     }
 }
-
-abstract class InfraControlL4 extends InfraControlL3 {
-    private int markerEnd;
-
-    public InfraControlL4(BenchmarkParams benchmarkParams, IterationParams iterationParams,
-                          CountDownLatch preSetup, CountDownLatch preTearDown,
-                          boolean firstIteration, boolean lastIteration,
-                          boolean shouldYield,
-                          Control notifyControl) {
-        super(benchmarkParams, iterationParams, preSetup, preTearDown, firstIteration, lastIteration, shouldYield, notifyControl);
-    }
-}
-

--- a/jmh-core/src/main/java/org/openjdk/jmh/util/Utils.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/util/Utils.java
@@ -38,18 +38,6 @@ import java.util.concurrent.*;
 
 public class Utils {
 
-    private static final Unsafe U;
-
-    static {
-        try {
-            Field unsafe = Unsafe.class.getDeclaredField("theUnsafe");
-            unsafe.setAccessible(true);
-            U = (Unsafe) unsafe.get(null);
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            throw new IllegalStateException(e);
-        }
-    }
-
     private Utils() {
 
     }
@@ -358,35 +346,6 @@ public class Utils {
         public void run() {
             while (!Thread.interrupted()); // burn;
         }
-    }
-
-    public static void check(Class<?> klass, String... fieldNames) {
-        for (String fieldName : fieldNames) {
-            check(klass, fieldName);
-        }
-    }
-
-    public static void check(Class<?> klass, String fieldName) {
-        final long requiredGap = 128;
-        long markerBegin = getOffset(klass, "markerBegin");
-        long markerEnd = getOffset(klass, "markerEnd");
-        long off = getOffset(klass, fieldName);
-        if (markerEnd - off < requiredGap || off - markerBegin < requiredGap) {
-            throw new IllegalStateException("Consistency check failed for " + fieldName + ", off = " + off + ", markerBegin = " + markerBegin + ", markerEnd = " + markerEnd);
-        }
-    }
-
-    public static long getOffset(Class<?> klass, String fieldName) {
-        do {
-            try {
-                Field f = klass.getDeclaredField(fieldName);
-                return U.objectFieldOffset(f);
-            } catch (NoSuchFieldException e) {
-                // whatever, will try superclass
-            }
-            klass = klass.getSuperclass();
-        } while (klass != null);
-        throw new IllegalStateException("Can't find field \"" + fieldName + "\"");
     }
 
     public static boolean isWindows() {


### PR DESCRIPTION
This is printed for every benchmark running with JDK 24 now:

```
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by org.openjdk.jmh.util.Utils (file:/Users/shipilev/Work/shipilev-jmh/jmh-samples/target/benchmarks.jar)
WARNING: Please consider reporting this to the maintainers of class org.openjdk.jmh.util.Utils
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
```

These have not failed for a long time, so we can just trust the padding works. This will also avoid running some of this checking code during benchmark execution, adding to benchmark accuracy.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903898](https://bugs.openjdk.org/browse/CODETOOLS-7903898): JMH: Unsafe deprecation warnings are printed in JDK 24 (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/140/head:pull/140` \
`$ git checkout pull/140`

Update a local copy of the PR: \
`$ git checkout pull/140` \
`$ git pull https://git.openjdk.org/jmh.git pull/140/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 140`

View PR using the GUI difftool: \
`$ git pr show -t 140`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/140.diff">https://git.openjdk.org/jmh/pull/140.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/140#issuecomment-2521260052)
</details>
