### PR TITLE
7903903: JMH: Tighten up generated code density

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/generators/core/BenchmarkGenerator.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/generators/core/BenchmarkGenerator.java
@@ -464,7 +464,6 @@ public class BenchmarkGenerator {
         writer.println(ident(1) + "static final String BLACKHOLE_CHALLENGE = \"Should not be calling this.\";");
         writer.println();
 
-        writer.println(ident(1) + "int startRndMask;");
         writer.println(ident(1) + "BenchmarkParams benchmarkParams;");
         writer.println(ident(1) + "IterationParams iterationParams;");
         writer.println(ident(1) + "ThreadParams threadParams;");
@@ -809,13 +808,13 @@ public class BenchmarkGenerator {
     }
 
     private String getStubArgs() {
-        return "control, res, benchmarkParams, iterationParams, threadParams, blackhole, notifyControl, startRndMask";
+        return "control, res, benchmarkParams, iterationParams, threadParams, blackhole, notifyControl";
     }
 
     private String getStubTypeArgs() {
         return "InfraControl control, RawResults result, " +
                 "BenchmarkParams benchmarkParams, IterationParams iterationParams, ThreadParams threadParams, " +
-                "Blackhole blackhole, Control notifyControl, int startRndMask";
+                "Blackhole blackhole, Control notifyControl";
     }
 
     private void methodProlog(PrintWriter writer) {
@@ -876,7 +875,7 @@ public class BenchmarkGenerator {
             writer.println(ident(3) + "notifyControl.startMeasurement = true;");
 
             // measurement loop call
-            writer.println(ident(3) + "int targetSamples = (int) (control.getDuration(TimeUnit.MILLISECONDS) * 20); // at max, 20 timestamps per millisecond");
+            writer.println(ident(3) + "int targetSamples = control.getDurationMs() * 20;");
             writer.println(ident(3) + "int batchSize = iterationParams.getBatchSize();");
             writer.println(ident(3) + "int opsPerInv = benchmarkParams.getOpsPerInvocation();");
             writer.println(ident(3) + "SampleBuffer buffer = new SampleBuffer();");
@@ -952,7 +951,7 @@ public class BenchmarkGenerator {
             writer.println(ident(2) + "long realTime = 0;");
             writer.println(ident(2) + "long operations = 0;");
             writer.println(ident(2) + "int rnd = (int)System.nanoTime();");
-            writer.println(ident(2) + "int rndMask = startRndMask;");
+            writer.println(ident(2) + "int rndMask = 0;");
             writer.println(ident(2) + "long time = 0;");
             writer.println(ident(2) + "int currentStride = 0;");
             writer.println(ident(2) + "do {");
@@ -967,7 +966,7 @@ public class BenchmarkGenerator {
 
             writer.println(ident(3) + "for (int b = 0; b < batchSize; b++) {");
             writer.println(ident(4) + "if (control.volatileSpoiler) return;");
-            writer.println(ident(4) + "" + emitCall(method, states) + ';');
+            writer.println(ident(4) + emitCall(method, states) + ';');
             writer.println(ident(3) + "}");
 
             writer.println(ident(3) + "if (sample) {");
@@ -983,7 +982,6 @@ public class BenchmarkGenerator {
 
             writer.println(ident(3) + "operations++;");
             writer.println(ident(2) + "} while(!control.isDone);");
-            writer.println(ident(2) + "startRndMask = Math.max(startRndMask, rndMask);");
 
             writer.println(ident(2) + "result.realTime = realTime;");
             writer.println(ident(2) + "result.measuredOps = operations;");

--- a/jmh-core/src/main/java/org/openjdk/jmh/generators/core/BenchmarkGenerator.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/generators/core/BenchmarkGenerator.java
@@ -474,8 +474,8 @@ public class BenchmarkGenerator {
         writer.println(ident(1) + "void init(InfraControl control, ThreadParams tp) {");
         writer.println(ident(2) + "benchmarkParams = control.benchmarkParams;");
         writer.println(ident(2) + "iterationParams = control.iterationParams;");
-        writer.println(ident(2) + "threadParams    = tp;");
-        writer.println(ident(2) + "notifyControl   = control.notifyControl;");
+        writer.println(ident(2) + "notifyControl = control.notifyControl;");
+        writer.println(ident(2) + "threadParams = tp;");
         writer.println(ident(2) + "if (blackhole == null) {");
         writer.println(ident(3) + "blackhole = new Blackhole(BLACKHOLE_CHALLENGE);");
         writer.println(ident(2) + "}");

--- a/jmh-core/src/main/java/org/openjdk/jmh/generators/core/BenchmarkGenerator.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/generators/core/BenchmarkGenerator.java
@@ -37,7 +37,6 @@ import java.io.*;
 import java.lang.reflect.Field;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Benchmark generator.
@@ -511,19 +510,12 @@ public class BenchmarkGenerator {
 
     private void generateImport(PrintWriter writer) {
         Class<?>[] imports = new Class<?>[]{
-                List.class, AtomicInteger.class,
-                Collection.class, ArrayList.class,
-                TimeUnit.class, CompilerControl.class,
-                InfraControl.class, ThreadParams.class,
-                BenchmarkTaskResult.class,
+                InfraControl.class, BenchmarkParams.class, IterationParams.class, ThreadParams.class,
+                Blackhole.class, Control.class, BenchmarkTaskResult.class, RawResults.class, ResultRole.class,
+                SampleBuffer.class, Field.class, FailureAssistException.class,
                 Result.class, ThroughputResult.class, AverageTimeResult.class,
-                SampleTimeResult.class, SingleShotResult.class, SampleBuffer.class,
-                Mode.class, Fork.class, Measurement.class, Threads.class, Warmup.class,
-                BenchmarkMode.class, RawResults.class, ResultRole.class,
-                Field.class, BenchmarkParams.class, IterationParams.class,
-                Blackhole.class, Control.class,
-                ScalarResult.class, AggregationPolicy.class,
-                FailureAssistException.class
+                SampleTimeResult.class, SingleShotResult.class,
+                ScalarResult.class, AggregationPolicy.class
         };
 
         for (Class<?> c : imports) {

--- a/jmh-core/src/main/java/org/openjdk/jmh/generators/core/BenchmarkGenerator.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/generators/core/BenchmarkGenerator.java
@@ -457,30 +457,14 @@ public class BenchmarkGenerator {
         writer.println("public final class " + info.generatedClassName + " {");
         writer.println();
 
-        // generate padding
+        // Generate padding
         Paddings.padding(writer, "p");
         writer.println();
-        writer.println(ident(1) + "static final String BLACKHOLE_CHALLENGE = \"Should not be calling this.\";");
-        writer.println();
 
-        // Shared fields and their initializations.
-        writer.println(ident(1) + "BenchmarkParams benchmarkParams;");
-        writer.println(ident(1) + "IterationParams iterationParams;");
-        writer.println(ident(1) + "ThreadParams threadParams;");
-        writer.println(ident(1) + "Blackhole blackhole;");
-        writer.println(ident(1) + "Control notifyControl;");
-        writer.println();
-        writer.println(ident(1) + "void init(InfraControl control, ThreadParams tp) {");
-        writer.println(ident(2) + "benchmarkParams = control.benchmarkParams;");
-        writer.println(ident(2) + "iterationParams = control.iterationParams;");
-        writer.println(ident(2) + "notifyControl = control.notifyControl;");
-        writer.println(ident(2) + "threadParams = tp;");
-        writer.println(ident(2) + "if (blackhole == null) {");
-        writer.println(ident(3) + "blackhole = new Blackhole(BLACKHOLE_CHALLENGE);");
-        writer.println(ident(2) + "}");
-        writer.println(ident(1) + "}");
+        // Write shared fields and their initializations
+        generateSharedFields(writer);
 
-        // write all methods
+        // Write all methods
         for (Mode benchmarkKind : Mode.values()) {
             if (benchmarkKind == Mode.All) continue;
             generateMethod(benchmarkKind, writer, info.methodGroup, states);
@@ -522,6 +506,26 @@ public class BenchmarkGenerator {
             writer.println("import " + c.getName() + ';');
         }
         writer.println();
+    }
+
+    private void generateSharedFields(PrintWriter writer) {
+        writer.println(ident(1) + "static final String BLACKHOLE_CHALLENGE = \"Should not be calling this.\";");
+        writer.println();
+        writer.println(ident(1) + "BenchmarkParams benchmarkParams;");
+        writer.println(ident(1) + "IterationParams iterationParams;");
+        writer.println(ident(1) + "ThreadParams threadParams;");
+        writer.println(ident(1) + "Blackhole blackhole;");
+        writer.println(ident(1) + "Control notifyControl;");
+        writer.println();
+        writer.println(ident(1) + "void init(InfraControl control, ThreadParams tp) {");
+        writer.println(ident(2) + "benchmarkParams = control.benchmarkParams;");
+        writer.println(ident(2) + "iterationParams = control.iterationParams;");
+        writer.println(ident(2) + "notifyControl = control.notifyControl;");
+        writer.println(ident(2) + "threadParams = tp;");
+        writer.println(ident(2) + "if (blackhole == null) {");
+        writer.println(ident(3) + "blackhole = new Blackhole(BLACKHOLE_CHALLENGE);");
+        writer.println(ident(2) + "}");
+        writer.println(ident(1) + "}");
     }
 
     /**

--- a/jmh-core/src/main/java/org/openjdk/jmh/generators/core/BenchmarkGenerator.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/generators/core/BenchmarkGenerator.java
@@ -464,11 +464,22 @@ public class BenchmarkGenerator {
         writer.println(ident(1) + "static final String BLACKHOLE_CHALLENGE = \"Should not be calling this.\";");
         writer.println();
 
+        // Shared fields and their initializations.
         writer.println(ident(1) + "BenchmarkParams benchmarkParams;");
         writer.println(ident(1) + "IterationParams iterationParams;");
         writer.println(ident(1) + "ThreadParams threadParams;");
         writer.println(ident(1) + "Blackhole blackhole;");
         writer.println(ident(1) + "Control notifyControl;");
+        writer.println();
+        writer.println(ident(1) + "void init(InfraControl control, ThreadParams tp) {");
+        writer.println(ident(2) + "benchmarkParams = control.benchmarkParams;");
+        writer.println(ident(2) + "iterationParams = control.iterationParams;");
+        writer.println(ident(2) + "threadParams    = tp;");
+        writer.println(ident(2) + "notifyControl   = control.notifyControl;");
+        writer.println(ident(2) + "if (blackhole == null) {");
+        writer.println(ident(3) + "blackhole = new Blackhole(BLACKHOLE_CHALLENGE);");
+        writer.println(ident(2) + "}");
+        writer.println(ident(1) + "}");
 
         // write all methods
         for (Mode benchmarkKind : Mode.values()) {
@@ -818,18 +829,11 @@ public class BenchmarkGenerator {
     }
 
     private void methodProlog(PrintWriter writer) {
-        // do nothing
-        writer.println(ident(2) + "this.benchmarkParams = control.benchmarkParams;");
-        writer.println(ident(2) + "this.iterationParams = control.iterationParams;");
-        writer.println(ident(2) + "this.threadParams    = threadParams;");
-        writer.println(ident(2) + "this.notifyControl   = control.notifyControl;");
-        writer.println(ident(2) + "if (this.blackhole == null) {");
-        writer.println(ident(3) + "this.blackhole = new Blackhole(BLACKHOLE_CHALLENGE);");
-        writer.println(ident(2) + "}");
+        writer.println(ident(2) + "init(control, threadParams);");
     }
 
     private void methodEpilog(PrintWriter writer) {
-        writer.println(ident(3) + "this.blackhole.evaporate(BLACKHOLE_CHALLENGE);");
+        writer.println(ident(3) + "blackhole.evaporate(BLACKHOLE_CHALLENGE);");
     }
 
     private String prefix(String argList) {

--- a/jmh-core/src/main/java/org/openjdk/jmh/generators/core/StateObjectHandler.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/generators/core/StateObjectHandler.java
@@ -709,7 +709,7 @@ class StateObjectHandler {
                 result.add("    while (" + so.type + ".tear" + helperLevel + "MutexUpdater.get(" + so.localIdentifier + ") == 1) {");
 
                 if (helperLevel == Level.Trial) {
-                    result.add("        TimeUnit.MILLISECONDS.sleep(" + so.localIdentifier + "_backoff);");
+                    result.add("        Thread.sleep(" + so.localIdentifier + "_backoff);");
                     result.add("        " + so.localIdentifier + "_backoff = Math.max(1024, " + so.localIdentifier + "_backoff * 2);");
                 }
 

--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/InfraControl.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/InfraControl.java
@@ -51,7 +51,7 @@ public class InfraControl extends InfraControlL3 {
      * @return requested loop duration in milliseconds.
      */
     public int getDurationMs() {
-        long ms = getDurationMs(TimeUnit.MILLISECONDS);
+        long ms = getDuration(TimeUnit.MILLISECONDS);
         int ims = (int) ms;
         if (ms != ims) {
             throw new IllegalStateException("Integer truncation problem");
@@ -63,7 +63,7 @@ public class InfraControl extends InfraControlL3 {
      * @param unit timeunit to use
      * @return requested loop duration in the requested unit.
      */
-    public long getDurationMs(TimeUnit unit) {
+    public long getDuration(TimeUnit unit) {
         return iterationParams.getTime().convertTo(unit);
     }
 

--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/InfraControl.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/InfraControl.java
@@ -50,15 +50,20 @@ public class InfraControl extends InfraControlL3 {
     /**
      * @return requested loop duration in milliseconds.
      */
-    public long getDuration() {
-        return getDuration(TimeUnit.MILLISECONDS);
+    public int getDurationMs() {
+        long ms = getDurationMs(TimeUnit.MILLISECONDS);
+        int ims = (int) ms;
+        if (ms != ims) {
+            throw new IllegalStateException("Integer truncation problem");
+        }
+        return ims;
     }
 
     /**
      * @param unit timeunit to use
      * @return requested loop duration in the requested unit.
      */
-    public long getDuration(TimeUnit unit) {
+    public long getDurationMs(TimeUnit unit) {
         return iterationParams.getTime().convertTo(unit);
     }
 


### PR DESCRIPTION
Part of [JDK-8345302](https://bugs.openjdk.org/browse/JDK-8345302), we want to generate denser scaffolding code. This is an umbrella task to tighten up the generated code without heavy restructuring.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903903](https://bugs.openjdk.org/browse/CODETOOLS-7903903): JMH: Tighten up generated code density (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/142/head:pull/142` \
`$ git checkout pull/142`

Update a local copy of the PR: \
`$ git checkout pull/142` \
`$ git pull https://git.openjdk.org/jmh.git pull/142/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 142`

View PR using the GUI difftool: \
`$ git pr show -t 142`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/142.diff">https://git.openjdk.org/jmh/pull/142.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/142#issuecomment-2532203941)
</details>
