### PR TITLE
7904060: Enable profiler classes to be reused outside of JMH

### DIFF
--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/ProfilerOptionFormatter.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/ProfilerOptionFormatter.java
@@ -31,7 +31,7 @@ import org.openjdk.jmh.util.Utils;
 import java.util.List;
 import java.util.Map;
 
-class ProfilerOptionFormatter implements HelpFormatter {
+public class ProfilerOptionFormatter implements HelpFormatter {
 
     private static final String LINE_SEPARATOR = System.getProperty("line.separator");
 

--- a/jmh-core/src/main/java/org/openjdk/jmh/profile/ProfilerUtils.java
+++ b/jmh-core/src/main/java/org/openjdk/jmh/profile/ProfilerUtils.java
@@ -36,7 +36,7 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.util.concurrent.TimeUnit;
 
-class ProfilerUtils {
+public class ProfilerUtils {
 
     public static OptionSet parseInitLine(String initLine, OptionParser parser) throws ProfilerException {
         parser.accepts("help", "Display help.");


### PR DESCRIPTION
This is the **fourth** in a series of PRs that I will be sending over the next few days, which make extending JMH to benchmark Java code running as GraalVM native images more easily. The codename for this extension is Fibula. It can still work without this PRs but without them the extension has to duplicate code that exists in JMH, which is not desirable.

This PR makes `ProfilerOptionFormatter` and `ProfilerUtils` classes public so that they can be reused by external profilers. An example of this usage can be seen [in this perf dwarf profiler used for native image JMH benchmarks](https://github.com/galderz/fibula/commit/43fffcf225ab163a97cf0703abe956144adf31e6).

Here is the PR list for reference:
1. [Make OutputFormatAdapter public](https://github.com/openjdk/jmh/pull/158)
2. [Enable BenchmarkParams construction to be overriden](https://github.com/openjdk/jmh/pull/160)
3. [Enable alternative Runner instantiation and Main reuse](https://github.com/openjdk/jmh/pull/161)
4. [Enable profiler classes to be reused outside of JMH](https://github.com/openjdk/jmh/pull/162)
5. [Enable JMH integration tests to be executed against other impls](https://github.com/openjdk/jmh/pull/163)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7904060](https://bugs.openjdk.org/browse/CODETOOLS-7904060): Enable profiler classes to be reused outside of JMH (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/162/head:pull/162` \
`$ git checkout pull/162`

Update a local copy of the PR: \
`$ git checkout pull/162` \
`$ git pull https://git.openjdk.org/jmh.git pull/162/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 162`

View PR using the GUI difftool: \
`$ git pr show -t 162`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/162.diff">https://git.openjdk.org/jmh/pull/162.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/162#issuecomment-3048324549)
</details>
