### PR TITLE
7904058: Enable BenchmarkParams construction to be overriden

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/ActionMode.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/ActionMode.java
@@ -24,7 +24,7 @@
  */
 package org.openjdk.jmh.runner;
 
-enum ActionMode {
+public enum ActionMode {
 
     /**
      * No action.

--- a/jmh-core/src/main/java/org/openjdk/jmh/runner/Runner.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/runner/Runner.java
@@ -383,7 +383,7 @@ public class Runner extends BaseRunner {
         return new Action(newBenchmarkParams(br, mode), mode);
     }
 
-    private BenchmarkParams newBenchmarkParams(BenchmarkListEntry benchmark, ActionMode mode) {
+    protected BenchmarkParams newBenchmarkParams(BenchmarkListEntry benchmark, ActionMode mode) {
         int[] threadGroups = options.getThreadGroups().orElse(benchmark.getThreadGroups());
 
         int threads = options.getThreads().orElse(


### PR DESCRIPTION
This is the **second** in a series of PRs that I will be sending over the next few days, which make extending JMH to benchmark Java code running as GraalVM native images more easily. The codename for this extension is Fibula. It can still work without this PRs but without them the extension has to duplicate code that exists in JMH, which is not desirable.

This PR enables `BenchmarkParams` construction to be overriden, in order to easily support JMH use case for benchmarking native images. The JIRA contains a detailed explanation. Having this PR in simplifies construction of `BenchmarkParams` instance. The changes https://github.com/galderz/fibula/commit/8fd8cf3f4eb1c6f37de7f807bfc697ef981a3e05#diff-601b6d98eff18db8a804efb415d515c3d397d42b9c982713b72c37bea2ebbf18 demonstrate the simplification enabled by the changes here.

Here is the PR list for reference:
1. [Make OutputFormatAdapter public](https://github.com/openjdk/jmh/pull/158)
2. [Enable BenchmarkParams construction to be overriden](https://github.com/openjdk/jmh/pull/160)
3. [Enable alternative Runner instantiation and Main reuse](https://github.com/openjdk/jmh/pull/161)
4. [Enable profiler classes to be reused outside of JMH](https://github.com/openjdk/jmh/pull/162)
5. [Enable JMH integration tests to be executed against other impls](https://github.com/openjdk/jmh/pull/163)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7904058](https://bugs.openjdk.org/browse/CODETOOLS-7904058): Enable BenchmarkParams construction to be overriden (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/160/head:pull/160` \
`$ git checkout pull/160`

Update a local copy of the PR: \
`$ git checkout pull/160` \
`$ git pull https://git.openjdk.org/jmh.git pull/160/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 160`

View PR using the GUI difftool: \
`$ git pr show -t 160`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/160.diff">https://git.openjdk.org/jmh/pull/160.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/160#issuecomment-3048074578)
</details>
