### PR TITLE
7904061: Enable JMH integration tests to be executed against other impls

### DIFF
--- a/jmh-core-it/pom.xml
+++ b/jmh-core-it/pom.xml
@@ -132,6 +132,17 @@ questions.
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/IterationCountAnnTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/IterationCountAnnTest.java
@@ -37,7 +37,6 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
-import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
@@ -49,7 +48,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Tests if harness favors the iteration count annotations.
  */
 @State(Scope.Thread)
-public class IterationCountAnnTest {
+public class IterationCountAnnTest implements RunnerFactory {
 
     private final AtomicInteger count = new AtomicInteger();
 
@@ -78,7 +77,7 @@ public class IterationCountAnnTest {
                 .include(Fixtures.getTestMask(this.getClass()))
                 .shouldFailOnError(true)
                 .build();
-        new Runner(opts).run();
+        createRunner(opts).run();
     }
 
 }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/IterationCountCmdTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/IterationCountCmdTest.java
@@ -35,7 +35,6 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
-import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
@@ -47,7 +46,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Tests if harness favors the iteration count cmdline parameters.
  */
 @State(Scope.Thread)
-public class IterationCountCmdTest {
+public class IterationCountCmdTest implements RunnerFactory {
 
     private final AtomicInteger count = new AtomicInteger();
 
@@ -77,7 +76,7 @@ public class IterationCountCmdTest {
                 .measurementTime(TimeValue.milliseconds(100))
                 .warmupIterations(0)
                 .build();
-        new Runner(opt).run();
+        createRunner(opt).run();
     }
 
 }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/RunnerFactory.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/RunnerFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2014, 2015, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jmh.it;
+
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+
+public interface RunnerFactory {
+    default Runner createRunner(Options opts) {
+        return new Runner(opts);
+    }
+}

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/SingleShotTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/SingleShotTest.java
@@ -30,7 +30,6 @@ import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Mode;
-import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
@@ -41,7 +40,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Tests if harness had indeed executed different tests in different JVMs.
  */
 @BenchmarkMode(Mode.SingleShotTime)
-public class SingleShotTest {
+public class SingleShotTest implements RunnerFactory {
 
     private static final AtomicInteger test1executed = new AtomicInteger();
     private static final AtomicInteger test2executed = new AtomicInteger();
@@ -69,7 +68,7 @@ public class SingleShotTest {
                 .shouldFailOnError(true)
                 .forks(1)
                 .build();
-        new Runner(opt).run();
+        createRunner(opt).run();
     }
 
     @Test
@@ -79,7 +78,7 @@ public class SingleShotTest {
                 .shouldFailOnError(true)
                 .forks(2)
                 .build();
-        new Runner(opt).run();
+        createRunner(opt).run();
     }
 
 }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/StackTraceInThrowableTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/StackTraceInThrowableTest.java
@@ -33,7 +33,6 @@ import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
-import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
@@ -42,7 +41,7 @@ import java.util.concurrent.TimeUnit;
 
 
 @State(Scope.Thread)
-public class StackTraceInThrowableTest {
+public class StackTraceInThrowableTest implements RunnerFactory {
 
     @Benchmark
     @BenchmarkMode(Mode.All)
@@ -60,7 +59,7 @@ public class StackTraceInThrowableTest {
                 .shouldFailOnError(true)
                 .jvmArgs("-XX:-StackTraceInThrowable")
                 .build();
-        new Runner(opts).run();
+        createRunner(opts).run();
     }
 
 }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/WarmupIterationCountAnnTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/WarmupIterationCountAnnTest.java
@@ -37,7 +37,6 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
-import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
@@ -49,7 +48,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Tests if harness honors warmup annotation settings.
  */
 @State(Scope.Thread)
-public class WarmupIterationCountAnnTest {
+public class WarmupIterationCountAnnTest implements RunnerFactory {
 
     private final AtomicInteger count = new AtomicInteger();
 
@@ -78,7 +77,7 @@ public class WarmupIterationCountAnnTest {
                 .include(Fixtures.getTestMask(this.getClass()))
                 .shouldFailOnError(true)
                 .build();
-        new Runner(opt).run();
+        createRunner(opt).run();
     }
 
 }

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/WarmupIterationCountCmdTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/WarmupIterationCountCmdTest.java
@@ -35,7 +35,6 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
-import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
@@ -47,7 +46,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Tests if harness honors warmup command line settings.
  */
 @State(Scope.Thread)
-public class WarmupIterationCountCmdTest {
+public class WarmupIterationCountCmdTest implements RunnerFactory {
 
     private final AtomicInteger count = new AtomicInteger();
 
@@ -78,7 +77,7 @@ public class WarmupIterationCountCmdTest {
                 .measurementIterations(1)
                 .warmupIterations(3)
                 .build();
-        new Runner(opt).run();
+        createRunner(opt).run();
     }
 
 


### PR DESCRIPTION
**NOTE**: This PR should be marked as draft because not all tests have been migrated to this setup. I've migrated the ones in the root test package to get a feel on how things would work and get feedback on whether this approach is fine for the JMH community.

This is the **last** in a series of PRs extending JMH to benchmark Java code running as GraalVM native images more easily.

In this PR:
* We enable `jmh-core-it` test jar to be created so that JMH extensions can consume it.
* We create a test `RunnerFactory` interface with a method called `createRunner` that by default creates JMH's `Runner` instance. JMH extensions that want to run the same test with a different runner would apply changes like [these](https://github.com/galderz/fibula/commit/79f48a8eabd38af4a4a023dacd2a925d8052aeea). Here the JMH extension extends the default `RunnerFactory` interface, and extends individual test classes to make them implement the extended runner factory interface.

The result of both these changes enables JMH tests to be executed with the JMH extension:

```
[INFO] --- failsafe:3.5.2:integration-test (default) @ fibula-jmh-it ---
[INFO] Using auto detected provider org.apache.maven.surefire.junit4.JUnit4Provider
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.mendrugo.fibula.jmh.it.SingleShotTest
# JMH version: fibula:999-SNAPSHOT
# VM version: JDK 24.0.1, Substrate VM, GraalVM CE 24.0.1+9.1
# *** WARNING: This VM is not supported by JMH. The produced benchmark data can be completely wrong.
# VM invoker: target/benchmarks
...
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.536 s -- in org.mendrugo.fibula.jmh.it.SingleShotTest
[INFO] Running org.mendrugo.fibula.jmh.it.IterationCountCmdTest
# JMH version: fibula:999-SNAPSHOT
# VM version: JDK 24.0.1, Substrate VM, GraalVM CE 24.0.1+9.1
# *** WARNING: This VM is not supported by JMH. The produced benchmark data can be completely wrong.
# VM invoker: target/benchmarks
...
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.712 s -- in org.mendrugo.fibula.jmh.it.IterationCountCmdTest
[INFO] Running org.mendrugo.fibula.jmh.it.IterationCountAnnTest
# JMH version: fibula:999-SNAPSHOT
# VM version: JDK 24.0.1, Substrate VM, GraalVM CE 24.0.1+9.1
# *** WARNING: This VM is not supported by JMH. The produced benchmark data can be completely wrong.
# VM invoker: target/benchmarks
...
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.345 s -- in org.mendrugo.fibula.jmh.it.IterationCountAnnTest
[INFO] Running org.mendrugo.fibula.jmh.it.WarmupIterationCountAnnTest
# JMH version: fibula:999-SNAPSHOT
# VM version: JDK 24.0.1, Substrate VM, GraalVM CE 24.0.1+9.1
# *** WARNING: This VM is not supported by JMH. The produced benchmark data can be completely wrong.
# VM invoker: target/benchmarks
...
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.751 s -- in org.mendrugo.fibula.jmh.it.WarmupIterationCountAnnTest
[INFO] Running org.mendrugo.fibula.jmh.it.WarmupIterationCountCmdTest
# JMH version: fibula:999-SNAPSHOT
# VM version: JDK 24.0.1, Substrate VM, GraalVM CE 24.0.1+9.1
# *** WARNING: This VM is not supported by JMH. The produced benchmark data can be completely wrong.
# VM invoker: target/benchmarks
...
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.756 s -- in org.mendrugo.fibula.jmh.it.WarmupIterationCountCmdTest
[INFO] Running org.mendrugo.fibula.jmh.it.StackTraceInThrowableTest
[WARNING] Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0 s -- in org.mendrugo.fibula.jmh.it.StackTraceInThrowableTest
[INFO] 
[INFO] Results:
[INFO] 
[WARNING] Tests run: 7, Failures: 0, Errors: 0, Skipped: 1
```

Note that above we can observe that one of the JMH tests is disabled. It could happen that several JMH tests are not applicable to native image, e.g. perfasm tests. In the usage changes above we can observe how JUnit's `@Ignore` annotation can be easily used to disable particular tests as needed. In the particular case of `PrintFlags`, the JMH extension could filter this flag and not pass on (there are already such cases) so with that modification the test could pass but I left it as is so that test exclusion can be demonstrated for this PR.

Here is the PR list for reference:
1. [Make OutputFormatAdapter public](https://github.com/openjdk/jmh/pull/158)
2. [Enable BenchmarkParams construction to be overriden](https://github.com/openjdk/jmh/pull/160)
3. [Enable alternative Runner instantiation and Main reuse](https://github.com/openjdk/jmh/pull/161)
4. [Enable profiler classes to be reused outside of JMH](https://github.com/openjdk/jmh/pull/162)
5. [Enable JMH integration tests to be executed against other impls](https://github.com/openjdk/jmh/pull/163)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7904061](https://bugs.openjdk.org/browse/CODETOOLS-7904061): Enable JMH integration tests to be executed against other impls (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/163/head:pull/163` \
`$ git checkout pull/163`

Update a local copy of the PR: \
`$ git checkout pull/163` \
`$ git pull https://git.openjdk.org/jmh.git pull/163/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 163`

View PR using the GUI difftool: \
`$ git pr show -t 163`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/163.diff">https://git.openjdk.org/jmh/pull/163.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/163#issuecomment-3048484718)
</details>
