### PR TITLE
7903908: JMH: Helpful message when benchmark builds are misconfigured

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/AbstractResourceReader.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/AbstractResourceReader.java
@@ -24,6 +24,8 @@
  */
 package org.openjdk.jmh.runner;
 
+import org.openjdk.jmh.util.FileUtils;
+
 import java.io.*;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -58,49 +60,54 @@ class AbstractResourceReader {
             try {
                 return Collections.<Reader>singletonList(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8));
             } catch (FileNotFoundException e) {
-                throw new RuntimeException("ERROR: Could not find resource", e);
+                internalError("Could not find " + file, e);
             }
         }
 
         if (resource != null) {
-            Enumeration<URL> urls;
+            List<Reader> readers = new ArrayList<>();
             try {
-                urls = getClass().getClassLoader().getResources(
-                        resource.startsWith("/")
-                                ? resource.substring(1)
-                                : resource
-                );
-            } catch (IOException e) {
-                throw new RuntimeException("ERROR: While obtaining resource: " + resource, e);
-            }
-
-            if (urls.hasMoreElements()) {
-                List<Reader> readers = new ArrayList<>();
-                URL url = null;
-                try {
-                    while (urls.hasMoreElements()) {
-                        url = urls.nextElement();
-                        InputStream stream = url.openStream();
-                        readers.add(new InputStreamReader(stream, StandardCharsets.UTF_8));
-                    }
-                } catch (IOException e) {
-                    for (Reader r : readers) {
-                        try {
-                            r.close();
-                        } catch (IOException e1) {
-                            // ignore
-                        }
-                    }
-                    throw new RuntimeException("ERROR: While opening resource: " + url, e);
+                String name = resource.startsWith("/") ? resource.substring(1) : resource;
+                Enumeration<URL> urls = getClass().getClassLoader().getResources(name);
+                while (urls.hasMoreElements()) {
+                   URL url = urls.nextElement();
+                   InputStream stream = url.openStream();
+                   readers.add(new InputStreamReader(stream, StandardCharsets.UTF_8));
                 }
-                return readers;
-            } else {
-                throw new RuntimeException("ERROR: Unable to find the resource: " + resource);
+            } catch (IOException e) {
+                internalError("Unable to find " + resource, e);
+                for (Reader r : readers) {
+                    FileUtils.safelyClose(r);
+                }
             }
+            if (readers.isEmpty()) {
+                internalError("Unable to find " + resource, null);
+            }
+            return readers;
         }
 
         throw new IllegalStateException();
     }
 
+    protected void internalError(String msg, Exception e) {
+        String guidance = "Internal error reading resource file: " + msg + "\n\n" +
+                "This often indicates a build configuration problem. Common causes are:\n\n" +
+                " 1. Annotation processing is not enabled or configured incorrectly.\n\n" +
+                "    Note that JDK 23+ disables running annotation processors by default,\n" +
+                "    which affects projects that used to build fine with older JDKs.\n" +
+                "    Check if you need to add a relevant option to your compiler plugin.\n\n" +
+                "    For example, maven-compiler-plugin can be configured like this:\n" +
+                "        <configuration>\n" +
+                "           <annotationProcessors>\n" +
+                "              <annotationProcessor>org.openjdk.jmh.generators.BenchmarkProcessor</annotationProcessor>\n" +
+                "           </annotationProcessors>\n" +
+                "        </configuration>\n" +
+                "\n" +
+                " 2. Multi-module benchmark builds have not merged the resource files.\n\n" +
+                "    Check if you need to add a relevant config to your build.\n\n" +
+                "    For example, maven-shade-plugin needs to explicitly enable resource transformers:\n" +
+                "       https://maven.apache.org/plugins/maven-shade-plugin/examples/resource-transformers.html\n\n";
+        throw new RuntimeException(guidance, e);
+    }
 
 }


### PR DESCRIPTION
When JMH benchmark project is misconfigured, the runner would print an unhelpful error like:

```
Exception in thread "main" java.lang.RuntimeException: ERROR: Unable to find the resource: /META-INF/BenchmarkList
at org.openjdk.jmh.runner.AbstractResourceReader.getReaders(AbstractResourceReader.java:98)
at org.openjdk.jmh.runner.BenchmarkList.find(BenchmarkList.java:124)
at org.openjdk.jmh.runner.Runner.internalRun(Runner.java:252)
at org.openjdk.jmh.runner.Runner.run(Runner.java:208)
at org.openjdk.jmh.Main.main(Main.java:71)
```

This is especially often when JDK 23 disabled annotation processors by default. We need to print more helpful message to guide users to resolution.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903908](https://bugs.openjdk.org/browse/CODETOOLS-7903908): JMH: Helpful message when benchmark builds are misconfigured (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/143/head:pull/143` \
`$ git checkout pull/143`

Update a local copy of the PR: \
`$ git checkout pull/143` \
`$ git pull https://git.openjdk.org/jmh.git pull/143/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 143`

View PR using the GUI difftool: \
`$ git pr show -t 143`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/143.diff">https://git.openjdk.org/jmh/pull/143.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/143#issuecomment-2538764739)
</details>
