### PR TITLE
7904059: Enable alternative Runner instantiation and Main reuse

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/Main.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/Main.java
@@ -37,67 +37,78 @@ import java.io.IOException;
 public class Main {
 
     public static void main(String[] argv) throws IOException {
+        Main main = new Main();
+
+        CommandLineOptions cmdOptions = main.createCommandLineOptions(argv);
+
+        Runner runner = new Runner(cmdOptions);
+
+        main.run(cmdOptions, runner);
+    }
+
+    protected CommandLineOptions createCommandLineOptions(String[] argv)
+    {
         try {
-            CommandLineOptions cmdOptions = new CommandLineOptions(argv);
-
-            Runner runner = new Runner(cmdOptions);
-
-            if (cmdOptions.shouldHelp()) {
-                cmdOptions.showHelp();
-                return;
-            }
-
-            if (cmdOptions.shouldList()) {
-                runner.list();
-                return;
-            }
-
-            if (cmdOptions.shouldListWithParams()) {
-                runner.listWithParams(cmdOptions);
-                return;
-            }
-
-            if (cmdOptions.shouldListProfilers()) {
-                cmdOptions.listProfilers();
-                return;
-            }
-
-            if (cmdOptions.shouldListResultFormats()) {
-                cmdOptions.listResultFormats();
-                return;
-            }
-
-            try {
-                runner.run();
-            } catch (NoBenchmarksException e) {
-                System.err.println("No matching benchmarks. Miss-spelled regexp?");
-
-                if (cmdOptions.verbosity().orElse(Defaults.VERBOSITY) != VerboseMode.EXTRA) {
-                    System.err.println("Use " + VerboseMode.EXTRA + " verbose mode to debug the pattern matching.");
-                } else {
-                    runner.list();
-                }
-                System.exit(1);
-            } catch (ProfilersFailedException e) {
-                // This is not exactly an error, print all messages and set the non-zero exit code.
-                Throwable ex = e;
-                while (ex != null) {
-                    System.err.println(ex.getMessage());
-                    for (Throwable supp : ex.getSuppressed()) {
-                        System.err.println(supp.getMessage());
-                    }
-                    ex = ex.getCause();
-                }
-                System.exit(1);
-            } catch (RunnerException e) {
-                System.err.print("ERROR: ");
-                e.printStackTrace(System.err);
-                System.exit(1);
-            }
-
+            return new CommandLineOptions(argv);
         } catch (CommandLineOptionException e) {
             System.err.println("Error parsing command line:");
             System.err.println(" " + e.getMessage());
+            System.exit(1);
+            return null;
+        }
+    }
+
+    protected void run(CommandLineOptions cmdOptions, Runner runner) throws IOException {
+        if (cmdOptions.shouldHelp()) {
+            cmdOptions.showHelp();
+            return;
+        }
+
+        if (cmdOptions.shouldList()) {
+            runner.list();
+            return;
+        }
+
+        if (cmdOptions.shouldListWithParams()) {
+            runner.listWithParams(cmdOptions);
+            return;
+        }
+
+        if (cmdOptions.shouldListProfilers()) {
+            cmdOptions.listProfilers();
+            return;
+        }
+
+        if (cmdOptions.shouldListResultFormats()) {
+            cmdOptions.listResultFormats();
+            return;
+        }
+
+        try {
+            runner.run();
+        } catch (NoBenchmarksException e) {
+            System.err.println("No matching benchmarks. Miss-spelled regexp?");
+
+            if (cmdOptions.verbosity().orElse(Defaults.VERBOSITY) != VerboseMode.EXTRA) {
+                System.err.println("Use " + VerboseMode.EXTRA + " verbose mode to debug the pattern matching.");
+            } else {
+                runner.list();
+            }
+            System.exit(1);
+        } catch (ProfilersFailedException e) {
+            // This is not exactly an error, print all messages and set the non-zero exit code.
+            Throwable ex = e;
+            while (ex != null) {
+                System.err.println(ex.getMessage());
+                for (Throwable supp : ex.getSuppressed()) {
+                    System.err.println(supp.getMessage());
+                }
+                ex = ex.getCause();
+            }
+            System.exit(1);
+        } catch (RunnerException e) {
+            System.err.print("ERROR: ");
+            e.printStackTrace(System.err);
             System.exit(1);
         }
     }


### PR DESCRIPTION
This is the **third** in a series of PRs that I will be sending over the next few days, which make extending JMH to benchmark Java code running as GraalVM native images more easily. The codename for this extension is Fibula. It can still work without this PRs but without them the extension has to duplicate code that exists in JMH, which is not desirable.

This PR refactors the main class to enable reuse of most of its logic, while allowing the construction of the `Runner` instance to be overridden by a subclass. An example of this override can be seen [here](https://github.com/galderz/fibula/commit/11bb06a3e30cfae61fb6d9319ee9cac1bf16d2d3).

Here is the PR list for reference:
1. [Make OutputFormatAdapter public](https://github.com/openjdk/jmh/pull/158)
2. [Enable BenchmarkParams construction to be overriden](https://github.com/openjdk/jmh/pull/160)
3. [Enable alternative Runner instantiation and Main reuse](https://github.com/openjdk/jmh/pull/161)
4. [Enable profiler classes to be reused outside of JMH](https://github.com/openjdk/jmh/pull/162)
5. [Enable JMH integration tests to be executed against other impls](https://github.com/openjdk/jmh/pull/163)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7904059](https://bugs.openjdk.org/browse/CODETOOLS-7904059): Enable alternative Runner instantiation and Main reuse (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/161/head:pull/161` \
`$ git checkout pull/161`

Update a local copy of the PR: \
`$ git checkout pull/161` \
`$ git pull https://git.openjdk.org/jmh.git pull/161/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 161`

View PR using the GUI difftool: \
`$ git pr show -t 161`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/161.diff">https://git.openjdk.org/jmh/pull/161.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/161#issuecomment-3048171359)
</details>
