### PR TITLE
7902944: JMH: Avoid weak references in Blackhole.consume(Object)

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/infra/Blackhole.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/infra/Blackhole.java
@@ -399,8 +399,23 @@ public final class Blackhole extends BlackholeL2 {
         int tlr = (this.tlr = (this.tlr * 1664525 + 1013904223));
         if ((tlr & tlrMask) == 0) {
             // SHOULD ALMOST NEVER HAPPEN IN MEASUREMENT
-            this.obj1 = new WeakReference<>(obj);
+            this.obj1 = new BoxedWeakRef(obj);
             this.tlrMask = (tlrMask << 1) + 1;
+        }
+    }
+
+    // Some objects, notably inline types in Valhalla, resist being referenced
+    // directly from a weak ref. For this reason, we wrap the object in the box
+    // first.
+    private static class BoxedWeakRef extends WeakReference<Object> {
+        public BoxedWeakRef(Object referent) {
+            super(new Box(referent));
+        }
+        private static class Box {
+            public Object o;
+            public Box(Object o) {
+                this.o = o;
+            }
         }
     }
 

--- a/jmh-core/src/main/java/org/openjdk/jmh/infra/Blackhole.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/infra/Blackhole.java
@@ -24,7 +24,6 @@
  */
 package org.openjdk.jmh.infra;
 
-import java.lang.ref.WeakReference;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Random;
@@ -109,11 +108,16 @@ public final class Blackhole extends BlackholeL2 {
      * with infinitesimal probability. Then again, smart compilers may skip from
      * generating the slow path, and apply the previous logic to constant-fold
      * the condition to "false". We are warming up the slow-path in the beginning
-     * to evade that effect. Some caution needs to be exercised not to retain the
-     * captured objects forever: this is normally achieved by calling evaporate()
-     * regularly, but we also additionally protect with retaining the object on
-     * weak reference (contrary to phantom-ref, publishing object still has to
-     * happen, because reference users might need to discover the object).
+     * to evade that effect.
+     *
+     * Some caution needs to be exercised not to retain the captured objects forever.
+     * We achieve this by providing the box and two aliases to that box. Storing through
+     * one alias and immediately clearing through another alias allows to both avoid
+     * dead-code elimination, and never retain the object, as long as alias analysis
+     * cannot prove we are dealing with the same box. This is achieved by reading aliases
+     * from volatile fields, which forces most compilers to assume the value is not stable,
+     * and using the non-inlined clearBox() method, which forces compilers to do aggressive
+     * inter-procedural optimizations to figure out aliasing.
      *
      * Observation (4) provides us with an opportunity to create a safety net in case
      * either (1), (2) or (3) fails. This is why Blackhole methods are prohibited from
@@ -187,7 +191,9 @@ public final class Blackhole extends BlackholeL2 {
         if (!challengeResponse.equals("Should not be calling this.")) {
             throw new IllegalStateException("Evaporate should not be called directly.");
         }
-        obj1 = null;
+        // The boxes should actually be always empty. Clear them out just in case.
+        box1.o = null;
+        box2.o = null;
     }
 
     /**
@@ -398,25 +404,15 @@ public final class Blackhole extends BlackholeL2 {
         int tlrMask = this.tlrMask; // volatile read
         int tlr = (this.tlr = (this.tlr * 1664525 + 1013904223));
         if ((tlr & tlrMask) == 0) {
-            // SHOULD ALMOST NEVER HAPPEN IN MEASUREMENT
-            this.obj1 = new BoxedWeakRef(obj);
+            // SHOULD ALMOST NEVER HAPPEN IN MEASUREMENT.
+            this.box1.o = obj;
+            clearBox();
             this.tlrMask = (tlrMask << 1) + 1;
         }
     }
 
-    // Some objects, notably inline types in Valhalla, resist being referenced
-    // directly from a weak ref. For this reason, we wrap the object in the box
-    // first.
-    private static class BoxedWeakRef extends WeakReference<Object> {
-        public BoxedWeakRef(Object referent) {
-            super(new Box(referent));
-        }
-        private static class Box {
-            public Object o;
-            public Box(Object o) {
-                this.o = o;
-            }
-        }
+    private void clearBox() {
+        this.box2.o = null;
     }
 
     private static volatile long consumedCPU = System.nanoTime();
@@ -489,7 +485,8 @@ abstract class BlackholeL2 extends BlackholeL1 {
     public long l2;
     public float f2;
     public double d2;
-    public volatile Object obj1;
+    public volatile Box box1;
+    public volatile Box box2;
     public volatile BlackholeL2 nullBait = null;
     public int tlr;
     public volatile int tlrMask;
@@ -498,7 +495,8 @@ abstract class BlackholeL2 extends BlackholeL1 {
         Random r = new Random(System.nanoTime());
         tlr = r.nextInt();
         tlrMask = 1;
-        obj1 = new Object();
+        box1 = new Box();
+        box2 = box1;
 
         b1 = (byte) r.nextInt(); b2 = (byte) (b1 + 1);
         bool1 = r.nextBoolean(); bool2 = !bool1;
@@ -533,6 +531,10 @@ abstract class BlackholeL2 extends BlackholeL1 {
         if (d1 == d2) {
             throw new IllegalStateException("double tombstones are equal");
         }
+    }
+
+    protected static class Box {
+        public Object o;
     }
 }
 

--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/CompilerHints.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/CompilerHints.java
@@ -80,6 +80,7 @@ public class CompilerHints extends AbstractResourceReader {
                 if (bhMode.shouldNotInline()) {
                     hints.add("dontinline,org/openjdk/jmh/infra/Blackhole.consumeFull");
                 }
+                hints.add("dontinline,org/openjdk/jmh/infra/Blackhole.clearBox");
                 hints.addAll(defaultHints);
                 hintsFile = FileUtils.createTempFileWithLines("compilecommand", hints);
             } catch (IOException e) {


### PR DESCRIPTION
See the bug for rationale. This avoids `WeakReference`-s completely through the aliased box trick. Not only this solves the original problem with inline types, it also allows for prompt reclamation of the objects, without relying on the specifics of VM reference processing.

I looked at `jmh-core-benchmarks` results, and they suggest this still works reliably without compiler blackholes. Compiler blackholes make all of this irrelevant.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7902944](https://bugs.openjdk.org/browse/CODETOOLS-7902944): JMH: Avoid weak references in Blackhole.consume(Object) (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/153/head:pull/153` \
`$ git checkout pull/153`

Update a local copy of the PR: \
`$ git checkout pull/153` \
`$ git pull https://git.openjdk.org/jmh.git pull/153/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 153`

View PR using the GUI difftool: \
`$ git pr show -t 153`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/153.diff">https://git.openjdk.org/jmh/pull/153.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/153#issuecomment-2580082002)
</details>
