### PR TITLE
7903915: JMH: Rebalance tests and test jobs parallelism

### DIFF
--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -18,8 +18,30 @@ jobs:
       matrix:
         java: [8, 11, 17, 21]
         os: [ubuntu-latest, windows-latest, macos-latest]
+        mode: [default, reflection, asm, executor-fjp, executor-custom]
+        exclude:
+          - os: windows-latest
+            mode: reflection
+          - os: windows-latest
+            mode: asm
+          - os: windows-latest
+            mode: executor-fjp
+          - os: windows-latest
+            mode: executor-custom
+          - os: macos-latest
+            mode: reflection
+          - os: macos-latest
+            mode: asm
+          - os: macos-latest
+            mode: executor-fjp
+          - os: macos-latest
+            mode: executor-custom
+        include:
+          - os: ubuntu-latest
+            java: 21
+            mode: executor-virtual
       fail-fast: false
-    name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}
+    name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}, ${{ matrix.mode }}
     timeout-minutes: 180
 
     steps:
@@ -31,6 +53,7 @@ jobs:
         java-version: ${{ matrix.java }}
         cache: maven
         check-latest: true
+
     - name: Set up perf (Linux)
       run: |
         sudo apt-get update
@@ -38,39 +61,45 @@ jobs:
         echo -1 | sudo tee /proc/sys/kernel/perf_event_paranoid
         perf stat echo 1
       if: (runner.os == 'Linux')
+
     - name: Set up async-profiler (Linux)
       run: |
         curl -L https://github.com/async-profiler/async-profiler/releases/download/v3.0/async-profiler-3.0-linux-x64.tar.gz | tar xzf -
         echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/async-profiler-3.0-linux-x64/lib/" >> $GITHUB_ENV
       if: (runner.os == 'Linux')
 
-    - name: Build with tests (Default)
-      run: mvn clean install -B --file pom.xml
-
-    - name: Build with tests (Reflection)
-      run: mvn clean install -P reflection -B --file pom.xml
-      if: (runner.os == 'Linux')
+    - name: Build without tests (Default)
+      run: mvn clean install -B --file pom.xml  -DskipTests
+      if: (matrix.mode == 'default')
 
     - name: Build without tests (Reflection)
       run: mvn clean install -P reflection -B --file pom.xml -DskipTests
-      if: (runner.os != 'Linux')
-
-    - name: Build with tests (ASM)
-      run: mvn clean install -P asm -B --file pom.xml
-      if: (runner.os == 'Linux')
+      if: (matrix.mode == 'default')
 
     - name: Build without tests (ASM)
       run: mvn clean install -P asm -B --file pom.xml -DskipTests
-      if: (runner.os != 'Linux')
+      if: (matrix.mode == 'default')
+
+    - name: Build with tests (Default)
+      run: mvn clean install -B --file pom.xml
+      if: (matrix.mode == 'default')
+
+    - name: Build with tests (Reflection)
+      run: mvn clean install -P reflection -B --file pom.xml
+      if: (matrix.mode == 'reflection')
+
+    - name: Build with tests (ASM)
+      run: mvn clean install -P asm -B --file pom.xml
+      if: (matrix.mode == 'asm')
 
     - name: Build with tests (FJP Executor)
       run: mvn clean install -P executor-fjp -B --file pom.xml
-      if: (runner.os == 'Linux')
+      if: (matrix.mode == 'executor-fjp')
 
     - name: Build with tests (Custom Executor)
       run: mvn clean install -P executor-custom -B --file pom.xml
-      if: (runner.os == 'Linux')
+      if: (matrix.mode == 'executor-custom')
 
     - name: Build with tests (Virtual Executor)
       run: mvn clean install -P executor-virtual -B --file pom.xml
-      if: (runner.os == 'Linux') && (matrix.java == '21')
+      if: (matrix.mode == 'executor-virtual')

--- a/jmh-core-it/pom.xml
+++ b/jmh-core-it/pom.xml
@@ -76,7 +76,7 @@ questions.
                         </goals>
                         <configuration>
                             <argLine>${jmh.testjvmargs}</argLine>
-                            <!-- Integration tests run with sleeps as payloads, we can execute them with larger parallelism. -->
+                            <!-- Integration tests run with sleeps as payloads, we can execute them with larger parallelism -->
                             <forkCount>1.5C</forkCount>
                             <!-- Integration tests sometimes set system properties, do not let them leak to other tests -->
                             <reuseForks>false</reuseForks>

--- a/jmh-core-it/pom.xml
+++ b/jmh-core-it/pom.xml
@@ -76,14 +76,16 @@ questions.
                         </goals>
                         <configuration>
                             <argLine>${jmh.testjvmargs}</argLine>
-                            <!-- Integration tests run with sleeps as payloads, we can execute them with larger parallelism -->
+                            <!-- Integration tests run with sleeps as payloads, we can execute them with larger parallelism. -->
                             <forkCount>1.5C</forkCount>
                             <!-- Integration tests sometimes set system properties, do not let them leak to other tests -->
                             <reuseForks>false</reuseForks>
                             <redirectTestOutputToFile>true</redirectTestOutputToFile>
                             <excludes>
-                                <!-- xctrace tests interfere with each other when executed concurrently -->
-                                <exclude>**/profilers/XCTrace*ProfilerTest.java</exclude>
+                                <!-- These tests interfere with each other when executed concurrently -->
+                                <exclude>**/batchsize/*</exclude>
+                                <exclude>**/ccontrol/*</exclude>
+                                <exclude>**/profilers/*</exclude>
                             </excludes>
                         </configuration>
                     </execution>
@@ -97,10 +99,13 @@ questions.
                         <configuration>
                             <argLine>${jmh.testjvmargs}</argLine>
                             <forkCount>1</forkCount>
+                            <reuseForks>false</reuseForks>
                             <redirectTestOutputToFile>true</redirectTestOutputToFile>
                             <includes>
-                                <!-- xctrace tests interfere with each other when executed concurrently -->
-                                <include>**/profilers/XCTrace*ProfilerTest.java</include>
+                                <!-- These tests interfere with each other when executed concurrently -->
+                                <include>**/batchsize/*</include>
+                                <include>**/ccontrol/*</include>
+                                <include>**/profilers/*</include>
                             </includes>
                         </configuration>
                     </execution>


### PR DESCRIPTION
The ongoing headache with some of the integration tests: some of them effectively test performance, so executing them in parallel introduces flaky failures. We can turn some of those tests serial, but then the testing time would explode on smaller machines, like we have in GHA. We can fix that by rebalancing our GHA test jobs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903915](https://bugs.openjdk.org/browse/CODETOOLS-7903915): JMH: Rebalance tests and test jobs parallelism (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/151/head:pull/151` \
`$ git checkout pull/151`

Update a local copy of the PR: \
`$ git checkout pull/151` \
`$ git pull https://git.openjdk.org/jmh.git pull/151/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 151`

View PR using the GUI difftool: \
`$ git pr show -t 151`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/151.diff">https://git.openjdk.org/jmh/pull/151.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/151#issuecomment-2548131512)
</details>
