### PR TITLE
7904047: JMH: support async-profiler 4.0 options

### DIFF
--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -64,8 +64,8 @@ jobs:
 
     - name: Set up async-profiler (Linux)
       run: |
-        curl -L https://github.com/async-profiler/async-profiler/releases/download/v3.0/async-profiler-3.0-linux-x64.tar.gz | tar xzf -
-        echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/async-profiler-3.0-linux-x64/lib/" >> $GITHUB_ENV
+        curl -L https://github.com/async-profiler/async-profiler/releases/download/v4.0/async-profiler-4.0-linux-x64.tar.gz | tar xzf -
+        echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/async-profiler-4.0-linux-x64/lib/" >> $GITHUB_ENV
       if: (runner.os == 'Linux')
 
     - name: Build without tests (Default)


### PR DESCRIPTION
JMH has built-in capability for running benchmarks with async-profiler. `-prof async` supports commonly used async-profiler options, however, these options became a bit outdated and don't reflect features appeared in async-profiler 3.0 and 4.0.

Async-profiler users [get confused](https://github.com/async-profiler/async-profiler/discussions/1345) why certain async-profiler options don't work with JMH.

This PR:
- updates async-profiler stack walking modes: `dwarf`, `vm`, `vmx`;
- adds native memory profiling option;
- adds OTLP output format;
- introduces `norm` and `lib` flags for tuning async-profiler frame names;
- fixes minor inaccuracies in option description.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7904047](https://bugs.openjdk.org/browse/CODETOOLS-7904047): JMH: support async-profiler 4.0 options (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/159/head:pull/159` \
`$ git checkout pull/159`

Update a local copy of the PR: \
`$ git checkout pull/159` \
`$ git pull https://git.openjdk.org/jmh.git pull/159/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 159`

View PR using the GUI difftool: \
`$ git pr show -t 159`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/159.diff">https://git.openjdk.org/jmh/pull/159.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/159#issuecomment-3002288442)
</details>
