### PR TITLE
7903911: JMH: Profiler integration tests should use hot methods

### DIFF
--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/CompilerProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/CompilerProfilerTest.java
@@ -45,7 +45,7 @@ public class CompilerProfilerTest {
 
     @Benchmark
     public void work() {
-        Fixtures.work();
+        Fixtures.busyWork();
     }
 
     @Test

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/JavaFlightRecorderProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/JavaFlightRecorderProfilerTest.java
@@ -46,7 +46,7 @@ public class JavaFlightRecorderProfilerTest {
 
     @Benchmark
     public void work() {
-        Fixtures.work();
+        Fixtures.busyWork();
     }
 
     @Test

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfC2CProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfC2CProfilerTest.java
@@ -52,7 +52,7 @@ public class LinuxPerfC2CProfilerTest {
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void somethingInTheMiddle() {
-        Fixtures.work();
+        Fixtures.busyWork();
     }
 
     @Test

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfNormProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfNormProfilerTest.java
@@ -48,12 +48,7 @@ public class LinuxPerfNormProfilerTest {
 
     @Benchmark
     public void work() {
-        somethingInTheMiddle();
-    }
-
-    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public void somethingInTheMiddle() {
-        Blackhole.consumeCPU(1);
+        Fixtures.busyWork();
     }
 
     @Test

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfProfilerTest.java
@@ -49,12 +49,7 @@ public class LinuxPerfProfilerTest {
 
     @Benchmark
     public void work() {
-        somethingInTheMiddle();
-    }
-
-    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
-    public void somethingInTheMiddle() {
-        Blackhole.consumeCPU(1);
+        Fixtures.busyWork();
     }
 
     @Test

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/StackProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/StackProfilerTest.java
@@ -51,7 +51,7 @@ public class StackProfilerTest {
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void somethingInTheMiddle() {
-        Fixtures.work();
+        Fixtures.busyWork();
     }
 
     @Test


### PR DESCRIPTION
Profiler tests are more reliable if we run hot methods as their targets. Otherwise we can never see the methods in profiles. This can be made a bit more reliable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903911](https://bugs.openjdk.org/browse/CODETOOLS-7903911): JMH: Profiler integration tests should use hot methods (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/150/head:pull/150` \
`$ git checkout pull/150`

Update a local copy of the PR: \
`$ git checkout pull/150` \
`$ git pull https://git.openjdk.org/jmh.git pull/150/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 150`

View PR using the GUI difftool: \
`$ git pr show -t 150`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/150.diff">https://git.openjdk.org/jmh/pull/150.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/150#issuecomment-2546619728)
</details>
