### PR TITLE
7904174: JMH: Enable JDK 25 testing

### DIFF
--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java: [8, 11, 17, 21]
+        java: [8, 11, 17, 21, 25]
         os: [ubuntu-latest, windows-latest, macos-latest]
         mode: [default, reflection, asm, executor-fjp, executor-custom]
         exclude:
@@ -57,12 +57,7 @@ jobs:
     - name: Set up perf (Linux)
       run: |
         sudo apt-get update
-        sudo apt-get install -y linux-tools-generic linux-tools-`uname -r`
-        # Very crude workaround for perf missing in 6.14 packages.
-        # Yank this once GHA upgrades to 6.17+.
-        sudo ln -s \
-          /usr/lib/linux-tools/`ls /usr/lib/linux-tools/ | grep generic`/perf \
-          /usr/lib/linux-tools/`uname -r`/perf
+        sudo apt-get install -y linux-tools-`uname -r`
         echo -1 | sudo tee /proc/sys/kernel/perf_event_paranoid
         perf stat echo 1
       if: (runner.os == 'Linux')

--- a/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfProfilerTest.java
+++ b/jmh-core-it/src/test/java/org/openjdk/jmh/it/profilers/LinuxPerfProfilerTest.java
@@ -79,8 +79,6 @@ public class LinuxPerfProfilerTest {
         }
 
         Assert.assertTrue(msg.contains("cycles"));
-        Assert.assertTrue(msg.contains("instructions"));
-        Assert.assertTrue(msg.contains("branches"));
     }
 
 }

--- a/jmh-core/src/test/java/org/openjdk/jmh/profile/PerfAsmMethodParsingTest.java
+++ b/jmh-core/src/test/java/org/openjdk/jmh/profile/PerfAsmMethodParsingTest.java
@@ -85,10 +85,9 @@ public class PerfAsmMethodParsingTest {
 
         String methods = sb.toString();
 
-        if (JDKVersion.parseMajor(System.getProperty("java.version")) >= 22) {
+        int version = JDKVersion.parseMajor(System.getProperty("java.version"));
+        if (version >= 11) {
             // These rely on logging available in up-to-date JDKs.
-            // At the time of writing, only JDK 22 contained all these fixes.
-            // TODO: As the relevant JDK updates get backported, consider bumping the versions down.
 
             // Added by JDK-8316514
             checkFor(methods, "runtime stub: VtableStub vtbl[");
@@ -96,8 +95,19 @@ public class PerfAsmMethodParsingTest {
 
             // Added by JDK-8316178
             checkFor(methods, "runtime stub: ExceptionBlob");
-            checkFor(methods, "runtime stub: _complete_monitor_locking_Java");
-            checkFor(methods, "runtime stub: StackOverflowError throw_exception");
+
+            if (version >= 26) {
+                // Format changed by JDK-8374698
+                checkFor(methods, "runtime stub: throw_StackOverflowError_blob (shared runtime)");
+                checkFor(methods, "runtime stub: complete_monitor_locking_blob (C2 runtime)");
+            } else if (version >= 25) {
+                // Stub report format changed by JDK-8339849
+                checkFor(methods, "runtime stub: Shared Runtime throw_StackOverflowError_blob");
+                checkFor(methods, "runtime stub: C2 Runtime complete_monitor_locking");
+            } else {
+                checkFor(methods, "runtime stub: StackOverflowError throw_exception");
+                checkFor(methods, "runtime stub: _complete_monitor_locking_Java");
+            }
         }
 
         // StubRoutines


### PR DESCRIPTION
We need to enable JDK 25 testing in GHA to avoid regressions. This would require some touchups in tests and test configurations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7904174](https://bugs.openjdk.org/browse/CODETOOLS-7904174): JMH: Enable JDK 25 testing (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmh.git pull/173/head:pull/173` \
`$ git checkout pull/173`

Update a local copy of the PR: \
`$ git checkout pull/173` \
`$ git pull https://git.openjdk.org/jmh.git pull/173/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 173`

View PR using the GUI difftool: \
`$ git pr show -t 173`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmh/pull/173.diff">https://git.openjdk.org/jmh/pull/173.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmh/pull/173#issuecomment-4154986838)
</details>
