### PR TITLE
7903641: JMH: Rework samples to avoid excess double and volatile cases

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/util/Utils.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/util/Utils.java
@@ -24,8 +24,6 @@
  */
 package org.openjdk.jmh.util;
 
-import sun.misc.Unsafe;
-
 import java.io.*;
 import java.lang.management.ManagementFactory;
 import java.lang.reflect.AccessibleObject;

--- a/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_03_States.java
+++ b/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_03_States.java
@@ -30,14 +30,16 @@
  */
 package org.openjdk.jmh.samples;
 
-import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
 public class JMHSample_03_States {
 
     /*
@@ -57,19 +59,19 @@ public class JMHSample_03_States {
 
     @State(Scope.Benchmark)
     public static class BenchmarkState {
-        volatile double x = Math.PI;
+        int x;
     }
 
     @State(Scope.Thread)
     public static class ThreadState {
-        volatile double x = Math.PI;
+        int x;
     }
 
     /*
      * Benchmark methods can reference the states, and JMH will inject the
      * appropriate states while calling these methods. You can have no states at
      * all, or have only one state, or have multiple states referenced. This
-     * makes building multi-threaded benchmark a breeze.
+     * simplifies building multithreaded benchmarks.
      *
      * For this exercise, we have two methods.
      */
@@ -79,7 +81,7 @@ public class JMHSample_03_States {
         // All benchmark threads will call in this method.
         //
         // However, since ThreadState is the Scope.Thread, each thread
-        // will have it's own copy of the state, and this benchmark
+        // will have its own copy of the state, and this benchmark
         // will measure unshared case.
         state.x++;
     }

--- a/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_04_DefaultState.java
+++ b/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_04_DefaultState.java
@@ -30,13 +30,13 @@
  */
 package org.openjdk.jmh.samples;
 
-import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.concurrent.TimeUnit;
 
 /*
  * Fortunately, in many cases you just need a single state object.
@@ -45,10 +45,12 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
  * Java program does.
  */
 
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
 public class JMHSample_04_DefaultState {
 
-    double x = Math.PI;
+    int x;
 
     @Benchmark
     public void measure() {

--- a/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_05_StateFixtures.java
+++ b/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_05_StateFixtures.java
@@ -36,10 +36,14 @@ import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
 public class JMHSample_05_StateFixtures {
 
-    double x;
+    int x;
 
     /*
      * Since @State objects are kept around during the lifetime of the
@@ -66,7 +70,7 @@ public class JMHSample_05_StateFixtures {
 
     @Setup
     public void prepare() {
-        x = Math.PI;
+        x = 1;
     }
 
     /*
@@ -75,7 +79,7 @@ public class JMHSample_05_StateFixtures {
 
     @TearDown
     public void check() {
-        assert x > Math.PI : "Nothing changed?";
+        assert x > 1 : "Nothing changed?";
     }
 
     /*
@@ -97,7 +101,7 @@ public class JMHSample_05_StateFixtures {
 
     @Benchmark
     public void measureWrong() {
-        double x = 0;
+        int x = 0;
         x++;
     }
 

--- a/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_06_FixtureLevel.java
+++ b/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_06_FixtureLevel.java
@@ -36,10 +36,14 @@ import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
 public class JMHSample_06_FixtureLevel {
 
-    double x;
+    int x;
 
     /*
      * Fixture methods have different levels to control when they should be run.
@@ -56,7 +60,7 @@ public class JMHSample_06_FixtureLevel {
 
     @TearDown(Level.Iteration)
     public void check() {
-        assert x > Math.PI : "Nothing changed?";
+        assert x > 1 : "Nothing changed?";
     }
 
     @Benchmark
@@ -66,7 +70,7 @@ public class JMHSample_06_FixtureLevel {
 
     @Benchmark
     public void measureWrong() {
-        double x = 0;
+        int x = 0;
         x++;
     }
 

--- a/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_07_FixtureLevelInvocation.java
+++ b/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_07_FixtureLevelInvocation.java
@@ -44,6 +44,7 @@ import java.util.concurrent.*;
  * which should not count as payload (e.g. sleep for some time to emulate
  * think time)
  */
+@BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 public class JMHSample_07_FixtureLevelInvocation {
 
@@ -77,7 +78,6 @@ public class JMHSample_07_FixtureLevelInvocation {
         public void down() {
             service.shutdown();
         }
-
     }
 
     /*
@@ -101,14 +101,12 @@ public class JMHSample_07_FixtureLevelInvocation {
      */
 
     @Benchmark
-    @BenchmarkMode(Mode.AverageTime)
-    public double measureHot(NormalState e, final Scratch s) throws ExecutionException, InterruptedException {
+    public int measureHot(NormalState e, final Scratch s) throws ExecutionException, InterruptedException {
         return e.service.submit(new Task(s)).get();
     }
 
     @Benchmark
-    @BenchmarkMode(Mode.AverageTime)
-    public double measureCold(LaggingState e, final Scratch s) throws ExecutionException, InterruptedException {
+    public int measureCold(LaggingState e, final Scratch s) throws ExecutionException, InterruptedException {
         return e.service.submit(new Task(s)).get();
     }
 
@@ -118,14 +116,13 @@ public class JMHSample_07_FixtureLevelInvocation {
 
     @State(Scope.Thread)
     public static class Scratch {
-        private double p;
-        public double doWork() {
-            p = Math.log(p);
-            return p;
+        private int p;
+        public int doWork() {
+            return p++;
         }
     }
 
-    public static class Task implements Callable<Double> {
+    public static class Task implements Callable<Integer> {
         private Scratch s;
 
         public Task(Scratch s) {
@@ -133,7 +130,7 @@ public class JMHSample_07_FixtureLevelInvocation {
         }
 
         @Override
-        public Double call() {
+        public Integer call() {
             return s.doWork();
         }
     }

--- a/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_08_DeadCode.java
+++ b/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_08_DeadCode.java
@@ -55,18 +55,18 @@ public class JMHSample_08_DeadCode {
      * are implicitly consumed by Blackholes, see JMHSample_09_Blackholes).
      */
 
-    private double x = Math.PI;
+    int x;
 
-    private double compute(double d) {
+    private int compute(int d) {
         for (int c = 0; c < 10; c++) {
-            d = d * d / Math.PI;
+            d = d * d / 42;
         }
         return d;
     }
 
     @Benchmark
     public void baseline() {
-        // do nothing, this is a baseline
+        // Do nothing, this is a baseline
     }
 
     @Benchmark
@@ -76,7 +76,7 @@ public class JMHSample_08_DeadCode {
     }
 
     @Benchmark
-    public double measureRight() {
+    public int measureRight() {
         // This is correct: the result is being used.
         return compute(x);
     }

--- a/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_09_Blackholes.java
+++ b/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_09_Blackholes.java
@@ -53,12 +53,12 @@ public class JMHSample_09_Blackholes {
      * code less readable with explicit Blackholes!
      */
 
-    double x1 = Math.PI;
-    double x2 = Math.PI * 2;
+    int x1;
+    int x2;
 
-    private double compute(double d) {
+    private int compute(int d) {
         for (int c = 0; c < 10; c++) {
-            d = d * d / Math.PI;
+            d = d * d / 42;
         }
         return d;
     }
@@ -68,7 +68,7 @@ public class JMHSample_09_Blackholes {
      */
 
     @Benchmark
-    public double baseline() {
+    public int baseline() {
         return compute(x1);
     }
 
@@ -78,7 +78,7 @@ public class JMHSample_09_Blackholes {
      */
 
     @Benchmark
-    public double measureWrong() {
+    public int measureWrong() {
         compute(x1);
         return compute(x2);
     }
@@ -92,7 +92,7 @@ public class JMHSample_09_Blackholes {
      */
 
     @Benchmark
-    public double measureRight_1() {
+    public int measureRight_1() {
         return compute(x1) + compute(x2);
     }
 

--- a/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_10_ConstantFold.java
+++ b/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_10_ConstantFold.java
@@ -55,41 +55,41 @@ public class JMHSample_10_ConstantFold {
      * values, and follow the rules to prevent DCE.
      */
 
-    // IDEs will say "Oh, you can convert this field to local variable". Don't. Trust. Them.
+    // IDEs will say "Look, this field could be final". Don't. Trust. Them.
     // (While this is normally fine advice, it does not work in the context of measuring correctly.)
-    private double x = Math.PI;
+    private int x = 42;
 
-    // IDEs will probably also say "Look, it could be final". Don't. Trust. Them. Either.
+    // IDEs will say "Oh, you can convert this field to local variable". Don't. Trust. Them. Either.
     // (While this is normally fine advice, it does not work in the context of measuring correctly.)
-    private final double wrongX = Math.PI;
+    private final int wrongX = 42;
 
-    private double compute(double d) {
+    private int compute(int d) {
         for (int c = 0; c < 10; c++) {
-            d = d * d / Math.PI;
+            d = d * d / 42;
         }
         return d;
     }
 
     @Benchmark
-    public double baseline() {
+    public int baseline() {
         // simply return the value, this is a baseline
-        return Math.PI;
+        return 42;
     }
 
     @Benchmark
-    public double measureWrong_1() {
+    public int measureWrong_1() {
         // This is wrong: the source is predictable, and computation is foldable.
-        return compute(Math.PI);
+        return compute(42);
     }
 
     @Benchmark
-    public double measureWrong_2() {
+    public int measureWrong_2() {
         // This is wrong: the source is predictable, and computation is foldable.
         return compute(wrongX);
     }
 
     @Benchmark
-    public double measureRight() {
+    public int measureRight() {
         // This is correct: the source is not predictable.
         return compute(x);
     }

--- a/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_20_Annotations.java
+++ b/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_20_Annotations.java
@@ -49,7 +49,7 @@ import java.util.concurrent.TimeUnit;
 @Fork(1)
 public class JMHSample_20_Annotations {
 
-    double x1 = Math.PI;
+    int x;
 
     /*
      * In addition to all the command line options usable at run time,
@@ -68,8 +68,8 @@ public class JMHSample_20_Annotations {
     @Benchmark
     @Warmup(iterations = 5, time = 100, timeUnit = TimeUnit.MILLISECONDS)
     @Measurement(iterations = 5, time = 100, timeUnit = TimeUnit.MILLISECONDS)
-    public double measure() {
-        return Math.log(x1);
+    public void measure() {
+        x++;
     }
 
     /*

--- a/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_24_Inheritance.java
+++ b/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_24_Inheritance.java
@@ -69,11 +69,11 @@ public class JMHSample_24_Inheritance {
     @State(Scope.Thread)
     @OutputTimeUnit(TimeUnit.NANOSECONDS)
     public static abstract class AbstractBenchmark {
-        int x;
+        double x;
 
         @Setup
         public void setup() {
-            x = 42;
+            x = Math.PI;
         }
 
         @Benchmark

--- a/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_25_API_GA.java
+++ b/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_25_API_GA.java
@@ -319,9 +319,9 @@ public class JMHSample_25_API_GA {
             final double MUTATE_PROB = 0.5;
             if (Math.random() < MUTATE_PROB) {
                 if (Math.random() < 0.5) {
-                    return v / (Math.random() * 2);
+                    return v / (Math.random() * 3);
                 } else {
-                    return v * (Math.random() * 2);
+                    return v * (Math.random() * 3);
                 }
             } else {
                 return v;

--- a/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_28_BlackholeHelpers.java
+++ b/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_28_BlackholeHelpers.java
@@ -76,9 +76,9 @@ public class JMHSample_28_BlackholeHelpers {
     private Worker workerRight;
     private Worker workerWrong;
 
-    private double compute(double d) {
+    private int compute(int d) {
         for (int c = 0; c < 10; c++) {
-            d = d * d / Math.PI;
+            d = d * d / 42;
         }
         return d;
     }
@@ -86,7 +86,7 @@ public class JMHSample_28_BlackholeHelpers {
     @Setup
     public void setup(final Blackhole bh) {
         workerBaseline = new Worker() {
-            double x;
+            int x;
 
             @Override
             public void work() {
@@ -95,7 +95,7 @@ public class JMHSample_28_BlackholeHelpers {
         };
 
         workerWrong = new Worker() {
-            double x;
+            int x;
 
             @Override
             public void work() {
@@ -104,7 +104,7 @@ public class JMHSample_28_BlackholeHelpers {
         };
 
         workerRight = new Worker() {
-            double x;
+            int x;
 
             @Override
             public void work() {


### PR DESCRIPTION
Generally, those samples need a bit of touchup. We used to do doubles there, because the relative overhead for double multiplication showed up against the blackholes overhead. Now that we are using compiler blackholes nearly everywhere, we can redo these in simple ints.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903641](https://bugs.openjdk.org/browse/CODETOOLS-7903641): JMH: Rework samples to avoid excess double and volatile cases (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/145/head:pull/145` \
`$ git checkout pull/145`

Update a local copy of the PR: \
`$ git checkout pull/145` \
`$ git pull https://git.openjdk.org/jmh.git pull/145/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 145`

View PR using the GUI difftool: \
`$ git pr show -t 145`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/145.diff">https://git.openjdk.org/jmh/pull/145.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/145#issuecomment-2541357144)
</details>
