### PR TITLE
7904037: Make OutputFormatAdapter public

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/OutputFormatAdapter.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/OutputFormatAdapter.java
@@ -29,7 +29,7 @@ import org.openjdk.jmh.runner.format.OutputFormat;
 import java.io.IOException;
 import java.io.OutputStream;
 
-class OutputFormatAdapter extends OutputStream {
+public class OutputFormatAdapter extends OutputStream {
     private final OutputFormat out;
 
     public OutputFormatAdapter(OutputFormat out) {


### PR DESCRIPTION
This is the first in a series of PRs that I will be sending over the next few days, which make extending JMH to benchmark Java code running as GraalVM native images more easily. The codename for this extension is Fibula. It can still work without this PRs but without them the extension has to duplicate code that exists in JMH, which is not desirable.

In this PR, we make `OutputFormatAdapter` public.

Why do that? This enables Fibula to reuse the same class when it wants to redirect the output from the process to the JMH output. This is useful for example when Fibula's PGO integration invokes native image to recreate the binary with the profiling information, see https://github.com/galderz/fibula/commit/20eaf64936ef3e8f77eaed2ac7e8094b57e66a8d

Here is the PR list for reference:
1. [Make OutputFormatAdapter public](https://github.com/openjdk/jmh/pull/158)
2. [Enable BenchmarkParams construction to be overriden](https://github.com/openjdk/jmh/pull/160)
3. [Enable alternative Runner instantiation and Main reuse](https://github.com/openjdk/jmh/pull/161)
4. [Enable profiler classes to be reused outside of JMH](https://github.com/openjdk/jmh/pull/162)
5. [Enable JMH integration tests to be executed against other impls](https://github.com/openjdk/jmh/pull/163)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7904037](https://bugs.openjdk.org/browse/CODETOOLS-7904037): Make OutputFormatAdapter public (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/158/head:pull/158` \
`$ git checkout pull/158`

Update a local copy of the PR: \
`$ git checkout pull/158` \
`$ git pull https://git.openjdk.org/jmh.git pull/158/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 158`

View PR using the GUI difftool: \
`$ git pr show -t 158`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/158.diff">https://git.openjdk.org/jmh/pull/158.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/158#issuecomment-2980210046)
</details>
