### PR TITLE
7903913: JMH: Compiler profiler misses profiled times

### DIFF
--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/CompilerProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/CompilerProfilerTest.java
@@ -60,9 +60,9 @@ public class CompilerProfilerTest {
         Map<String, Result> sr = rr.getSecondaryResults();
         double timeTotal = ProfilerTestUtils.checkedGet(sr, "compiler.time.total").getScore();
         double timeWarmup = ProfilerTestUtils.checkedGet(sr, "compiler.time.warmup").getScore();
-        double timeMeasurement = ProfilerTestUtils.checkedGet(sr, "compiler.time.measure").getScore();
+        double timeMeasurement = ProfilerTestUtils.checkedGet(sr, "compiler.time.measurement").getScore();
 
-        String details = "Total: " + timeTotal + ", Warmup: " + timeWarmup + ", Measure: " + timeMeasurement;
+        String details = "Total: " + timeTotal + ", Warmup: " + timeWarmup + ", Measurement: " + timeMeasurement;
 
         if (timeTotal < timeWarmup + timeMeasurement) {
             throw new IllegalStateException("Warmup+measure should be less than total. " + details);

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/CompilerProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/CompilerProfilerTest.java
@@ -59,19 +59,21 @@ public class CompilerProfilerTest {
 
         Map<String, Result> sr = rr.getSecondaryResults();
         double timeTotal = ProfilerTestUtils.checkedGet(sr, "compiler.time.total").getScore();
-        double timeProfiled = ProfilerTestUtils.checkedGet(sr, "compiler.time.profiled").getScore();
+        double timeWarmup = ProfilerTestUtils.checkedGet(sr, "compiler.time.warmup").getScore();
+        double timeMeasurement = ProfilerTestUtils.checkedGet(sr, "compiler.time.measure").getScore();
 
-        if (timeProfiled > timeTotal) {
-            throw new IllegalStateException("Profiled time is larger than total time. " +
-                    "Total: " + timeTotal + ", Profiled: " + timeProfiled);
-        }
+        String details = "Total: " + timeTotal + ", Warmup: " + timeWarmup + ", Measure: " + timeMeasurement;
 
-        if (timeProfiled <= 0) {
-            throw new IllegalStateException("Should have profiled time: " + timeProfiled);
+        if (timeTotal < timeWarmup + timeMeasurement) {
+            throw new IllegalStateException("Warmup+measure should be less than total. " + details);
         }
 
         if (timeTotal <= 0) {
-            throw new IllegalStateException("Should have total time: " + timeTotal);
+            throw new IllegalStateException("Should have total time." + details);
+        }
+
+        if (timeWarmup + timeMeasurement <= 0) {
+            throw new IllegalStateException("Should have warmup+measure time." + details);
         }
     }
 


### PR DESCRIPTION
Despite [CODETOOLS-7903911](https://bugs.openjdk.org/browse/CODETOOLS-7903911), compiler profiler still misses the "profiled" times. At this point, I think the problem is the asynchronous nature of compilations: if compiler completes compilation outside of iteration, profiler would miss it.

`profiled` is not a great counter, we can replace it with two counters that cover `warmup` and `measure` phases directly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903913](https://bugs.openjdk.org/browse/CODETOOLS-7903913): JMH: Compiler profiler misses profiled times (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/149/head:pull/149` \
`$ git checkout pull/149`

Update a local copy of the PR: \
`$ git checkout pull/149` \
`$ git pull https://git.openjdk.org/jmh.git pull/149/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 149`

View PR using the GUI difftool: \
`$ git pr show -t 149`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/149.diff">https://git.openjdk.org/jmh/pull/149.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/149#issuecomment-2546104097)
</details>
